### PR TITLE
Fixed picks showing score incorrectly

### DIFF
--- a/backend/src/models/UserPick.js
+++ b/backend/src/models/UserPick.js
@@ -89,8 +89,9 @@ export class UserPick {
 
   static async updateResults({ gameId, winningTeamId }) {
     // Set won/points for all picks for a final game
+    // Correct picks get +confidence points, incorrect picks get -confidence points
     await pool.query(`UPDATE user_picks
-      SET won = (picked_team_id = $2), points = CASE WHEN picked_team_id = $2 THEN confidence_level ELSE 0 END, updated_at=NOW()
+      SET won = (picked_team_id = $2), points = CASE WHEN picked_team_id = $2 THEN confidence_level ELSE -confidence_level END, updated_at=NOW()
       WHERE game_id = $1`, [gameId, winningTeamId]);
   }
 }


### PR DESCRIPTION
This pull request introduces important updates to the pick logic and game data handling for both backend and frontend, especially to support a special case for the 2025 season and improve how pick results are calculated and displayed. The main changes include a new mapping for preseason week 4 in 2025, adjustments to how pick results are scored, and frontend improvements for displaying win/loss status and points.

**Backend: 2025 Preseason Week 4 Mapping and Pick Scoring**

* Added logic in `GameService.getGamesForWeek` and the picks routes to treat preseason week 4 as regular season week 0 for the 2025 season, ensuring correct data fetching and storage for that special case. [[1]](diffhunk://#diff-076230a5af6c8dd355a460edc892961b1a6498a541312277ec9ea60642584325R33-R51) [[2]](diffhunk://#diff-076230a5af6c8dd355a460edc892961b1a6498a541312277ec9ea60642584325L77-R103) [[3]](diffhunk://#diff-c28bb0f38d419b6dbc9167c63e9f18db65d1d7a84fb72bd0e7a53802998dd655R63-R83) [[4]](diffhunk://#diff-c28bb0f38d419b6dbc9167c63e9f18db65d1d7a84fb72bd0e7a53802998dd655R155-R174)
* Updated the pick result calculation in `UserPick.updateResults` so that correct picks earn positive confidence points, while incorrect picks lose confidence points (negative value).
* Ensured that confidence clearing for implicit overrides uses the mapped season/week values, maintaining consistency with the new mapping logic.

**Frontend: Pick Result Display Improvements**

* Enhanced `GamePickRow.svelte` to merge draft and server pick data for final games, ensuring accurate display of pick results and points.
* Refined win/loss status calculation and result line rendering to use backend-calculated `won` and `points` values, and to show correct positive/negative points for wins and losses. [[1]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L26-R40) [[2]](diffhunk://#diff-a4fba2731582958dafa61f3e3302f6253465baf764ec7899007c1dcf9ffd5ee4L219-R232)