### PR TITLE
frontend ci job

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,76 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20]
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify design tokens are up to date
+        run: |
+          pnpm tokens:generate
+          # Fail if generation produced uncommitted changes (ensures committed tokens current)
+          if [ -n "$(git status --porcelain frontend/src/designsystem/platform-tokens frontend/src/designsystem/tokens || true)" ]; then
+            echo '::error::Design tokens are out of date. Run pnpm tokens:generate and commit the changes.'
+            git --no-pager diff --name-only frontend/src/designsystem/platform-tokens frontend/src/designsystem/tokens || true
+            exit 1
+          fi
+
+      - name: Build
+        env:
+          VITE_API_URL: https://api.confidence-picks.com
+        run: pnpm build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist-node-${{ matrix.node }}
+          path: frontend/dist
+          if-no-files-found: error
+
+  summary:
+    name: CI Summary
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Provide result summary
+        run: |
+          echo "All matrix builds succeeded." >> $GITHUB_STEP_SUMMARY
+          echo "Artifacts contain the production build for each tested Node version." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate continuous integration (CI) for the frontend codebase. The workflow ensures builds are tested on multiple Node.js versions, verifies design tokens are up to date, and uploads build artifacts for each environment.

**Frontend CI automation:**

* Added `.github/workflows/frontend-ci.yml` to set up a CI workflow for the frontend, triggered on pull requests affecting the `frontend` directory or via manual dispatch.
* Configured the workflow to run builds on Node.js versions 18 and 20 using a matrix strategy, ensuring compatibility across environments.
* Implemented a step to verify that design tokens are current and fail the build if they are out of date, enforcing consistency in design assets.

**Build and artifact management:**

* Automated the build process using environment variables and `pnpm`, and configured the workflow to upload the production build artifacts for each Node version tested.
* Added a summary job to provide a CI result overview and clarify artifact contents in the workflow summary.