### PR TITLE
feat: scripts and fixing confidence scores

### DIFF
--- a/backend/scripts/checkPickScoring.js
+++ b/backend/scripts/checkPickScoring.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import pool from '../src/config/database.js';
+
+async function checkProductionScoring() {
+  try {
+    console.log('=== CHECKING PRODUCTION PICK SCORING ===\n');
+    console.log('Environment:', process.env.NODE_ENV || 'development');
+    console.log('Database URL:', process.env.DATABASE_URL ? 'Set' : 'Not set');
+
+    console.log('\nSTEP 1: Final Games in Week 0');
+    const { rows: finalGames } = await pool.query(`
+      SELECT id, espn_id, 
+        (home_team->>'id')::int as home_team_id,
+        (away_team->>'id')::int as away_team_id,
+        home_score, away_score, status, game_date
+      FROM games 
+      WHERE status = 'FINAL' AND season = 2025 AND season_type = 2 AND week = 0
+      ORDER BY id
+    `);
+
+    console.log(`Found ${finalGames.length} final games:`);
+    finalGames.forEach(g => {
+      const winner = g.home_score > g.away_score ? 'HOME' : g.away_score > g.home_score ? 'AWAY' : 'TIE';
+      const winnerTeamId = g.home_score > g.away_score ? g.home_team_id : g.away_score > g.home_score ? g.away_team_id : null;
+      console.log(`Game ${g.id}: Away(${g.away_team_id}) @ Home(${g.home_team_id}) = ${g.away_score}-${g.home_score} (${winner} wins, winner ID: ${winnerTeamId})`);
+    });
+
+    console.log('\nSTEP 2: All Users');
+    const { rows: users } = await pool.query(`
+      SELECT id, email, name
+      FROM users 
+      ORDER BY id
+    `);
+
+    console.log('All users:');
+    users.forEach(u => {
+      console.log(`User ${u.id}: ${u.email} (${u.name || 'No name'})`);
+    });
+
+    console.log('\nSTEP 3: All User Picks for Final Games');
+    const { rows: picks } = await pool.query(`
+      SELECT 
+        up.user_id,
+        up.game_id,
+        up.picked_team_id,
+        up.confidence_level,
+        up.won,
+        up.points,
+        g.home_score,
+        g.away_score,
+        (g.home_team->>'id')::int as home_team_id,
+        (g.away_team->>'id')::int as away_team_id,
+        u.email
+      FROM user_picks up
+      JOIN games g ON up.game_id = g.id
+      JOIN users u ON up.user_id = u.id
+      WHERE g.status = 'FINAL' 
+        AND g.season = 2025 
+        AND g.season_type = 2 
+        AND g.week = 0
+        AND up.picked_team_id IS NOT NULL
+      ORDER BY up.user_id, up.game_id
+    `);
+
+    console.log(`Found ${picks.length} picks for final games:`);
+    const userGroups = {};
+    picks.forEach(p => {
+      if (!userGroups[p.user_id]) userGroups[p.user_id] = [];
+      userGroups[p.user_id].push(p);
+    });
+
+    Object.keys(userGroups).forEach(userId => {
+      console.log(`\n--- User ${userId} (${userGroups[userId][0].email}) ---`);
+      let totalPoints = 0;
+      userGroups[userId].forEach(p => {
+        const winnerTeamId = p.home_score > p.away_score ? p.home_team_id : p.away_score > p.home_score ? p.away_team_id : null;
+        const shouldWin = p.picked_team_id == winnerTeamId;
+        const correctPoints = shouldWin ? p.confidence_level : -p.confidence_level;
+        const status = p.won === true ? 'WON' : p.won === false ? 'LOST' : 'NULL';
+        console.log(`  Game ${p.game_id}: picked team ${p.picked_team_id}, conf ${p.confidence_level}, actual winner ${winnerTeamId}, should ${shouldWin ? 'WIN' : 'LOSE'}, DB: ${status} ${p.points}pts, correct: ${correctPoints}pts`);
+        totalPoints += (p.points || 0);
+      });
+      console.log(`  TOTAL: ${totalPoints} points`);
+    });
+
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    await pool.end();
+  }
+}
+
+checkProductionScoring();

--- a/backend/scripts/checkTeamStructure.js
+++ b/backend/scripts/checkTeamStructure.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import pool from '../src/config/database.js';
+
+async function checkTeamStructure() {
+  try {
+    console.log('=== CHECKING TEAM DATA STRUCTURE ===\n');
+    
+    const { rows } = await pool.query(`
+      SELECT id, home_team, away_team, home_score, away_score 
+      FROM games 
+      WHERE id = 447 
+      LIMIT 1
+    `);
+    
+    if (rows.length > 0) {
+      console.log('Game 447 structure:');
+      console.log('ID:', rows[0].id);
+      console.log('home_team:', typeof rows[0].home_team, rows[0].home_team);
+      console.log('away_team:', typeof rows[0].away_team, rows[0].away_team);
+      console.log('home_score:', rows[0].home_score);
+      console.log('away_score:', rows[0].away_score);
+      
+      if (typeof rows[0].home_team === 'object') {
+        console.log('\nhome_team.id:', rows[0].home_team.id);
+        console.log('away_team.id:', rows[0].away_team.id);
+      }
+    }
+    
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    await pool.end();
+  }
+}
+
+checkTeamStructure();

--- a/backend/scripts/fixProductionScoring.js
+++ b/backend/scripts/fixProductionScoring.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import pool from '../src/config/database.js';
+
+async function fixProductionScoring() {
+  try {
+    console.log('=== FIXING PRODUCTION SCORING ===\n');
+    console.log('Environment:', process.env.NODE_ENV || 'development');
+    
+    // Get all final games
+    console.log('🔍 Finding all final games...');
+    const { rows: finalGames } = await pool.query(`
+      SELECT id, home_team, away_team, home_score, away_score, status 
+      FROM games 
+      WHERE status = 'FINAL'
+      ORDER BY id
+    `);
+    
+    console.log(`📊 Found ${finalGames.length} final games to process\n`);
+    
+    let updatedGames = 0;
+    let totalUpdatedPicks = 0;
+    
+    for (const game of finalGames) {
+      // Determine winning team (FIXED: use .id property)
+      let winningTeamId = null;
+      if (game.home_score > game.away_score) {
+        winningTeamId = parseInt(game.home_team.id);
+      } else if (game.away_score > game.home_score) {
+        winningTeamId = parseInt(game.away_team.id);
+      }
+      // If tie, winningTeamId remains null
+      
+      console.log(`Game ${game.id}: ${game.away_team.abbreviation} @ ${game.home_team.abbreviation} = ${game.away_score}-${game.home_score}`);
+      console.log(`  Winner: ${winningTeamId ? (winningTeamId === parseInt(game.home_team.id) ? game.home_team.abbreviation : game.away_team.abbreviation) : 'TIE'} (ID: ${winningTeamId})`);
+      
+      // Update ALL user picks for this game with correct scoring
+      const { rowCount } = await pool.query(`
+        UPDATE user_picks
+        SET 
+          won = (picked_team_id = $2), 
+          points = CASE 
+            WHEN picked_team_id = $2 THEN confidence_level 
+            ELSE -confidence_level 
+          END, 
+          updated_at = NOW()
+        WHERE game_id = $1 AND picked_team_id IS NOT NULL
+      `, [game.id, winningTeamId]);
+      
+      if (rowCount > 0) {
+        console.log(`  ✅ Updated ${rowCount} picks for this game\n`);
+        updatedGames++;
+        totalUpdatedPicks += rowCount;
+      } else {
+        console.log(`  ⚪ No picks found for this game\n`);
+      }
+    }
+    
+    // Get summary of results
+    console.log('📈 Getting final summary...');
+    const { rows: summary } = await pool.query(`
+      SELECT 
+        COUNT(*) as total_picks,
+        COUNT(CASE WHEN won = true THEN 1 END) as won_picks,
+        COUNT(CASE WHEN won = false THEN 1 END) as lost_picks,
+        SUM(points) as total_points,
+        COUNT(DISTINCT user_id) as total_users,
+        COUNT(DISTINCT game_id) as total_games
+      FROM user_picks 
+      WHERE points IS NOT NULL
+    `);
+    
+    console.log('\n=== SCORING FIX COMPLETE ===');
+    console.log(`✅ Updated ${updatedGames} games`);
+    console.log(`✅ Updated ${totalUpdatedPicks} total picks`);
+    console.log(`📊 Final stats:`, summary[0]);
+    
+  } catch (error) {
+    console.error('❌ Error fixing scoring:', error);
+  } finally {
+    await pool.end();
+  }
+}
+
+fixProductionScoring();

--- a/backend/scripts/updateProductionScoring.js
+++ b/backend/scripts/updateProductionScoring.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import pool from '../src/config/database.js';
+
+/**
+ * Script to update production database with correct scoring logic.
+ * This recalculates points for all final games to use the new scoring system:
+ * - Correct picks: +confidence points
+ * - Incorrect picks: -confidence points
+ */
+
+async function updateProductionScoring() {
+  try {
+    console.log('🔄 Starting production scoring update...');
+    
+    // Get all final games
+    const { rows: finalGames } = await pool.query(`
+      SELECT id, home_team, away_team, home_score, away_score, status 
+      FROM games 
+      WHERE status = 'FINAL'
+      ORDER BY id
+    `);
+    
+    console.log(`📊 Found ${finalGames.length} final games to process`);
+    
+    let updatedGames = 0;
+    
+    for (const game of finalGames) {
+      // Determine winning team
+      let winningTeamId = null;
+      if (game.home_score > game.away_score) {
+        winningTeamId = game.home_team;
+      } else if (game.away_score > game.home_score) {
+        winningTeamId = game.away_team;
+      }
+      // If tie, winningTeamId remains null
+      
+      // Update all picks for this game with correct scoring
+      const { rowCount } = await pool.query(`
+        UPDATE user_picks
+        SET 
+          won = (picked_team_id = $2), 
+          points = CASE 
+            WHEN picked_team_id = $2 THEN confidence_level 
+            ELSE -confidence_level 
+          END, 
+          updated_at = NOW()
+        WHERE game_id = $1 AND picked_team_id IS NOT NULL
+      `, [game.id, winningTeamId]);
+      
+      if (rowCount > 0) {
+        console.log(`✅ Game ${game.id}: Updated ${rowCount} picks (winner: team ${winningTeamId})`);
+        updatedGames++;
+      }
+    }
+    
+    // Get summary of results
+    const { rows: summary } = await pool.query(`
+      SELECT 
+        COUNT(*) as total_picks,
+        COUNT(CASE WHEN won = true THEN 1 END) as won_picks,
+        COUNT(CASE WHEN won = false THEN 1 END) as lost_picks,
+        SUM(points) as total_points,
+        AVG(points) as avg_points
+      FROM user_picks 
+      WHERE points IS NOT NULL
+    `);
+    
+    console.log('\n📈 Production scoring update complete!');
+    console.log(`🎯 Updated ${updatedGames} games`);
+    console.log(`📊 Summary:`, summary[0]);
+    
+  } catch (error) {
+    console.error('❌ Error updating production scoring:', error);
+    throw error;
+  } finally {
+    await pool.end();
+  }
+}
+
+// Run the script
+updateProductionScoring().catch(console.error);

--- a/backend/src/routes/picks.js
+++ b/backend/src/routes/picks.js
@@ -340,7 +340,8 @@ router.get('/:identifier/scoreboard', authenticateToken, async (req, res) => {
         const home = typeof r.home_team === 'string' ? JSON.parse(r.home_team) : r.home_team;
         const away = typeof r.away_team === 'string' ? JSON.parse(r.away_team) : r.away_team;
         const winnerTeamId = (r.home_score > r.away_score) ? home.id : away.id;
-        r.points = (winnerTeamId === r.picked_team_id) ? r.confidence_level : 0;
+        // Use correct scoring: +confidence for wins, -confidence for losses
+        r.points = (winnerTeamId === r.picked_team_id) ? r.confidence_level : -r.confidence_level;
       }
     }
 


### PR DESCRIPTION
This pull request introduces several new scripts and a scoring logic update for production picks in the backend. The main goal is to correct and verify the calculation of user pick points for final games, ensuring that correct picks receive positive confidence points and incorrect picks receive negative confidence points. Additionally, scripts for checking team data structure and verifying scoring are added to assist with debugging and validation.

**Scoring logic fixes and updates:**

* Updated the scoring calculation in the picks scoreboard route to award `+confidence_level` for correct picks and `-confidence_level` for incorrect picks, instead of zero for losses.
* Added `fixProductionScoring.js` and `updateProductionScoring.js` scripts to batch update all user picks in the production database to use the new scoring system, recalculating points for all final games. [[1]](diffhunk://#diff-810d43310246a09788d7111b40c4f7c38ec5b44ec9a5629c7f891253977349eaR1-R85) [[2]](diffhunk://#diff-9bd63c0b86484eed7a6d61aa01f33ab79240624635d630e0c68357e34498ebe1R1-R82)

**Debugging and verification scripts:**

* Added `checkPickScoring.js`, a script to verify pick scoring for final games and users by comparing database values to expected results.
* Added `checkTeamStructure.js`, a script to inspect the structure of team data in the `games` table for debugging purposes.