### PR TITLE
update group UI

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -40,8 +40,17 @@
       try {
         let user = AuthService.getUser();
         if (!user) {
-          user = await AuthService.getCurrentUser();
-        }
+          // Try refreshing token silently if expired
+            try {
+              await AuthService.refreshToken();
+              user = AuthService.getUser() || await AuthService.getCurrentUser();
+            } catch (e) {
+              // Ignore; will clear tokens below
+            }
+          if (!user) {
+            user = await AuthService.getCurrentUser();
+          }
+  }
         
         if (user) {
           // Update global auth store so UI updates immediately

--- a/frontend/src/components/GroupsPage.svelte
+++ b/frontend/src/components/GroupsPage.svelte
@@ -124,6 +124,7 @@
     <GroupsList 
       {groups}
       {isLoading}
+  showHeader={false}
       onCreateNew={handleCreateNew}
       onJoinExisting={handleJoinExisting}
       onViewGroup={handleViewGroup}
@@ -132,46 +133,7 @@
   onDeleteGroup={handleDeleteGroup}
     />
 
-    <!-- Quick Stats -->
-    {#if groups.length > 0 && !isLoading}
-      <div class="mt-lg grid grid-cols-1 md:grid-cols-3 gap-md">
-        <div class="p-md bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-base">
-          <div class="flex items-center">
-            <svg class="w-8 h-8 text-primary-500 mr-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
-            </svg>
-            <div>
-              <div class="text-2xl font-bold text-[var(--color-text-primary)]">{groups.length}</div>
-              <div class="text-sm text-[var(--color-text-secondary)]">Total Groups</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="p-md bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-base">
-          <div class="flex items-center">
-            <svg class="w-8 h-8 text-success-500 mr-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-            <div>
-              <div class="text-2xl font-bold text-[var(--color-text-primary)]">{groups.filter(g => g.isOwner).length}</div>
-              <div class="text-sm text-[var(--color-text-secondary)]">Groups Owned</div>
-            </div>
-          </div>
-        </div>
-
-        <div class="p-md bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-base">
-          <div class="flex items-center">
-            <svg class="w-8 h-8 text-info-500 mr-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"></path>
-            </svg>
-            <div>
-              <div class="text-2xl font-bold text-[var(--color-text-primary)]">{groups.reduce((sum, g) => sum + g.memberCount, 0)}</div>
-              <div class="text-sm text-[var(--color-text-secondary)]">Total Members</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    {/if}
+  <!-- Stats section removed per UX request -->
   </div>
 </div>
 

--- a/frontend/src/designsystem/components/GroupsList.svelte
+++ b/frontend/src/designsystem/components/GroupsList.svelte
@@ -11,8 +11,9 @@
   export let onLeaveGroup = () => {};
   export let onDeleteGroup = () => {};
   export let onRefresh = () => {};
+  export let showHeader = true; // allow parent to hide built-in header/subheader
   
-  let showActions = 'create'; // 'create', 'join', or null
+  // Removed expandable action panels; buttons now route directly
   
   function handleViewGroup(group) {
     onViewGroup(group);
@@ -34,56 +35,65 @@
 </script>
 
 <div class="space-y-6">
-  <!-- Header -->
-  <div class="flex justify-between items-center">
-    <div>
+  <!-- Header / Actions -->
+  {#if showHeader}
+  <div class="flex flex-col md:flex-row md:justify-between md:items-center gap-sm md:gap-0">
+    <div class="order-1">
       <h1 class="text-2xl font-bold text-gray-900">My Groups</h1>
       <p class="text-gray-600 mt-1">Manage your confidence picks groups</p>
     </div>
-    
-    <div class="flex space-x-3">
+    <div class="flex flex-col order-2 md:order-none md:flex-row md:space-x-3 gap-sm md:gap-0 w-full md:w-auto md:items-center mt-sm md:mt-0">
+      <Button 
+        variant="primary"
+        on:click={onCreateNew}
+      >
+        Create Group
+      </Button>
+      <Button 
+        variant="secondary"
+        on:click={onJoinExisting}
+      >
+        Join Group
+      </Button>
       <Button 
         variant="secondary" 
         size="sm"
         on:click={onRefresh}
         disabled={isLoading}
       >
+        <svg class="w-4 h-4 mr-xs" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992V4.356M2.985 14.652v4.992h4.992M19.207 15.6a8.25 8.25 0 01-14.64 2.474m-.774-9.574a8.25 8.25 0 0114.64-2.474" />
+        </svg>
         Refresh
-      </Button>
-      
-      <Button 
-        variant="primary"
-        on:click={() => showActions = showActions === 'create' ? null : 'create'}
-      >
-        Create Group
-      </Button>
-      
-      <Button 
-        variant="secondary"
-        on:click={() => showActions = showActions === 'join' ? null : 'join'}
-      >
-        Join Group
       </Button>
     </div>
   </div>
-  
-  <!-- Action panels -->
-  {#if showActions === 'create'}
-    <div class="border-l-4 border-blue-500 bg-blue-50 p-4 rounded-r-lg">
-      <p class="text-blue-700 mb-2">Create a new group to start making confidence picks with friends!</p>
-      <Button variant="primary" size="sm" on:click={onCreateNew}>
-        Open Create Form
-      </Button>
-    </div>
-  {/if}
-  
-  {#if showActions === 'join'}
-    <div class="border-l-4 border-green-500 bg-green-50 p-4 rounded-r-lg">
-      <p class="text-green-700 mb-2">Join an existing group using the Group ID shared by the owner.</p>
-      <Button variant="primary" size="sm" on:click={onJoinExisting}>
-        Open Join Form
-      </Button>
-    </div>
+  {:else}
+  <div class="flex flex-col md:flex-row md:justify-end md:items-center gap-sm md:gap-3">
+    <Button 
+      variant="primary"
+      on:click={onCreateNew}
+    >
+      Create Group
+    </Button>
+    <Button 
+      variant="secondary"
+      on:click={onJoinExisting}
+    >
+      Join Group
+    </Button>
+    <Button 
+      variant="secondary" 
+      size="sm"
+      on:click={onRefresh}
+      disabled={isLoading}
+    >
+      <svg class="w-4 h-4 mr-xs" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992V4.356M2.985 14.652v4.992h4.992M19.207 15.6a8.25 8.25 0 01-14.64 2.474m-.774-9.574a8.25 8.25 0 0114.64-2.474" />
+      </svg>
+      Refresh
+    </Button>
+  </div>
   {/if}
   
   <!-- Loading state -->

--- a/frontend/src/designsystem/components/InlineToast.svelte
+++ b/frontend/src/designsystem/components/InlineToast.svelte
@@ -1,0 +1,44 @@
+<script>
+  import { onMount } from 'svelte';
+  import { fade } from 'svelte/transition';
+  export let open = false;
+  export let message = '';
+  export let variant = 'info'; // info | success | warning | error
+  export let timeout = 2000; // ms
+  export let onClose = () => {};
+
+  let timer;
+  $: if (open) {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      open = false;
+      onClose();
+    }, timeout);
+  }
+
+  const variantClasses = {
+    info: 'bg-secondary-900 text-neutral-0 dark:bg-secondary-100 dark:text-secondary-900',
+    success: 'bg-success-600 text-neutral-0 dark:bg-success-500',
+    warning: 'bg-warning-600 text-neutral-0 dark:bg-warning-500',
+    error: 'bg-error-600 text-neutral-0 dark:bg-error-500'
+  };
+  const vIcon = {
+    info: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+    success: 'M5 13l4 4L19 7',
+    warning: 'M12 9v3m0 4h.01M12 5.5l7.5 13h-15L12 5.5z',
+    error: 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z'
+  };
+</script>
+
+{#if open}
+  <div transition:fade={{ duration: 150 }} class="pointer-events-none absolute -top-9 left-1/2 -translate-x-1/2 z-20 text-xs px-sm py-xs rounded shadow-md font-medium whitespace-nowrap flex items-center gap-1 transition-all duration-150 {variantClasses[variant]}" role="status" aria-live="polite">
+    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" d={vIcon[variant] || vIcon.info}></path>
+    </svg>
+    {message}
+  </div>
+{/if}
+
+<style>
+  :global(.inline-toast-anchor){ position:relative; }
+</style>

--- a/frontend/src/lib/authService.js
+++ b/frontend/src/lib/authService.js
@@ -48,6 +48,10 @@ class AuthService {
     try {
       // Decode JWT to get user info (without verification - just for display)
       const payload = JSON.parse(atob(token.split('.')[1]));
+      // If token expired, signal caller to refresh by returning null
+      if (payload?.exp && Date.now() / 1000 >= payload.exp) {
+        return null;
+      }
       return {
         id: payload.userId,
         email: payload.email,


### PR DESCRIPTION
This pull request introduces several improvements to the frontend group management experience, focusing on better authentication handling, UI/UX enhancements, and code simplification. The most notable changes are the addition of a reusable inline toast notification, improved handling of expired authentication tokens, and significant UI refinements for group and member lists. Additionally, the codebase was simplified by removing expandable action panels and the groups stats section.

**Authentication and Error Handling:**

* Improved expired token handling in `AuthService`: If the JWT is expired, `getUser()` now returns `null`, prompting the caller to refresh the token.
* Updated authentication flow in `App.svelte` to attempt a silent token refresh if the user is not found, ensuring smoother session recovery.
* Enhanced `authFetch` in `groupsService.js` to automatically attempt a silent token refresh once if a 401/403 response is received, improving reliability of authenticated API calls. [[1]](diffhunk://#diff-7749f8f29a2a2d2892cdd9aa59ca76c710fc6aa531ad3edc090cdf0d6e1a28c0L7-R7) [[2]](diffhunk://#diff-7749f8f29a2a2d2892cdd9aa59ca76c710fc6aa531ad3edc090cdf0d6e1a28c0R17-R33)

**UI/UX Improvements:**

* Added a reusable `InlineToast` component for inline notifications (e.g., "Copied" toast for group identifier), improving user feedback on actions. [[1]](diffhunk://#diff-7afcf46ba98d37505c113927c1f942262c3298ba2fd7c0db1b8f95b001b2ba6bR1-R44) [[2]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL84-R88) [[3]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aR157) [[4]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aR168-R169)
* Refined layouts for group details, messages, and member lists to improve readability, responsiveness, and handling of long text. [[1]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL222-R236) [[2]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL243-R263) [[3]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL273-R289) [[4]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL335-R359)

**Codebase Simplification:**

* Removed expandable action panels from `GroupsList.svelte`; action buttons now route directly, and the header is optionally hidden for parent control. [[1]](diffhunk://#diff-19ea68986ce45e8fba26fdba499b8e0acfffb7cd2a590114938d11294eb5ec15R14-R16) [[2]](diffhunk://#diff-19ea68986ce45e8fba26fdba499b8e0acfffb7cd2a590114938d11294eb5ec15L37-R94) [[3]](diffhunk://#diff-e8248cdc27aca3d44865e2688ae1257f23dda2555c305f759014ad5bb7f32092R127)
* Removed the "Quick Stats" section from `GroupsPage.svelte` per UX feedback, streamlining the page.