### PR TITLE
Feature/remove group statistics

### DIFF
--- a/frontend/src/components/GroupDetailsPage.svelte
+++ b/frontend/src/components/GroupDetailsPage.svelte
@@ -12,7 +12,7 @@
   let messages = [];
   let isLoading = false;
   let error = null;
-  let activeTab = 'picks'; // default to picks per requirements
+  let activeTab = 'leaderboard'; // default to leaderboard
   
   // Message form
   let newMessage = '';


### PR DESCRIPTION
This pull request updates the default tab and tab layout for the `GroupDetailsPage.svelte` component. The main change is switching the default and primary tab from "picks" and "overview" to "leaderboard," and removing the "overview" tab and its associated content (group statistics and recent activity). The tab logic and displayed content are updated accordingly to reflect these changes.

**Tab and UI changes:**

* Changed the default active tab to `leaderboard` instead of `picks` (`GroupDetailsPage.svelte`).
* Replaced all references and logic for the "overview" tab with "leaderboard," including the tab button, conditional rendering, and leaderboard loading logic (`GroupDetailsPage.svelte`) [[1]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL115-R115) [[2]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL210-R213) [[3]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL237-R238).
* Removed the "Group Statistics" and "Recent Activity" sections previously displayed in the "overview" tab (`GroupDetailsPage.svelte`).
* Updated markup to correctly close grid wrappers after removing overview content (`GroupDetailsPage.svelte`).