### PR TITLE
fix: no outer card container in mobile layout

### DIFF
--- a/frontend/src/components/GroupDetailsPage.svelte
+++ b/frontend/src/components/GroupDetailsPage.svelte
@@ -488,7 +488,7 @@
               {clearingState ? 'Clearing…' : 'Clear All'}
             </button>
           </div>
-          <div class="bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg p-lg">
+          <div class="picks-container bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg p-lg">
             <PicksPanel bind:this={picksPanelRef} bind:canSave bind:savingState bind:clearingState bind:hasSortedPicks groupIdentifier={group.identifier} />
           </div>
         </div>
@@ -510,4 +510,14 @@
 <style>
   .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
   .no-scrollbar::-webkit-scrollbar { display: none; }
+  
+  @media (max-width: 950px) {
+    .picks-container {
+      background: transparent !important;
+      border: none !important;
+      border-radius: 0 !important;
+      padding: 0 !important;
+      box-shadow: none !important;
+    }
+  }
 </style>


### PR DESCRIPTION
This pull request introduces a small UI improvement to the `GroupDetailsPage.svelte` component by making the picks panel container more responsive on smaller screens. The main update is the addition of a media query that removes background, border, padding, and box-shadow styles from the picks container when the viewport is less than 950px wide.

Responsive design update:

* Added a `.picks-container` class to the picks panel container and applied a media query in the `<style>` block to remove background, border, border-radius, padding, and box-shadow for screens narrower than 950px, improving mobile and tablet usability. [[1]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aL491-R491) [[2]](diffhunk://#diff-6a0aba40b98d0f478086e2c1ee2ec406f3d393673e1d2af6df17dcd95437140aR513-R522)