### PR TITLE
feat: invites

### DIFF
--- a/.github/workflows/cleanup-invites.yml
+++ b/.github/workflows/cleanup-invites.yml
@@ -1,0 +1,42 @@
+name: Prune Expired Group Invites
+
+on:
+  schedule:
+    # Every day at 03:15 UTC
+    - cron: '15 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install backend dependencies (frozen)
+        working-directory: ./backend
+        run: pnpm install --frozen-lockfile
+
+      - name: Run invite cleanup (delete mode)
+        working-directory: ./backend
+        env:
+          NODE_ENV: production
+          # Set a repository secret named DATABASE_URL pointing at your production DB
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DEV_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          INVITE_RETENTION_DAYS: 0
+        run: pnpm run cleanup:invites
+
+      - name: Summary
+        if: always()
+        run: |
+          echo 'Invite cleanup completed.' >> $GITHUB_STEP_SUMMARY

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
     "dev": "node --watch src/app.js",
     "start": "node src/app.js",
     "db:init": "node src/database/init.js",
+  "cleanup:invites": "node src/scripts/cleanupInvites.js",
     "test": "node --test tests/*.test.js",
     "test:db": "node --test tests/db-init.test.js",
     "test:server": "node --test tests/server.test.js",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,6 +8,7 @@ import apiRoutes from './routes/api.js';
 import authRoutes from './routes/auth.js';
 import groupsRoutes from './routes/groups.js';
 import picksRoutes from './routes/picks.js';
+import invitesRoutes from './routes/invites.js';
 import { initDatabase } from './database/init.js';
 
 const app = express();
@@ -48,6 +49,7 @@ app.use('/api', apiRoutes);
 app.use('/auth', authRoutes);
 app.use('/api/groups', groupsRoutes);
 app.use('/api/groups', picksRoutes);
+app.use('/api/invites', invitesRoutes);
 
 // Health check
 app.get('/', (req, res) => {

--- a/backend/src/models/GroupInvite.js
+++ b/backend/src/models/GroupInvite.js
@@ -1,0 +1,89 @@
+import pool from '../config/database.js';
+import crypto from 'crypto';
+
+export class GroupInvite {
+  static generateToken() {
+    return crypto.randomBytes(16).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+
+  static async createLinkInvite({ groupId, userId, expiresInDays = 14, maxUses = null }) {
+    const token = this.generateToken();
+    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
+    const query = `
+      INSERT INTO group_invitations (group_id, invited_by, invited_email, token, expires_at, invite_type, max_uses)
+      VALUES ($1, $2, NULL, $3, $4, 'link', $5)
+      RETURNING *
+    `;
+    const result = await pool.query(query, [groupId, userId, token, expiresAt, maxUses]);
+    return result.rows[0];
+  }
+
+  static async getByToken(token) {
+    const query = `
+      SELECT gi.*, g.name, g.identifier, g.description, g.max_members, g.created_by,
+             u_owner.name AS owner_name, u_owner.picture_url AS owner_picture_url,
+             COUNT(gm.id) as member_count
+      FROM group_invitations gi
+      JOIN groups g ON gi.group_id = g.id
+      LEFT JOIN users u_owner ON g.created_by = u_owner.id
+      LEFT JOIN group_memberships gm ON g.id = gm.group_id
+      WHERE gi.token = $1
+      GROUP BY gi.id, g.id, u_owner.name, u_owner.picture_url
+    `;
+    const result = await pool.query(query, [token]);
+    if (result.rows.length === 0) return null;
+    return result.rows[0];
+  }
+
+  static inviteValidity(inviteRow) {
+    if (!inviteRow) return { valid: false, reason: 'not_found' };
+    if (inviteRow.revoked_at) return { valid: false, reason: 'revoked' };
+    if (new Date(inviteRow.expires_at).getTime() < Date.now()) return { valid: false, reason: 'expired' };
+    if (inviteRow.max_uses != null && inviteRow.uses >= inviteRow.max_uses) return { valid: false, reason: 'exhausted' };
+    return { valid: true };
+  }
+
+  static async accept(token, userId) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      // Lock the invitation row (and associated group row) to ensure consistent uses increment
+      const inviteRes = await client.query(`
+        SELECT gi.*, g.max_members, g.identifier
+        FROM group_invitations gi
+        JOIN groups g ON gi.group_id = g.id
+        WHERE gi.token = $1
+        FOR UPDATE
+      `, [token]);
+      if (inviteRes.rows.length === 0) throw new Error('Invalid invitation');
+      const invite = inviteRes.rows[0];
+
+      // Get current member count separately (no GROUP BY in locked select)
+      const memberCountRes = await client.query('SELECT COUNT(*)::int AS count FROM group_memberships WHERE group_id = $1', [invite.group_id]);
+      const currentMembers = memberCountRes.rows[0].count;
+      const validity = this.inviteValidity(invite);
+      if (!validity.valid) throw new Error(validity.reason);
+      if (currentMembers >= invite.max_members) throw new Error('group_full');
+      const memberRes = await client.query('SELECT 1 FROM group_memberships WHERE group_id=$1 AND user_id=$2', [invite.group_id, userId]);
+      let alreadyMember = memberRes.rows.length > 0;
+      if (!alreadyMember) {
+        await client.query('INSERT INTO group_memberships (group_id, user_id, role) VALUES ($1,$2,\'member\') ON CONFLICT DO NOTHING', [invite.group_id, userId]);
+        alreadyMember = false;
+      }
+      const usageRes = await client.query('SELECT 1 FROM group_invitation_uses WHERE invitation_id=$1 AND user_id=$2', [invite.id, userId]);
+      if (usageRes.rows.length === 0) {
+        await client.query('INSERT INTO group_invitation_uses (invitation_id, user_id) VALUES ($1,$2)', [invite.id, userId]);
+        if (!alreadyMember) {
+          await client.query('UPDATE group_invitations SET uses = uses + 1 WHERE id=$1', [invite.id]);
+        }
+      }
+      await client.query('COMMIT');
+      return { groupIdentifier: invite.identifier, alreadyMember };
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/backend/src/routes/invites.js
+++ b/backend/src/routes/invites.js
@@ -1,0 +1,55 @@
+import express from 'express';
+import { optionalAuth, authenticateToken } from '../middleware/auth.js';
+import { Group } from '../models/Group.js';
+import { GroupInvite } from '../models/GroupInvite.js';
+
+const router = express.Router();
+
+router.get('/:token', optionalAuth, async (req, res) => {
+  try {
+    const token = req.params.token;
+    const row = await GroupInvite.getByToken(token);
+    if (!row) return res.status(404).json({ valid: false, reason: 'not_found' });
+    const validity = GroupInvite.inviteValidity(row);
+    let alreadyMember = false;
+    if (req.user) {
+      const memberCheck = await Group.getUserGroups(req.user.id);
+      alreadyMember = memberCheck.some(g => g.id === row.group_id);
+    }
+    res.json({
+      valid: validity.valid,
+      reason: validity.reason,
+      alreadyMember,
+      group: {
+        identifier: row.identifier,
+        name: row.name,
+        description: row.description,
+        memberCount: parseInt(row.member_count || 0),
+        maxMembers: row.max_members,
+        ownerName: row.owner_name,
+        ownerPictureUrl: row.owner_picture_url
+      },
+      invite: {
+        token: row.token,
+        expiresAt: row.expires_at,
+        maxUses: row.max_uses,
+        uses: row.uses,
+        remainingUses: row.max_uses != null ? Math.max(row.max_uses - row.uses, 0) : null
+      }
+    });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+router.post('/:token/accept', authenticateToken, async (req, res) => {
+  try {
+    const { token } = req.params;
+    const result = await GroupInvite.accept(token, req.user.id);
+    res.json({ joined: !result.alreadyMember, alreadyMember: result.alreadyMember, groupIdentifier: result.groupIdentifier });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
+export default router;

--- a/backend/src/scripts/cleanupInvites.js
+++ b/backend/src/scripts/cleanupInvites.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Prune expired / exhausted / revoked group invites.
+ *
+ * Retention strategy:
+ *  - Delete invites whose expires_at < now minus INVITE_RETENTION_DAYS (grace window)
+ *  - Also delete any invite already expired AND (max_uses reached OR revoked)
+ *
+ * Environment variables:
+ *  INVITE_RETENTION_DAYS (default: 0)  -> days AFTER expiration to keep for audit.
+ *  DRY_RUN=true                         -> log what would be deleted, but don't delete.
+ *
+ * Exit codes: 0 success, 1 failure.
+ */
+import '../config/database.js'; // loads env + pool listeners
+import pool from '../config/database.js';
+
+async function main() {
+  const retentionDays = parseInt(process.env.INVITE_RETENTION_DAYS || '0', 10);
+  const dryRun = /^true$/i.test(process.env.DRY_RUN || '');
+
+  const now = new Date();
+  const retentionCutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+
+  const params = [retentionCutoff];
+  // We use CTE to collect candidates for reporting.
+  const sql = `WITH candidates AS (
+    SELECT id, token, expires_at, max_uses, uses, revoked_at
+    FROM group_invitations
+    WHERE (
+      expires_at < $1  -- beyond retention window (expires_at < cutoff => expires_at + retentionDays < now)
+    )
+    OR (
+      expires_at < NOW() AND (
+         (max_uses IS NOT NULL AND uses >= max_uses) OR revoked_at IS NOT NULL
+      )
+    )
+  )
+  ${dryRun ? 'SELECT * FROM candidates' : 'DELETE FROM group_invitations WHERE id IN (SELECT id FROM candidates) RETURNING *'};`;
+
+  const start = Date.now();
+  const res = await pool.query(sql, params);
+  const ms = Date.now() - start;
+
+  if (dryRun) {
+    console.log(`[DRY RUN] Would delete ${res.rows.length} invitations`);
+  } else {
+    console.log(`Deleted ${res.rows.length} invitations in ${ms}ms`);
+  }
+
+  // Optionally vacuum (skipped here to avoid requiring elevated perms)
+}
+
+main().then(()=> pool.end()).catch(err => { console.error('Cleanup failed', err); pool.end(()=> process.exit(1)); });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,7 @@
   import LoginPage from './components/LoginPage.svelte';
   import ProfilePage from './components/ProfilePage.svelte';
   import AuthCallback from './components/AuthCallback.svelte';
+  import InvitePage from './components/InvitePage.svelte';
   import AuthService from './lib/authService.js';
   import { auth, setAuthUser, clearAuth } from './lib/authStore.js';
 
@@ -311,6 +312,8 @@
   {:else if $currentRoute.startsWith('/auth/callback')}
     <!-- Auth Callback -->
     <AuthCallback />
+  {:else if $currentRoute.startsWith('/invite/') && $currentRoute.split('/').length === 3}
+    <InvitePage token={$currentRoute.split('/')[2]} />
   {:else}
     <!-- 404 Page -->
     <div class="max-w-4xl mx-auto px-lg py-lg">

--- a/frontend/src/components/AuthCallback.svelte
+++ b/frontend/src/components/AuthCallback.svelte
@@ -21,7 +21,22 @@
 			if (enriched) user = enriched;
 			if (user) setAuthUser(user);
 			status = 'Authenticated. Redirecting...';
-			setTimeout(() => navigateTo('/groups'), 500);
+			// Determine post-login redirect / invite auto-accept
+			let target = '/groups';
+			try {
+				const storedRedirect = sessionStorage.getItem('postLoginRedirect');
+				const inviteToken = sessionStorage.getItem('postLoginInviteToken');
+				if (inviteToken) {
+					// We'll navigate to invite page and set auto-accept flag
+					sessionStorage.removeItem('postLoginInviteToken');
+					sessionStorage.setItem('autoAcceptInviteToken', inviteToken);
+					target = `/invite/${inviteToken}`;
+				} else if (storedRedirect) {
+					target = storedRedirect;
+				}
+				sessionStorage.removeItem('postLoginRedirect');
+			} catch(_) {}
+			setTimeout(() => navigateTo(target), 400);
 		} catch (e) {
 			console.error('Auth callback error', e);
 			error = e.message;

--- a/frontend/src/components/InvitePage.svelte
+++ b/frontend/src/components/InvitePage.svelte
@@ -1,0 +1,108 @@
+<script>
+  import { onMount } from 'svelte';
+  import { navigateTo } from '../lib/router.js';
+  import { getInvite, acceptInvite } from '../lib/invitesService.js';
+  import AuthService from '../lib/authService.js';
+  import Avatar from '../designsystem/components/Avatar.svelte';
+  import Button from '../designsystem/components/Button.svelte';
+
+  export let token = '';
+  let loading = true;
+  let invite = null;
+  let error = null;
+  let accepting = false;
+
+  async function load() {
+    loading = true; error=null;
+    try { invite = await getInvite(token); } catch(e){ error = e.message; } finally { loading=false; }
+  }
+
+  async function handleAccept() {
+    if (!AuthService.getToken()) {
+      // Persist intent & redirect target for post-login auto-accept
+      try {
+        sessionStorage.setItem('postLoginRedirect', window.location.pathname);
+        sessionStorage.setItem('postLoginInviteToken', token);
+      } catch(_) {}
+      navigateTo(`/login`);
+      return;
+    }
+    accepting = true; error=null;
+    try {
+      const res = await acceptInvite(token);
+      navigateTo(`/groups/${res.groupIdentifier}`);
+    } catch(e){ error=e.message; } finally { accepting=false; }
+  }
+
+  function handleDecline() { navigateTo('/groups'); }
+
+  onMount(async () => {
+    await load();
+    // If callback set auto-accept flag for this token, attempt accept automatically
+    try {
+      const autoToken = sessionStorage.getItem('autoAcceptInviteToken');
+      if (autoToken === token) {
+        sessionStorage.removeItem('autoAcceptInviteToken');
+        if (AuthService.getToken() && invite?.valid && !invite?.alreadyMember) {
+          // Fire and forget; internal state will reflect
+          handleAccept();
+        }
+      }
+    } catch(_) {}
+  });
+</script>
+
+<div class="min-h-screen flex items-center justify-center bg-neutral-0 dark:bg-secondary-900 px-md py-xl">
+  <div class="w-full max-w-md bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg p-xl space-y-lg">
+    {#if loading}
+      <div class="animate-pulse space-y-sm">
+        <div class="h-6 bg-secondary-200 dark:bg-secondary-700 rounded"></div>
+        <div class="h-4 bg-secondary-200 dark:bg-secondary-700 rounded w-2/3"></div>
+        <div class="h-32 bg-secondary-200 dark:bg-secondary-700 rounded"></div>
+      </div>
+    {:else if error}
+      <div>
+        <h1 class="text-xl font-heading font-semibold text-error-600 dark:text-error-400 mb-sm">Invitation Error</h1>
+        <p class="text-sm text-[var(--color-text-secondary)] mb-md">{error}</p>
+        <Button variant="secondary" size="sm" on:click={() => navigateTo('/groups')}>Go to Groups</Button>
+      </div>
+    {:else if invite}
+      {#if !invite.valid}
+        <div>
+          <h1 class="text-xl font-heading font-semibold text-[var(--color-text-primary)] mb-sm">Invite Unavailable</h1>
+          <p class="text-sm text-[var(--color-text-secondary)] mb-md">Reason: {invite.reason}</p>
+          <Button variant="secondary" size="sm" on:click={() => navigateTo('/groups')}>Browse Groups</Button>
+        </div>
+      {:else}
+        <div class="space-y-md">
+          <div class="flex items-center gap-sm">
+            <Avatar name={invite.group.ownerName} pictureUrl={invite.group.ownerPictureUrl} variant="md" />
+            <div>
+              <h1 class="text-xl font-heading font-semibold text-[var(--color-text-primary)]">Join {invite.group.name}</h1>
+              <p class="text-xs text-[var(--color-text-secondary)]">Hosted by {invite.group.ownerName}</p>
+            </div>
+          </div>
+          {#if invite.group.description}
+            <p class="text-sm text-[var(--color-text-secondary)] whitespace-pre-wrap">{invite.group.description}</p>
+          {/if}
+          <div class="flex items-center gap-sm text-xs text-[var(--color-text-secondary)]">
+            <span>{invite.group.memberCount} members</span>
+            <span>•</span>
+            <span>Max {invite.group.maxMembers}</span>
+            {#if invite.invite.remainingUses != null}
+              <span>• {invite.invite.remainingUses} uses left</span>
+            {/if}
+          </div>
+          {#if invite.alreadyMember}
+            <Button variant="primary" size="sm" class="w-full" on:click={() => navigateTo(`/groups/${invite.group.identifier}`)}>Go to Group</Button>
+          {:else}
+            <div class="flex flex-col gap-sm">
+              <Button variant="primary" size="sm" class="w-full" disabled={accepting} on:click={handleAccept}>{accepting ? 'Joining…' : 'Accept & Join'}</Button>
+              <Button variant="secondary" size="sm" class="w-full" on:click={handleDecline}>Decline</Button>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/LoginPage.svelte
+++ b/frontend/src/components/LoginPage.svelte
@@ -15,6 +15,10 @@
     // Check for error in URL params
     const urlParams = new URLSearchParams(window.location.search);
     const errorParam = urlParams.get('error');
+    const redirectParam = urlParams.get('redirect');
+    if (redirectParam) {
+      try { sessionStorage.setItem('postLoginRedirect', decodeURIComponent(redirectParam)); } catch(_) {}
+    }
     
     if (errorParam) {
       switch (errorParam) {
@@ -31,6 +35,12 @@
   });
 
   function handleGoogleSignIn() {
+    // Optionally capture current redirect (if user arrived via manual link) before leaving
+    try {
+      const urlParams = new URLSearchParams(window.location.search);
+      const redirectParam = urlParams.get('redirect');
+      if (redirectParam) sessionStorage.setItem('postLoginRedirect', decodeURIComponent(redirectParam));
+    } catch(_) {}
     AuthService.login();
   }
 </script>

--- a/frontend/src/lib/invitesService.js
+++ b/frontend/src/lib/invitesService.js
@@ -1,0 +1,48 @@
+import AuthService from './authService.js';
+
+const API_BASE = () => `${AuthService.getApiBaseUrl()}/api`;
+
+async function authFetch(url, options = {}, attempt = 0) {
+  const token = AuthService.getToken();
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {})
+    }
+  });
+  if ((res.status === 401 || res.status === 403) && attempt === 0 && token) {
+    try {
+      await AuthService.refreshToken();
+      const newToken = AuthService.getToken();
+      return authFetch(url, { ...options, headers: { 'Content-Type': 'application/json', ...(options.headers||{}), Authorization: `Bearer ${newToken}` } }, 1);
+    } catch (_) {}
+  }
+  return res;
+}
+
+export async function createLinkInvite(groupIdentifier, { expiresInDays = 14, maxUses = null } = {}) {
+  const res = await authFetch(`${API_BASE()}/groups/${groupIdentifier}/invites`, { method: 'POST', body: JSON.stringify({ expiresInDays, maxUses }) });
+  if (!res.ok) {
+    const data = await res.json().catch(()=>({}));
+    throw new Error(data.error || 'Failed to create invite');
+  }
+  return res.json();
+}
+
+export async function getInvite(token) {
+  const res = await authFetch(`${API_BASE()}/invites/${token}`);
+  if (res.status === 404) throw new Error('Invitation not found');
+  if (!res.ok) throw new Error('Failed to load invitation');
+  return res.json();
+}
+
+export async function acceptInvite(token) {
+  const res = await authFetch(`${API_BASE()}/invites/${token}/accept`, { method: 'POST' });
+  if (!res.ok) {
+    const data = await res.json().catch(()=>({}));
+    throw new Error(data.error || 'Failed to accept invite');
+  }
+  return res.json();
+}

--- a/frontend/src/lib/router.js
+++ b/frontend/src/lib/router.js
@@ -35,6 +35,8 @@ function getRouteForPath(path, hash = '', search = '') {
         return '/picks';
     } else if (path === '/leaderboard') {
         return '/leaderboard';
+    } else if (path.startsWith('/invite/') && path.split('/').length === 3) {
+        return path; // invite landing page
     } else {
         return '404';
     }


### PR DESCRIPTION
This pull request introduces major enhancements to the group invitations feature, adding support for shareable link-style invites, improving database tracking and cleanup, and updating both backend and frontend to support these new flows. The changes include new database schema fields and tables, new API endpoints for creating and accepting link invites, automated cleanup of expired/exhausted invites, and frontend support for sharing and accepting invites via links.

**Backend enhancements for group invitations:**

* Added new columns and a tracking table to `group_invitations` for link-style invites, usage limits, and invite consumption analytics. Also added relevant indexes for performance. (`backend/src/database/schema.sql`)
* Implemented `GroupInvite` model with methods for generating tokens, creating link invites, validating invites, and accepting invites with usage tracking and group membership logic. (`backend/src/models/GroupInvite.js`)
* Added new API endpoints for creating link invites (`POST /api/groups/:identifier/invites`) and for retrieving/accepting invites by token (`GET/POST /api/invites/:token`). (`backend/src/routes/groups.js`, `backend/src/routes/invites.js`, `backend/src/app.js`) [[1]](diffhunk://#diff-69819b21b307e72bc3dd91fbd0afa324d8265e3400872925f38458cf35460d56R163-R186) [[2]](diffhunk://#diff-c6b6dfb698dc9777a3ddad04bfff9bb37919aa1469c1e6ae21dc4c2ed32fa424R1-R55) [[3]](diffhunk://#diff-eb434d797b3f5637e7269f5bc9be8842a8e8761c93f3f8347326f9418c746b8cR11) [[4]](diffhunk://#diff-eb434d797b3f5637e7269f5bc9be8842a8e8761c93f3f8347326f9418c746b8cR52)

**Automated invite cleanup:**

* Added a scheduled GitHub Actions workflow and a backend script to prune expired, exhausted, or revoked group invites, with support for retention windows and dry run mode. (`.github/workflows/cleanup-invites.yml`, `backend/package.json`, `backend/src/scripts/cleanupInvites.js`) [[1]](diffhunk://#diff-cdbb1090ba276fd243dfbd5dc915a106d079370d662c8ad79f49ba16ebcb2ba9R1-R42) [[2]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R9) [[3]](diffhunk://#diff-14827ad570a60cf41aab97a6d62b550d9ea85dffbab58246269fd04605f37d4bR1-R54)

**Frontend support for link invites:**

* Added UI and logic to create and share link invites from the group details page, including clipboard and native sharing support. (`frontend/src/components/GroupDetailsPage.svelte`, `frontend/src/lib/invitesService.js`) [[1]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aR7) [[2]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aR115-R138) [[3]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aR344-R346) [[4]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aR356-R358)
* Implemented invite landing page and auto-accept flow after login, updating routing and post-login redirect logic. (`frontend/src/App.svelte`, `frontend/src/components/AuthCallback.svelte`) [[1]](diffhunk://#diff-184aa74154efca953e93834a39e3c1612a6f2cbae0ac8c16d88b902740d63a2fR15) [[2]](diffhunk://#diff-184aa74154efca953e93834a39e3c1612a6f2cbae0ac8c16d88b902740d63a2fR315-R316) [[3]](diffhunk://#diff-618500968a2c83756e0ffb51754eb9133f6871e5e2fe788bbc1a490c1ae67731L24-R39)