### PR TITLE
test(auth): regression test pinning backend's ?token/?refresh OAuth contract

### DIFF
--- a/frontend/src/pages/AuthCallback.test.tsx
+++ b/frontend/src/pages/AuthCallback.test.tsx
@@ -59,6 +59,30 @@ describe('AuthCallback', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
   });
 
+  // Regression: backend/src/routes/auth.js redirects to
+  // /auth/callback?token=…&refresh=… (NOT accessToken/refreshToken).
+  // Prior to fix/auth-callback-param-names the React AuthCallback only read
+  // the long-form names, so every successful OAuth round-trip silently fell
+  // through to the missing-tokens branch and bounced the user back to /login.
+  // This test pins the actual backend contract so any future regression of
+  // the param names trips a unit test rather than reaching prod.
+  it('persists tokens and hydrates the user when given the backend "?token=&refresh=" shape', async () => {
+    window.history.pushState({}, '', '/auth/callback?token=BACKEND_ACCESS&refresh=BACKEND_REFRESH');
+    mockGetCurrentUser.mockResolvedValue(testUser as any);
+
+    render(
+      <MemoryRouter>
+        <AuthCallback />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+
+    expect(mockSetTokens).toHaveBeenCalledWith('BACKEND_ACCESS', 'BACKEND_REFRESH');
+    expect(mockSetAuthUser).toHaveBeenCalledWith(testUser);
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
   it('redirects to /login with an error toast when tokens are missing', async () => {
     window.history.pushState({}, '', '/auth/callback');
 


### PR DESCRIPTION
Follow-up to #84. Adds a third happy-path test to AuthCallback.test.tsx
that hits the exact URL the backend redirects to
(\`?token=…&refresh=…\`, auth.js:25 / :92). The previous test only covered
the long-form names (\`accessToken\` / \`refreshToken\`) that the React port
had invented, which is why goal-5 shipped with a green suite and a broken
prod login.

If anyone changes AuthCallback to stop reading the short-form params, this
test will fail in CI before reaching prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)