### PR TITLE
fix(groups): plumb poolType through create + read (unbreaks WC group rendering)

### DIFF
--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -17,11 +17,15 @@ export class Group {
     this.updatedAt = data.updatedAt;
     this.memberCount = data.memberCount;
     this.userRole = data.userRole; // For current user's role in group
+    // 'nfl_weekly' (default) or 'world_cup_2026'. Carried through so the
+    // frontend's GroupDetailsPage can branch on group.poolType — without it
+    // every WC group rendered the NFL PicksTab.
+    this.poolType = data.poolType;
   }
 
   // Create new group
   static async create(groupData, creatorId) {
-    const { name, identifier, description, isPublic, maxMembers, avatarUrl } = groupData;
+    const { name, identifier, description, isPublic, maxMembers, avatarUrl, poolType } = groupData;
     
     // Ensure identifier is unique and URL-friendly
     // Clean identifier: lowercase, replace invalid chars with dash, collapse dashes, trim dashes
@@ -35,14 +39,16 @@ export class Group {
     try {
       await client.query('BEGIN');
       
-      // Create group
+      // Create group. pool_type defaults to 'nfl_weekly' at the schema level
+      // (see addWorldCupColumns.js migration), so omitting it preserves the
+      // pre-WC behavior for NFL callers. Pass through when set.
       const groupQuery = `
-        INSERT INTO groups (name, identifier, description, is_public, max_members, avatar_url, created_by)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        INSERT INTO groups (name, identifier, description, is_public, max_members, avatar_url, created_by, pool_type)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, 'nfl_weekly'))
         RETURNING *
       `;
       const groupResult = await client.query(groupQuery, [
-        name, cleanIdentifier, description, isPublic, maxMembers, avatarUrl, creatorId
+        name, cleanIdentifier, description, isPublic, maxMembers, avatarUrl, creatorId, poolType || null
       ]);
       
       const group = groupResult.rows[0];
@@ -114,7 +120,8 @@ export class Group {
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       memberCount: parseInt(row.member_count),
-      userRole: row.user_role
+      userRole: row.user_role,
+      poolType: row.pool_type,
     });
   }
 
@@ -149,7 +156,8 @@ export class Group {
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       memberCount: parseInt(row.member_count),
-      userRole: row.user_role
+      userRole: row.user_role,
+      poolType: row.pool_type,
     }));
   }
 

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -8,23 +8,30 @@ const router = express.Router();
 // Create a new group
 router.post('/', authenticateToken, async (req, res) => {
   try {
-    const { name, identifier, description, isPublic = true, maxMembers = 40, avatarUrl } = req.body;
-    
+    const { name, identifier, description, isPublic = true, maxMembers = 40, avatarUrl, poolType } = req.body;
+
     if (!name || !identifier) {
       return res.status(400).json({ error: 'Name and identifier are required' });
     }
-    
+
     if (maxMembers > 40) {
       return res.status(400).json({ error: 'Maximum members cannot exceed 40' });
     }
-    
+
+    // poolType is optional. The CHECK constraint on groups.pool_type would
+    // reject bad values with a 500, so we surface a 400 first.
+    if (poolType && poolType !== 'nfl_weekly' && poolType !== 'world_cup_2026') {
+      return res.status(400).json({ error: 'Invalid poolType' });
+    }
+
     const group = await Group.create({
       name,
       identifier,
       description,
       isPublic,
       maxMembers,
-      avatarUrl
+      avatarUrl,
+      poolType,
     }, req.user.id);
     
     res.status(201).json(group);


### PR DESCRIPTION
Reproed live: user created \`wc2026-test-group\`, the page showed NFL games (NYJ@CHI, JAX@CIN, …) and the leaderboard was the 'coming soon' placeholder. Goal-13 added all the WC2026 UI but the create-group write path silently dropped \`poolType\`:

| Layer | Before | After |
|---|---|---|
| \`routes/groups.js POST '/'\` | Destructured everything except \`poolType\` | Accepts \`poolType\`, validates against the schema CHECK domain, passes to \`Group.create\` |
| \`Group.create\` | No \`pool_type\` column in INSERT | Adds \`pool_type\` to the INSERT with \`COALESCE(\$8, 'nfl_weekly')\` so omitted/null falls through to the schema default |
| \`Group\` constructor | No \`this.poolType\` | Carries \`data.poolType\` |
| \`Group.findByIdentifier\` + \`Group.getUserGroups\` | Never mapped \`row.pool_type\` | Maps it to \`poolType\` in the Group(…) call |

After this lands, \`GroupDetailsPage\` will see \`group.poolType === 'world_cup_2026'\`, \`isWorldCup\` flips true, and the page renders \`<WorldCupLeaderboardTab/>\` plus the 'Make World Cup Picks' CTA (which routes to \`/world-cup?group=<id>\`) instead of the NFL PicksTab.

## Pre-existing data

Every group created between the goal-13 migration and this fix has \`pool_type = 'nfl_weekly'\` regardless of intent. The user's \`wc2026-test-group\` (id 16) needs a one-off update after merge:

\`\`\`sql
UPDATE groups SET pool_type = 'world_cup_2026' WHERE identifier = 'wc2026-test-group';
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)