### PR TITLE
picks cleanup

### DIFF
--- a/frontend/src/components/ConfirmDeleteModal.svelte
+++ b/frontend/src/components/ConfirmDeleteModal.svelte
@@ -5,6 +5,8 @@
   export let slug = '';
   export let loading = false;
   export let error = null;
+  // mode: 'delete' (default) | 'leave'
+  export let mode = 'delete';
   const dispatch = createEventDispatcher();
   let inputValue = '';
 
@@ -22,7 +24,7 @@
 </script>
 
 {#if open}
-  <div class="fixed inset-0 z-50 flex items-center justify-center" aria-modal="true" role="dialog" aria-label="Confirm group deletion">
+  <div class="fixed inset-0 z-50 flex items-center justify-center" aria-modal="true" role="dialog" aria-label={mode === 'leave' ? 'Confirm leave group' : 'Confirm group deletion'}>
     <div 
       class="absolute inset-0 bg-secondary-900/60 backdrop-blur-sm" 
       role="button" 
@@ -32,8 +34,12 @@
       tabindex="-1"
     ></div>
     <div class="relative w-full max-w-md bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg p-lg shadow-xl space-y-md">
-      <h3 class="text-xl font-heading font-semibold text-error-600 dark:text-error-400">Delete Group</h3>
-      <p class="text-sm text-[var(--color-text-secondary)]">This will permanently delete <span class="font-semibold">{name}</span> and all associated data. Type <code class="font-mono bg-secondary-100 dark:bg-secondary-700 px-1 py-0.5 rounded">{slug}</code> to confirm.</p>
+      <h3 class="text-xl font-heading font-semibold {mode === 'leave' ? 'text-warning-600 dark:text-warning-400' : 'text-error-600 dark:text-error-400'}">{mode === 'leave' ? 'Leave Group' : 'Delete Group'}</h3>
+      {#if mode === 'leave'}
+        <p class="text-sm text-[var(--color-text-secondary)]">You will be removed from <span class="font-semibold">{name}</span> and lose access to its picks, messages, and leaderboard. Type <code class="font-mono bg-secondary-100 dark:bg-secondary-700 px-1 py-0.5 rounded">{slug}</code> to confirm.</p>
+      {:else}
+        <p class="text-sm text-[var(--color-text-secondary)]">This will permanently delete <span class="font-semibold">{name}</span> and all associated data. Type <code class="font-mono bg-secondary-100 dark:bg-secondary-700 px-1 py-0.5 rounded">{slug}</code> to confirm.</p>
+      {/if}
       <input
         class="w-full px-sm py-xs border border-secondary-300 dark:border-secondary-600 rounded-base bg-neutral-0 dark:bg-secondary-700 text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-error-500"
         placeholder={slug}
@@ -51,12 +57,16 @@
           Cancel
         </button>
         <button
-          class="px-md py-xs bg-error-600 hover:bg-error-700 text-neutral-0 rounded-base text-sm font-medium focus:outline-none focus:ring-2 focus:ring-error-500 focus:ring-offset-2 disabled:opacity-50"
+          class="px-md py-xs {mode === 'leave' ? 'bg-warning-600 hover:bg-warning-700 focus:ring-warning-500 border border-warning-700' : 'bg-error-600 hover:bg-error-700 focus:ring-error-500 border border-error-600'} text-neutral-0 rounded-base text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50"
           on:click={handleConfirm}
           disabled={!canConfirm}
           type="button"
         >
-          {loading ? 'Deleting...' : 'Confirm Delete'}
+          {#if loading}
+            {mode === 'leave' ? 'Leaving...' : 'Deleting...'}
+          {:else}
+            {mode === 'leave' ? 'Confirm Leave' : 'Confirm Delete'}
+          {/if}
         </button>
       </div>
       {#if error}

--- a/frontend/src/components/GamePickRow.svelte
+++ b/frontend/src/components/GamePickRow.svelte
@@ -1,14 +1,21 @@
 <script>
   import { createEventDispatcher } from 'svelte';
+  import Button from '../designsystem/components/Button.svelte';
   export let game;
   export let draft;
   export let totalGames = 0;
+  export let isSorted = false; // passed from parent to allow full range selection
   export let focusGameId = null; // when this game's id matches, auto focus/scroll
+  export let cleared = false; // when true, ignore original server pick fallback
 
   const dispatch = createEventDispatcher();
-  $: pick = draft[game.id] || (game.pick && (game.pick.pickedTeamId != null || game.pick.confidence != null)
-    ? { pickedTeamId: game.pick.pickedTeamId != null ? Number(game.pick.pickedTeamId) : null, confidence: game.pick.confidence, points: game.pick.points }
-    : null);
+  $: pick = (() => {
+    // If row is marked cleared, only consider draft (which will usually be undefined) and never fall back to server pick
+    if (cleared) return draft[game.id] || null;
+    return draft[game.id] || (game.pick && (game.pick.pickedTeamId != null || game.pick.confidence != null)
+      ? { pickedTeamId: game.pick.pickedTeamId != null ? Number(game.pick.pickedTeamId) : null, confidence: game.pick.confidence, points: game.pick.points }
+      : null);
+  })();
   $: awayTeamId = Number(game.awayTeam.id);
   $: homeTeamId = Number(game.homeTeam.id);
   $: pickTeamId = pick?.pickedTeamId != null ? Number(pick.pickedTeamId) : null;
@@ -20,17 +27,17 @@
   $: pickLost = final && pick?.pickedTeamId && winnerTeamId && winnerTeamId !== pick.pickedTeamId;
   $: incomplete = pick && !(pick.pickedTeamId && pick.confidence != null);
   let localConfidence = '';
+  let showPicker = false;
   // Sync down only when pick has a definite confidence value; never forcibly clear user's in-progress selection.
   $: if (pick && pick.confidence != null && String(pick.confidence) !== localConfidence) {
     localConfidence = String(pick.confidence);
   }
 
-  function onConfidenceChange(e) {
-    const raw = e.target.value;
-    const parsed = raw === '' ? null : parseInt(raw, 10);
-    localConfidence = raw; // optimistic local update
-    console.debug('[GamePickRow change]', { gameId: game.id, raw, parsed, before: draft[game.id] || null });
+  function chooseConfidence(val) {
+    const parsed = val == null ? null : parseInt(val, 10);
+    localConfidence = parsed == null ? '' : String(parsed);
     dispatch('assignConfidence', parsed);
+    showPicker = false;
   }
 
   // Build allowed confidence options.
@@ -42,19 +49,22 @@
       .filter(([gid, val]) => val && val.confidence != null && parseInt(gid) !== game.id)
       .map(([_, val]) => val.confidence)
   );
-  $: allowedConfidences = completePick
-    ? Array.from({ length: totalGames }, (_, i) => i + 1)
-    : Array.from({ length: totalGames }, (_, i) => i + 1).filter(n => !usedConfidences.has(n) || (pick && pick.confidence === n));
+  // Always cap to totalGames; if this pick is complete allow full range for reassignment, else only unused numbers (plus its current one)
+  $: allowedConfidences = (() => {
+    console.log("allowed confidences: " + totalGames);
+    const full = Array.from({ length: totalGames }, (_, i) => i + 1);
+    // If currently a complete pick OR rendered in sorted list, allow full range (user can override others)
+    if (completePick || isSorted) return full;
+    return full.filter(n => !usedConfidences.has(n) || (pick && pick.confidence === n));
+  })();
 
   function select(teamId) { dispatch('toggleWinner', Number(teamId)); }
   function setConfidence(n) { dispatch('assignConfidence', n); }
   function clearConfidence() {
-    // Clear confidence first
-    dispatch('assignConfidence', null);
-    // If a winner was selected, toggle it off (this will remove the draft entry if no confidence remains)
-    if (pick?.pickedTeamId != null) {
-      dispatch('toggleWinner', pick.pickedTeamId);
-    }
+    // Clear both confidence and winner entirely; parent will remove draft entry and mark cleared set
+    localConfidence = '';
+    dispatch('clearPick');
+    showPicker = false;
   }
   function onTeamKey(e, teamId) {
     if (['Enter',' '].includes(e.key)) { e.preventDefault(); select(teamId); }
@@ -111,14 +121,21 @@
 <div class="game-card pick-card {incomplete ? 'incomplete' : ''}" data-final={final} id={'game-row-'+game.id}>
   <div class="game-header">
     <span class="game-date">{formatGameDate(game.gameDate)}</span>
-    <span class="game-status {statusLabel.replace(/\s/g,'-')}">
+    <div class="header-right">
+      <span class="game-status {statusLabel.replace(/\s/g,'-')}">
       {#if statusLabel === 'in progress'}
         {#if game.displayClock}{game.displayClock} · {/if}
         {#if game.period}Q{game.period}{/if}
       {:else}
         {statusLabel}
       {/if}
-    </span>
+      </span>
+  {#if !game.meta.locked && statusLabel === 'not started' && (pick?.pickedTeamId != null || pick?.confidence != null)}
+        <Button variant="destructive" size="sm" class="clear-inline" on:click={(e)=>{ e.stopPropagation(); clearConfidence(); }}>
+          Clear
+        </Button>
+      {/if}
+    </div>
   </div>
   <div class="matchup" role="radiogroup" aria-label="Select winner">
     <div class="team away-team clickable {awaySelected ? 'selected' : ''} {final && winnerTeamId===game.awayTeam.id ? 'winner' : ''} {pickLost && awaySelected ? 'lost' : ''}"
@@ -160,17 +177,19 @@
       </div>
       <span class="team-score">{game.homeScore}</span>
     </div>
-  <div class="confidence-wrapper {game.meta.locked ? 'locked-state' : ''}">
+    <div class="confidence-wrapper {game.meta.locked ? 'locked-state' : ''}">
       {#if !game.meta.locked}
-        <div class="conf-big" title={localConfidence ? `Confidence ${localConfidence}` : 'No confidence selected'}>{localConfidence || '--'}</div>
-        <label class="conf-label sr-only" for={'conf-'+game.id}>Confidence</label>
-        <select id={'conf-'+game.id} value={localConfidence} on:change={onConfidenceChange} class="conf-select" aria-label="Confidence value">
-          <option value="">Select…</option>
-          {#each allowedConfidences as c}
-            <option value={c}>{c}</option>
-          {/each}
-        </select>
-  <button type="button" class="clear-conf-btn" on:click={clearConfidence} aria-label="Clear confidence" title="Clear confidence value">✕</button>
+        <button type="button" class="conf-button" aria-haspopup="listbox" aria-expanded={showPicker} on:click|stopPropagation={() => showPicker = !showPicker} title={localConfidence ? `Confidence ${localConfidence}` : 'Select confidence'}>
+          <span class="conf-value">{localConfidence || '—'}</span>
+          <span class="conf-arrows" aria-hidden="true">▲▼</span>
+        </button>
+        {#if showPicker}
+          <div class="conf-popover" role="listbox" aria-label="Select confidence" tabindex="0" on:click|stopPropagation on:keydown={(e)=>{ if(e.key==='Escape'){ showPicker=false; e.stopPropagation(); } }}>
+            {#each allowedConfidences as c}
+              <button type="button" class="conf-option {String(c) === localConfidence ? 'active' : ''}" role="option" aria-selected={String(c) === localConfidence} on:click={() => chooseConfidence(c)}>{c}</button>
+            {/each}
+          </div>
+        {/if}
       {:else}
         <div class="locked" title="Locked">{pick?.confidence ?? '—'}</div>
       {/if}
@@ -198,13 +217,14 @@
 
 <style>
   .pick-card { padding:1rem 1rem .75rem; }
-  .game-card { background: var(--color-surface-secondary,#ffffff); border:1px solid var(--color-surface-tertiary,#e5e7eb); border-radius:12px; display:flex; flex-direction:column; gap:.6rem; box-shadow:0 2px 4px rgba(0,0,0,.06); }
-  .game-header { display:flex; justify-content:space-between; align-items:center; padding-bottom:.35rem; border-bottom:1px solid var(--color-surface-tertiary,#e5e7eb); }
+  .game-card { background: var(--color-surface-secondary,#ffffff); border:1px solid var(--color-surface-tertiary,#e5e7eb); border-radius:12px; display:flex; flex-direction:column; gap:.6rem; box-shadow:0 2px 4px rgba(0,0,0,.06); position:relative; }
+  .game-header { display:flex; align-items:center; padding-bottom:.35rem; border-bottom:1px solid var(--color-surface-tertiary,#e5e7eb); }
+  .header-right { margin-left:auto; display:flex; align-items:center; gap:.5rem; }
   .game-date { font-size:.75rem; color: var(--color-text-tertiary,#6c757d); }
   .game-status { font-size:.6rem; padding:.2rem .45rem; border-radius:4px; text-transform:uppercase; letter-spacing:.5px; font-weight:600; background:var(--color-surface-tertiary,#e9ecef); color:var(--color-text-secondary,#495057); }
   .game-status.in-progress { background:#dc3545; color:#fff; }
   .game-status.final { background:#198754; color:#fff; }
-  .matchup { display:grid; grid-template-columns: 1fr auto 1fr 68px; align-items:stretch; gap:0; }
+  .matchup { display:grid; grid-template-columns: 1fr auto 1fr 72px; align-items:stretch; gap:0; position:relative; }
   .team { display:flex; justify-content:space-between; align-items:center; padding:.5rem .75rem; gap:.75rem; position:relative; border-radius:8px; user-select:none; outline:2px solid transparent; outline-offset:2px; transition: outline-color .15s, box-shadow .15s, transform .1s; }
   .team.clickable { cursor:pointer; }
   .team.selected { 
@@ -232,21 +252,22 @@
   .team-full { font-size:.55rem; opacity:.85; text-transform:uppercase; letter-spacing:.5px; }
   .team-score { font-size:1.2rem; font-weight:700; min-width:2ch; text-align:right; text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000,0 0 4px #000; color:#cfe8ff; }
   .vs { display:flex; align-items:center; justify-content:center; font-weight:600; font-size:.75rem; padding:.25rem .6rem; color:var(--color-text-tertiary,#6c757d); background:var(--color-surface-tertiary,#e9ecef); }
-  .confidence-wrapper { display:flex; flex-direction:column; align-items:center; justify-content:flex-start; gap:.4rem; padding:.45rem .5rem .6rem; background:var(--color-surface-tertiary,#e5e7eb); border-top-right-radius:8px; border-bottom-right-radius:8px; min-width:92px; }
+  .confidence-wrapper { display:flex; align-items:center; justify-content:center; padding:.45rem .4rem; background:var(--color-surface-tertiary,#e5e7eb); border-top-right-radius:8px; border-bottom-right-radius:8px; position:relative; }
   .confidence-wrapper.locked-state { opacity:.8; }
   :global(.dark) .confidence-wrapper { background:#374151; }
-  .conf-label { font-size:.65rem; text-transform:uppercase; letter-spacing:.6px; opacity:.8; text-align:center; font-weight:600; }
-  .conf-select { font-size:.95rem; padding:.55rem .5rem; border:1px solid var(--color-surface-tertiary,#d1d5db); border-radius:8px; background:var(--color-surface-primary,#fff); font-weight:600; width:100%; }
-  .clear-conf-btn { margin-top:.15rem; width:100%; font-size:.65rem; font-weight:600; letter-spacing:.5px; background:#fee2e2; color:#b91c1c; border:1px solid #fca5a5; border-radius:6px; padding:.25rem .4rem; cursor:pointer; transition:background .15s, color .15s, border-color .15s; }
-  .clear-conf-btn:hover { background:#fecaca; }
-  .clear-conf-btn:active { background:#fca5a5; }
-  :global(.dark) .clear-conf-btn { background:#7f1d1d; color:#fecaca; border-color:#991b1b; }
-  :global(.dark) .clear-conf-btn:hover { background:#991b1b; }
-  :global(.dark) .clear-conf-btn:active { background:#b91c1c; }
-  .conf-big { font-size:1.45rem; font-weight:700; line-height:1; padding:.4rem .7rem; background:linear-gradient(135deg,#1e3a8a,#2563eb); color:#fff; border-radius:10px; box-shadow:0 2px 4px rgba(0,0,0,.25); min-width:2.8ch; text-align:center; }
-  .conf-big:empty::after { content:'--'; }
+  .conf-button { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:.25rem; background:linear-gradient(135deg,#1e3a8a,#2563eb); color:#fff; border:none; border-radius:10px; padding:.5rem .55rem .55rem; cursor:pointer; font-weight:700; font-size:1.35rem; line-height:1; min-width:2.8ch; position:relative; box-shadow:0 2px 4px rgba(0,0,0,.25); }
+  .conf-button:focus-visible { outline:2px solid #2563eb; outline-offset:2px; }
+  .conf-value { font-variant-numeric:tabular-nums; }
+  .conf-arrows { font-size:.55rem; letter-spacing:-1px; margin-top:2px; opacity:.85; font-weight:600; }
+  .conf-popover { position:absolute; top:100%; right:0; margin-top:.4rem; background:var(--color-surface-primary,#ffffff); border:1px solid var(--color-surface-tertiary,#d1d5db); box-shadow:0 6px 18px -4px rgba(0,0,0,.25); border-radius:10px; padding:.4rem .45rem .5rem; display:grid; grid-template-columns:repeat(auto-fill,minmax(40px,1fr)); gap:.35rem; min-width:200px; z-index:30; }
+  .conf-option { background:var(--color-surface-tertiary,#f1f5f9); border:1px solid var(--color-surface-tertiary,#e2e8f0); border-radius:8px; padding:.4rem .25rem; font-size:.85rem; font-weight:600; cursor:pointer; transition:background .15s,border-color .15s,color .15s; }
+  .conf-option:hover { background:#2563eb; color:#fff; border-color:#2563eb; }
+  .conf-option.active { background:#1d4ed8; color:#fff; border-color:#1d4ed8; }
+  :global(.dark) .conf-popover { background:#1f2937; border-color:#374151; }
+  :global(.dark) .conf-option { background:#374151; border-color:#4b5563; color:#e5e7eb; }
+  :global(.dark) .conf-option:hover { background:#2563eb; border-color:#2563eb; color:#fff; }
+  :global(.dark) .conf-option.active { background:#1d4ed8; border-color:#1d4ed8; }
   .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0; }
-  .conf-select:focus { outline:2px solid #2563eb; outline-offset:1px; }
   .locked { font-size:.75rem; font-weight:600; text-align:center; padding:.3rem .4rem; border-radius:6px; background:var(--color-surface-tertiary,#e5e7eb); }
   .result-line { margin-top:.4rem; font-size:.6rem; font-weight:600; letter-spacing:.5px; padding:.25rem .5rem; border-radius:4px; text-transform:uppercase; width:max-content; }
   .result-line.won { background:#16a34a22; color:#15803d; }
@@ -270,11 +291,10 @@
   :global(.dark) .game-status.not-started { background:#4b5563; }
   :global(.dark) .vs { background:#374151; color:#9ca3af; }
   :global(.dark) .locked { background:#374151; color:#e5e7eb; }
-  /* Align mobile layout with nav hamburger (Tailwind md breakpoint = 768px) */
-  @media (max-width:767px){
+  @media (max-width:950px){
     .matchup { 
       display:grid; 
-      grid-template-columns: 1fr 92px; 
+  grid-template-columns: 1fr 80px; 
       grid-template-rows: auto auto auto; 
       gap:.4rem .5rem; 
       align-items:stretch; 
@@ -298,6 +318,6 @@
       border-top-right-radius:8px; 
       border-bottom-right-radius:8px; 
     }
-    .conf-big { margin-bottom:.45rem; }
+  .conf-button { font-size:1.2rem; }
   }
 </style>


### PR DESCRIPTION
This pull request introduces improvements to both the backend and frontend pick management flows, focusing on enabling users to clear their picks for games, updating the UI for clarity and accessibility, and supporting new modal confirmation modes. The most significant changes are grouped below.

**Backend pick clearing logic:**

* Added support for a new `clearedGameIds` field in the picks API, allowing users to explicitly clear picks for specific games. This includes validation to ensure only unlocked games can be cleared and prevents upserting picks for games that are being cleared. [[1]](diffhunk://#diff-c28bb0f38d419b6dbc9167c63e9f18db65d1d7a84fb72bd0e7a53802998dd655L118-R136) [[2]](diffhunk://#diff-c28bb0f38d419b6dbc9167c63e9f18db65d1d7a84fb72bd0e7a53802998dd655L149-R171)
* Ensured that picks submitted for games listed in `clearedGameIds` are ignored, and clearing is performed before upserting new picks to handle confidence number reassignment correctly.

**Frontend pick row improvements:**

* Updated `GamePickRow.svelte` to support a "Clear" button for unlocked games, which allows users to fully clear both winner and confidence selections. Also, the confidence selection UI was refactored from a dropdown to a popover for improved usability and accessibility. [[1]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4R133-R138) [[2]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L165-R192) [[3]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L235-L249)
* Added logic to ensure that when a pick is marked as cleared, the row ignores any fallback to server picks, showing only the user's current draft state.

**Modal confirmation enhancements:**

* Enhanced `ConfirmDeleteModal.svelte` to support a new `mode` prop, allowing it to be used for both group deletion and leaving a group, with corresponding changes to the modal text, aria-labels, and button styling. [[1]](diffhunk://#diff-2b4a058d19280dbd0e66d2e6cf4d220d99f67d74e80dffa7a541a4b77502ab38R8-R9) [[2]](diffhunk://#diff-2b4a058d19280dbd0e66d2e6cf4d220d99f67d74e80dffa7a541a4b77502ab38L25-R27) [[3]](diffhunk://#diff-2b4a058d19280dbd0e66d2e6cf4d220d99f67d74e80dffa7a541a4b77502ab38L35-R42) [[4]](diffhunk://#diff-2b4a058d19280dbd0e66d2e6cf4d220d99f67d74e80dffa7a541a4b77502ab38L54-R69)

**Accessibility and styling updates:**

* Improved accessibility of modal dialogs and pick row controls with updated aria-labels and keyboard navigation support for the confidence picker. [[1]](diffhunk://#diff-2b4a058d19280dbd0e66d2e6cf4d220d99f67d74e80dffa7a541a4b77502ab38L25-R27) [[2]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L165-R192)
* Refined responsive layout and visual styling for pick rows and confidence picker to better support various screen sizes and dark mode. [[1]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L201-R227) [[2]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L235-L249) [[3]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L273-R297)