### PR TITLE
Bug/siwa not working

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -30,6 +30,7 @@ app.use(cors({
     allowedHeaders: ['Content-Type', 'Authorization']
 }));
 app.use(express.json());
+app.use(express.urlencoded({ extended: true })); // Add this for Apple Sign In form data
 app.use(cookieParser());
 
 app.use(session({

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -14,7 +14,12 @@ function getApplePrivateKey() {
   // Priority 1: Environment variable (for CI/production)
   if (process.env.APPLE_PRIVATE_KEY) {
     // Replace \n with actual newlines
-    return process.env.APPLE_PRIVATE_KEY.replace(/\\n/g, '\n');
+    const key = process.env.APPLE_PRIVATE_KEY.replace(/\\n/g, '\n');
+    console.log('🍎 Using private key from env variable');
+    console.log('🍎 Key starts with:', key.substring(0, 50));
+    console.log('🍎 Key ends with:', key.substring(key.length - 50));
+    console.log('🍎 Key has newlines:', key.includes('\n'));
+    return key;
   }
   
   // Priority 2: File path (for local development)
@@ -22,7 +27,11 @@ function getApplePrivateKey() {
     const keyPath = path.resolve(__dirname, '..', process.env.APPLE_PRIVATE_KEY_PATH.replace('./src/', ''));
     
     if (fs.existsSync(keyPath)) {
-      return fs.readFileSync(keyPath, 'utf8');
+      const key = fs.readFileSync(keyPath, 'utf8');
+      console.log('🍎 Using private key from file');
+      console.log('🍎 Key starts with:', key.substring(0, 50));
+      console.log('🍎 Key ends with:', key.substring(key.length - 50));
+      return key;
     }
   }
   
@@ -71,12 +80,14 @@ if (hasAppleConfig && applePrivateKey) {
     ? 'https://api.confidence-picks.com/auth/apple/callback'
     : 'http://localhost:3001/auth/apple/callback');
   console.log('🍎 - privateKey length:', applePrivateKey.length);
+  console.log('🍎 - privateKey type:', typeof applePrivateKey);
+  console.log('🍎 - privateKey is string:', typeof applePrivateKey === 'string');
 
   passport.use(new AppleStrategy({
     clientID: process.env.APPLE_CLIENT_ID,
     teamID: process.env.APPLE_TEAM_ID,
     keyID: process.env.APPLE_KEY_ID,
-    privateKey: applePrivateKey,
+    privateKey: applePrivateKey.trim(), // Ensure no extra whitespace
     callbackURL: process.env.NODE_ENV === 'production'
       ? 'https://api.confidence-picks.com/auth/apple/callback'
       : 'http://localhost:3001/auth/apple/callback',

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -132,14 +132,16 @@ if (hasAppleConfig && applePrivateKey) {
       let firstName = profile.name?.firstName;
       let lastName = profile.name?.lastName;
       
-      // Check if this is the first auth and user data is in request
-      if (req.query?.user) {
+      // Check if this is the first auth and user data is in request body or query
+      const userData = req.body?.user || req.query?.user;
+      if (userData) {
         try {
-          const userData = JSON.parse(req.query.user);
-          firstName = firstName || userData.firstName;
-          lastName = lastName || userData.lastName;
+          const parsedUserData = typeof userData === 'string' ? JSON.parse(userData) : userData;
+          firstName = firstName || parsedUserData.name?.firstName;
+          lastName = lastName || parsedUserData.name?.lastName;
+          console.log('🍎 Found user data in request:', JSON.stringify(parsedUserData, null, 2));
         } catch (e) {
-          console.log('🍎 Could not parse user data from request');
+          console.log('🍎 Could not parse user data from request:', e.message);
         }
       }
       

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -102,7 +102,7 @@ if (hasAppleConfig && applePrivateKey) {
     clientID: process.env.APPLE_CLIENT_ID,
     teamID: process.env.APPLE_TEAM_ID,
     keyID: process.env.APPLE_KEY_ID,
-    privateKey: applePrivateKey, // Use key exactly as loaded
+    privateKeyString: applePrivateKey, // Use privateKeyString instead of privateKey!
     callbackURL: process.env.NODE_ENV === 'production'
       ? 'https://api.confidence-picks.com/auth/apple/callback'
       : 'http://localhost:3001/auth/apple/callback',

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -63,6 +63,15 @@ const hasAppleConfig = process.env.APPLE_CLIENT_ID &&
                       !process.env.APPLE_CLIENT_ID.startsWith('REPLACE_WITH_');
 
 if (hasAppleConfig && applePrivateKey) {
+  console.log('🍎 Configuring Apple Strategy with:');
+  console.log('🍎 - clientID:', process.env.APPLE_CLIENT_ID);
+  console.log('🍎 - teamID:', process.env.APPLE_TEAM_ID);
+  console.log('🍎 - keyID:', process.env.APPLE_KEY_ID);
+  console.log('🍎 - callbackURL:', process.env.NODE_ENV === 'production'
+    ? 'https://api.confidence-picks.com/auth/apple/callback'
+    : 'http://localhost:3001/auth/apple/callback');
+  console.log('🍎 - privateKey length:', applePrivateKey.length);
+
   passport.use(new AppleStrategy({
     clientID: process.env.APPLE_CLIENT_ID,
     teamID: process.env.APPLE_TEAM_ID,
@@ -71,7 +80,8 @@ if (hasAppleConfig && applePrivateKey) {
     callbackURL: process.env.NODE_ENV === 'production'
       ? 'https://api.confidence-picks.com/auth/apple/callback'
       : 'http://localhost:3001/auth/apple/callback',
-    scope: ['email', 'name']
+    scope: ['email', 'name'],
+    passReqToCallback: false
   }, async (accessToken, refreshToken, profile, done) => {
     console.log('🍎 APPLE STRATEGY CALLED - Entry Point');
     console.log('🍎 Apple Strategy - accessToken exists:', !!accessToken);

--- a/backend/src/config/passport.js
+++ b/backend/src/config/passport.js
@@ -73,7 +73,13 @@ if (hasAppleConfig && applePrivateKey) {
       : 'http://localhost:3001/auth/apple/callback',
     scope: ['email', 'name']
   }, async (accessToken, refreshToken, profile, done) => {
+    console.log('🍎 APPLE STRATEGY CALLED - Entry Point');
+    console.log('🍎 Apple Strategy - accessToken exists:', !!accessToken);
+    console.log('🍎 Apple Strategy - refreshToken exists:', !!refreshToken);
+    
     try {
+      console.log('🍎 Apple Strategy - Raw Profile:', JSON.stringify(profile, null, 2));
+      
       // Apple provides user info differently
       const appleData = {
         appleId: profile.id,
@@ -82,10 +88,20 @@ if (hasAppleConfig && applePrivateKey) {
         lastName: profile.name?.lastName
       };
       
+      console.log('🍎 Apple Strategy - Processed Data:', JSON.stringify(appleData, null, 2));
+      
       const user = await User.createOrUpdateFromApple(appleData);
+      console.log('🍎 Apple Strategy - User Created:', JSON.stringify({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        appleId: user.appleId
+      }, null, 2));
+      
       return done(null, user);
     } catch (error) {
-      console.error('Apple Strategy Error:', error);
+      console.error('❌ Apple Strategy Error:', error);
+      console.error('❌ Error Stack:', error.stack);
       return done(error, null);
     }
   }));

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -123,6 +123,9 @@ export class User {
     const { appleId, email, firstName, lastName } = appleData;
     const name = firstName && lastName ? `${firstName} ${lastName}` : firstName || lastName || 'Apple User';
     
+    // If no email provided, generate a fallback email based on Apple ID
+    const userEmail = email || `apple_${appleId}@confidence-picks.local`;
+    
     // First try to find by Apple ID
     let existingUser = await User.findByAppleId(appleId);
     
@@ -186,7 +189,7 @@ export class User {
       RETURNING *
     `;
     
-    const values = [appleId, email, name];
+    const values = [appleId, userEmail, name];
     const result = await pool.query(query, values);
     
     return new User({

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -59,10 +59,30 @@ router.post('/apple/callback', (req, res, next) => {
   
   console.log('🍎 About to call passport.authenticate');
   passport.authenticate('apple', { 
-    session: false,
-    failureRedirect: process.env.NODE_ENV === 'production' 
-      ? 'https://www.confidence-picks.com/login?error=apple_auth_failed'
-      : 'http://localhost:5173/login?error=apple_auth_failed'
+    session: false
+  }, (err, user, info) => {
+    console.log('🍎 Passport authenticate callback - err:', err);
+    console.log('🍎 Passport authenticate callback - user:', user);
+    console.log('🍎 Passport authenticate callback - info:', info);
+    
+    if (err) {
+      console.error('❌ Apple authentication error:', err);
+      const frontendURL = process.env.NODE_ENV === 'production' 
+        ? 'https://www.confidence-picks.com'
+        : 'http://localhost:5173';
+      return res.redirect(`${frontendURL}/login?error=apple_token_failed`);
+    }
+    
+    if (!user) {
+      console.error('❌ No user returned from Apple auth');
+      const frontendURL = process.env.NODE_ENV === 'production' 
+        ? 'https://www.confidence-picks.com'
+        : 'http://localhost:5173';
+      return res.redirect(`${frontendURL}/login?error=apple_no_user`);
+    }
+    
+    req.user = user;
+    next();
   })(req, res, next);
 }, async (req, res) => {
   try {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -43,30 +43,18 @@ router.get('/apple', (req, res, next) => {
 });
 
 router.post('/apple/callback', (req, res, next) => {
-  console.log('🍎 Apple callback route hit - body:', JSON.stringify(req.body, null, 2));
-  console.log('🍎 Apple callback route hit - headers:', JSON.stringify(req.headers, null, 2));
-  
-  const appleConfigured = isAppleConfigured();
-  console.log('🍎 Apple configured status:', appleConfigured);
-  
-  if (!appleConfigured) {
-    console.log('❌ Apple not configured');
+  if (!isAppleConfigured()) {
     const frontendURL = process.env.NODE_ENV === 'production' 
       ? 'https://www.confidence-picks.com'
       : 'http://localhost:5173';
     return res.redirect(`${frontendURL}/login?error=apple_not_configured`);
   }
   
-  console.log('🍎 About to call passport.authenticate');
   passport.authenticate('apple', { 
     session: false
   }, (err, user, info) => {
-    console.log('🍎 Passport authenticate callback - err:', err);
-    console.log('🍎 Passport authenticate callback - user:', user);
-    console.log('🍎 Passport authenticate callback - info:', info);
-    
     if (err) {
-      console.error('❌ Apple authentication error:', err);
+      console.error('Apple authentication error:', err);
       const frontendURL = process.env.NODE_ENV === 'production' 
         ? 'https://www.confidence-picks.com'
         : 'http://localhost:5173';
@@ -86,10 +74,8 @@ router.post('/apple/callback', (req, res, next) => {
   })(req, res, next);
 }, async (req, res) => {
   try {
-    console.log('🍎 Apple callback handler reached - req.user:', req.user);
-    
     if (!req.user) {
-      console.error('❌ No user found in Apple callback');
+      console.error('No user found in Apple callback');
       const frontendURL = process.env.NODE_ENV === 'production' 
         ? 'https://www.confidence-picks.com'
         : 'http://localhost:5173';
@@ -104,7 +90,7 @@ router.post('/apple/callback', (req, res, next) => {
     
     res.redirect(`${frontendURL}/auth/callback?token=${accessToken}&refresh=${refreshToken}`);
   } catch (error) {
-    console.error('❌ Apple callback error:', error);
+    console.error('Apple callback error:', error);
     const frontendURL = process.env.NODE_ENV === 'production' 
       ? 'https://www.confidence-picks.com'
       : 'http://localhost:5173';

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -43,16 +43,30 @@ router.get('/apple', (req, res, next) => {
 });
 
 router.post('/apple/callback', (req, res, next) => {
-  if (!isAppleConfigured()) {
+  console.log('🍎 Apple callback route hit - body:', JSON.stringify(req.body, null, 2));
+  console.log('🍎 Apple callback route hit - headers:', JSON.stringify(req.headers, null, 2));
+  
+  const appleConfigured = isAppleConfigured();
+  console.log('🍎 Apple configured status:', appleConfigured);
+  
+  if (!appleConfigured) {
+    console.log('❌ Apple not configured');
     const frontendURL = process.env.NODE_ENV === 'production' 
       ? 'https://www.confidence-picks.com'
       : 'http://localhost:5173';
     return res.redirect(`${frontendURL}/login?error=apple_not_configured`);
   }
-  passport.authenticate('apple', { session: false })(req, res, next);
+  
+  console.log('🍎 About to call passport.authenticate');
+  passport.authenticate('apple', { 
+    session: false,
+    failureRedirect: process.env.NODE_ENV === 'production' 
+      ? 'https://www.confidence-picks.com/login?error=apple_auth_failed'
+      : 'http://localhost:5173/login?error=apple_auth_failed'
+  })(req, res, next);
 }, async (req, res) => {
   try {
-    console.log('🍎 Apple callback - req.user:', req.user);
+    console.log('🍎 Apple callback handler reached - req.user:', req.user);
     
     if (!req.user) {
       console.error('❌ No user found in Apple callback');


### PR DESCRIPTION
This pull request improves the Apple Sign In authentication flow by enhancing how user data is extracted and validated, adding robust error handling, and ensuring users are created even if Apple does not provide an email. The main changes span the authentication strategy, user model, and route handling.

**Apple Sign In authentication improvements:**

* Updated the Apple authentication strategy in `passport.js` to decode the ID token for user info, handle first-time sign-ins with name extraction from the request, and validate the Apple private key using JWT signing. Also switched to using `privateKeyString` and enabled `passReqToCallback` for more flexible data handling.
* Added JWT import for token decoding and validation in `passport.js`.

**User model robustness:**

* Modified the `User` model to generate a fallback email address based on Apple ID if Apple does not provide an email, ensuring every user has a unique email.
* Updated user creation logic to use the fallback email when necessary.

**Route error handling and compatibility:**

* Enhanced the `/apple/callback` route to provide more detailed error handling and user feedback, including redirecting with specific error messages on authentication failure or missing user. [[1]](diffhunk://#diff-482f2488eddf4c75755221a6325ee3783d3ff9208f2cc369df2c3fa407cbd854L52-R78) [[2]](diffhunk://#diff-482f2488eddf4c75755221a6325ee3783d3ff9208f2cc369df2c3fa407cbd854L73-R93)
* Added `express.urlencoded` middleware to support Apple Sign In form data parsing.