### PR TITLE
bug: use correct button class

### DIFF
--- a/frontend/src/designsystem/components/Button.svelte
+++ b/frontend/src/designsystem/components/Button.svelte
@@ -68,8 +68,9 @@
     }
   };
 
-  $: currentVariant = variantClasses[variant];
-  $: currentDarkVariant = darkVariantClasses[variant];
+  // Gracefully fallback if an unknown variant is provided
+  $: currentVariant = variantClasses[variant] || variantClasses.primary;
+  $: currentDarkVariant = darkVariantClasses[variant] || darkVariantClasses.primary;
   $: currentSize = sizeClasses[size];
 
   $: buttonState = disabled ? 'disabled' : 'default';

--- a/frontend/src/designsystem/components/GroupCard.svelte
+++ b/frontend/src/designsystem/components/GroupCard.svelte
@@ -78,7 +78,7 @@
         Edit
       </Button>
       <Button 
-        variant="danger" 
+        variant="destructive" 
         size="sm"
         on:click={onDelete}
       >


### PR DESCRIPTION
This pull request introduces a minor fix to the button styling and improves the handling of variant props in the design system components. The most notable changes are a fallback for unknown button variants and an update to the variant name for consistency.

Button variant handling improvements:

* Added a fallback to use the `primary` variant if an unknown variant is provided in `Button.svelte`, preventing potential styling issues.

Design system consistency:

* Changed the `variant` prop from `"danger"` to `"destructive"` in `GroupCard.svelte` to match the variant naming convention used in the design system.