### PR TITLE
fix: update button height

### DIFF
--- a/frontend/src/components/GroupCard.svelte
+++ b/frontend/src/components/GroupCard.svelte
@@ -73,7 +73,7 @@
         Edit
       </Button>
       <Button 
-        variant="danger" 
+        variant="destructive" 
         size="sm"
         on:click={onDelete}
       >

--- a/frontend/src/designsystem/components/Button.svelte
+++ b/frontend/src/designsystem/components/Button.svelte
@@ -15,9 +15,9 @@
 
   // Size-specific classes
   const sizeClasses = {
-    sm: 'px-xs py-xxxs text-sm rounded-sm',
-    md: 'px-md py-xs text-base rounded-base',
-    lg: 'px-lg py-sm text-lg rounded-md'
+    sm: 'px-xs py-xxxs text-sm rounded-sm h-10',
+    md: 'px-md py-xs text-base rounded-base h-10',
+    lg: 'px-lg py-sm text-lg rounded-md h-10'
   };
 
   // Variant-specific classes


### PR DESCRIPTION
This pull request makes minor updates to button styling and usage to improve consistency and clarity. The main changes involve updating the button variant naming and ensuring all button sizes have a fixed height.

Styling consistency improvements:

* Updated the `variant` prop in `GroupCard.svelte` from `"danger"` to `"destructive"` to match the standardized variant naming convention.
* Modified the size-specific classes in `Button.svelte` to add a fixed height (`h-10`) for all button sizes, ensuring consistent button height across the UI.