### PR TITLE
bug: groups not available in login

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -60,7 +60,12 @@
   }
 
   function handleNavigate(event) {
-    navigateTo(event.detail.href);
+    const target = event.detail.href;
+    if (!isAuthenticated && target.startsWith('/groups')) {
+      navigateTo('/login');
+      return;
+    }
+    navigateTo(target);
   }
 
   function handleThemeToggle(event) {
@@ -81,6 +86,10 @@
   function handleSignOut() {
     AuthService.logout();
     clearAuth();
+  }
+  // Route guard: if user manually lands on groups routes unauthenticated, redirect to login
+  $: if ($currentRoute.startsWith('/groups') && !isAuthenticated) {
+    navigateTo('/login');
   }
 </script>
 
@@ -183,7 +192,7 @@
               </button>
               <button
                 class="px-lg py-sm bg-secondary-100 text-secondary-900 border border-secondary-300 rounded-base text-base font-medium hover:bg-secondary-200 transition-colors duration-fast focus:outline-none focus:ring-2 focus:ring-secondary-500 focus:ring-offset-2 dark:bg-secondary-800 dark:text-secondary-100 dark:border-secondary-600 dark:hover:bg-secondary-700"
-                on:click={() => navigateTo('/groups')}
+                on:click={() => navigateTo(isAuthenticated ? '/groups' : '/login')}
               >
                 Browse Groups
               </button>

--- a/frontend/src/designsystem/components/Navigation.svelte
+++ b/frontend/src/designsystem/components/Navigation.svelte
@@ -22,7 +22,7 @@
   // Navigation items configuration
   const navigationItems = [
     { label: 'Home', href: '/', icon: 'home' },
-    { label: 'Groups', href: '/groups', icon: 'user-group' },
+    { label: 'Groups', href: '/groups', icon: 'user-group', requiresAuth: true },
     { label: 'About', href: '/about', icon: 'information-circle' },
     { label: 'Design System', href: '/design-system', icon: 'cog-6-tooth' }
   ];
@@ -122,7 +122,7 @@
 
       <!-- Desktop Navigation -->
       <div class="hidden md:flex md:items-center md:space-x-lg">
-        {#each navigationItems as item}
+  {#each navigationItems.filter(item => displayName || !item.requiresAuth) as item}
           <button
             class="flex items-center px-xs py-xxxs rounded-base text-sm font-medium transition-colors duration-fast {isActive(item.href) 
               ? 'text-primary-600 bg-primary-50 dark:text-primary-400 dark:bg-primary-900' 
@@ -236,7 +236,7 @@
   <div class="space-y-sm mt-sm">
     <h2 class="text-xs font-semibold tracking-wide uppercase text-secondary-500 dark:text-secondary-400">Menu</h2>
     <div class="space-y-xxs">
-      {#each navigationItems as item}
+  {#each navigationItems.filter(item => displayName || !item.requiresAuth) as item}
         <button
           class="flex items-center w-full px-sm py-xs rounded-base text-left text-sm font-medium transition-colors duration-fast {isActive(item.href)
             ? 'text-primary-600 bg-primary-50 dark:text-primary-400 dark:bg-primary-900'


### PR DESCRIPTION
This pull request adds route guarding to ensure only authenticated users can access the "Groups" section of the app. It introduces checks and redirects throughout the navigation logic and UI, so unauthenticated users are sent to the login page when attempting to browse groups. The navigation menu also hides "Groups" for unauthenticated users.

**Authentication and Route Guarding:**

* Added logic in `App.svelte` to redirect unauthenticated users to `/login` when they attempt to navigate to any `/groups` route, both via navigation events and direct route access. [[1]](diffhunk://#diff-184aa74154efca953e93834a39e3c1612a6f2cbae0ac8c16d88b902740d63a2fL63-R68) [[2]](diffhunk://#diff-184aa74154efca953e93834a39e3c1612a6f2cbae0ac8c16d88b902740d63a2fR90-R93)
* Updated the "Browse Groups" button in `App.svelte` to send unauthenticated users to `/login` instead of `/groups`.

**Navigation UI Updates:**

* Marked the "Groups" navigation item in `Navigation.svelte` as requiring authentication (`requiresAuth: true`).
* Filtered navigation items in both desktop and mobile menus to hide "Groups" unless the user is authenticated (`displayName` truthy). [[1]](diffhunk://#diff-dc98865d18d3ad5c7432f837c775b12e1104a6a7280d6849f7a07ceebf2bdb47L125-R125) [[2]](diffhunk://#diff-dc98865d18d3ad5c7432f837c775b12e1104a6a7280d6849f7a07ceebf2bdb47L239-R239)