### PR TITLE
Adding week 0 as a test

### DIFF
--- a/backend/src/models/Game.js
+++ b/backend/src/models/Game.js
@@ -48,12 +48,22 @@ static fromESPNData(espnGame) {
 
   
   const weekData = competition.week || espnGame.week || {};
-  const week = weekData.number || 1;
+  let week = weekData.number || 1;
 
     // Fix the season parsing - it's available in the competition
   const season = competition.season || espnGame.season || {};
   const seasonYear = season.year || new Date().getFullYear();
-  const seasonType = season.type || 2;
+  let seasonType = season.type || 2;
+
+  // Map ONLY the final preseason week to regular season week 0 for picks/testing
+  try {
+    const PRE_FINAL = parseInt(process.env.PRESEASON_FINAL_WEEK || '4', 10); // default 4
+    if (seasonType === 1 && week === PRE_FINAL) {
+      console.log(`[week-map] Mapping preseason week ${PRE_FINAL} to regular season week 0`);
+      week = 0; // represent as week 0
+      seasonType = 2; // treat as regular season for picks/standings
+    }
+  } catch (_) { /* ignore env parse issues */ }
 
   const statusBlock = competition.status || {};
   const statusType = statusBlock.type || {};


### PR DESCRIPTION
This pull request introduces support for "week 0" (representing the final preseason week) across both backend and frontend, allowing users to make picks and view games for this special week. The main changes ensure that week 0 is properly mapped, validated, and selectable throughout the application.

**Backend changes:**

_Game week mapping and validation:_
* In `Game.js`, the final preseason week is now mapped to regular season week 0 for picks and standings, based on an environment variable. This allows consistent handling of preseason picks.
* In `picks.js`, week validation logic is updated to allow week 0 in endpoints for getting, posting, and clearing picks, ensuring requests for week 0 are accepted and handled correctly. [[1]](diffhunk://#diff-c28bb0f38d419b6dbc9167c63e9f18db65d1d7a84fb72bd0e7a53802998dd655L52-R54) [[2]](diffhunk://#diff-c28bb0f38d419b6dbc9167c63e9f18db65d1d7a84fb72bd0e7a53802998dd655L118-R119) [[3]](diffhunk://#diff-c28bb0f38d419b6dbc9167c63e9f18db65d1d7a84fb72bd0e7a53802998dd655L193-R194)
* The closest week computation now returns 0 if no games are found, supporting week 0 as a valid option.

**Frontend changes:**

_Week selection and display:_
* In `PicksPanel.svelte`, the week selector now includes "Week 0 (Preseason)" as an option, and fallback logic ensures week 0 is used when appropriate. The picks fetch logic is updated to allow fetching for week 0. [[1]](diffhunk://#diff-4a9f6b6ba6de2794936e576434c9a523a9af0c0df571ad8910f43950f8d76067L36-R36) [[2]](diffhunk://#diff-4a9f6b6ba6de2794936e576434c9a523a9af0c0df571ad8910f43950f8d76067L54-R59) [[3]](diffhunk://#diff-4a9f6b6ba6de2794936e576434c9a523a9af0c0df571ad8910f43950f8d76067L220-R222)