### PR TITLE
fix(tokens): unbreak design-tokens CI gate (drop Svelte glob + non-deterministic timestamp)

### DIFF
--- a/frontend/scripts/generate-platform-tokens.js
+++ b/frontend/scripts/generate-platform-tokens.js
@@ -173,8 +173,8 @@ function transformIconsForTailwind(iconTokens) {
 async function generateTailwindConfig(tokens) {
   const config = {
     content: [
-      './src/**/*.{html,js,svelte,ts}',
-      './src/designsystem/components/**/*.svelte'
+      './src/**/*.{html,js,ts,tsx}',
+      './src/designsystem/components/**/*.{ts,tsx}'
     ],
     theme: {
       extend: {}
@@ -270,9 +270,10 @@ async function generatePlatformTokens() {
       iconMapContent
     );
     
-    // Generate summary file
+    // Generate summary file. generatedAt is intentionally omitted: a wall-clock
+    // timestamp would make every CI run dirty against the committed file, which
+    // turns the "verify design tokens are up to date" gate into a flake.
     const summary = {
-      generatedAt: new Date().toISOString(),
       tokenFiles: Object.keys(tokens),
       tailwindExtensions: Object.keys(tailwindConfig.theme.extend),
       iconCount: Object.keys(iconMap).length

--- a/frontend/src/designsystem/platform-tokens/summary.json
+++ b/frontend/src/designsystem/platform-tokens/summary.json
@@ -1,5 +1,4 @@
 {
-  "generatedAt": "2025-07-22T03:24:09.245Z",
   "tokenFiles": [
     "animation",
     "border",


### PR DESCRIPTION
The 'Verify design tokens are up to date' step in Frontend CI re-runs the
tokens generator and \`git diff --exit-code\` against committed tokens. Two
sources of permanent drift made it flake every PR:

1. \`generateTailwindConfig\` hard-coded Svelte content extensions
   (\`.svelte\`, \`./src/designsystem/components/**/*.svelte\`) while the
   committed tailwind.config.js uses React extensions (\`.tsx\`).
2. \`summary.json.generatedAt\` was a wall-clock \`new Date().toISOString()\`
   that differed every run.

Both were the root cause of CI failures starting at PR #73. Fix:

- Generator now outputs \`./src/**/*.{html,js,ts,tsx}\` +
  \`./src/designsystem/components/**/*.{ts,tsx}\` so the regenerated
  tailwind.config.js matches the committed file byte-for-byte.
- Drop \`generatedAt\` from summary.json so the file is stable across runs.

This unblocks PRs #76–#82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)