### PR TITLE
feat(picks): restore 'save to all groups' toggle on NFL + WC pickers

### DIFF
--- a/frontend/src/lib/groupsService.js
+++ b/frontend/src/lib/groupsService.js
@@ -49,7 +49,10 @@ export async function getMyGroups() {
     userRole: g.userRole,
   createdAt: g.createdAt,
   createdByName: g.createdByName || null,
-  createdByPictureUrl: g.createdByPictureUrl || null
+  createdByPictureUrl: g.createdByPictureUrl || null,
+  // Forwarded so the picks pages can fan a single submit out to every group
+  // of the same poolType ('save to all my World Cup groups' / NFL groups).
+  poolType: g.poolType || null
   }));
 }
 

--- a/frontend/src/pages/GamesPage.test.tsx
+++ b/frontend/src/pages/GamesPage.test.tsx
@@ -9,9 +9,12 @@ vi.mock('../lib/authService.js', () => ({
   default: { getApiBaseUrl: () => 'http://test' },
 }));
 vi.mock('../lib/picksService.js', () => ({ savePicks: vi.fn() }));
+vi.mock('../lib/groupsService.js', () => ({ getMyGroups: vi.fn() }));
 
 import { savePicks } from '../lib/picksService.js';
+import { getMyGroups } from '../lib/groupsService.js';
 const mockSavePicks = vi.mocked(savePicks);
+const mockGetMyGroups = vi.mocked(getMyGroups);
 
 const buf = { id: '1', name: 'Bills', abbreviation: 'BUF', logo: '' };
 const ne = { id: '2', name: 'Patriots', abbreviation: 'NE', logo: '' };
@@ -168,5 +171,32 @@ describe('GamesPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit Picks' }));
     expect(await screen.findByText('Server said no')).toBeInTheDocument();
+  });
+
+  it('fans the same picks out to every NFL group when "Save to all" is checked', async () => {
+    // Three groups: two NFL (one explicit poolType, one legacy null) + one WC.
+    // Fan-out must call savePicks for both NFL identifiers and skip the WC one.
+    mockGetMyGroups.mockResolvedValue([
+      { id: 1, identifier: 'sunday-squad', poolType: 'nfl_weekly' },
+      { id: 2, identifier: 'office-pool', poolType: null }, // legacy pre-#86
+      { id: 3, identifier: 'wc-crew', poolType: 'world_cup_2026' },
+    ] as any);
+    mockSavePicks.mockResolvedValue({ games: [] });
+
+    renderPage();
+    await screen.findByText('Bills');
+
+    const row10 = screen.getByTestId('game-row-10');
+    fireEvent.click(within(row10).getByRole('radio', { name: 'Pick Bills to win' }));
+    fireEvent.click(within(row10).getByRole('button', { name: /Confidence for BUF at NE/ }));
+    fireEvent.click(within(row10).getByRole('option', { name: '1' }));
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Save to all my NFL groups' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to All' }));
+
+    await waitFor(() => expect(mockSavePicks).toHaveBeenCalledTimes(2));
+    const calledIdentifiers = mockSavePicks.mock.calls.map((c) => c[0]).sort();
+    expect(calledIdentifiers).toEqual(['office-pool', 'sunday-squad']);
+    expect(await screen.findByText('Picks saved to 2 groups')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/GamesPage.tsx
+++ b/frontend/src/pages/GamesPage.tsx
@@ -8,6 +8,7 @@ import GamePickRow, { type DraftPick, type PickGame } from '../components/GamePi
 import AuthService from '../lib/authService.js';
 import { getCurrentNFLSeason } from '../lib/nflSeasonUtils.js';
 import { savePicks } from '../lib/picksService.js';
+import { getMyGroups } from '../lib/groupsService.js';
 
 // Ported from GamesPage.svelte + GamePickRow.svelte (commit d6b2566^). The page
 // owns the year/season-type/week selector, fetches the public games endpoint,
@@ -185,6 +186,12 @@ export default function GamesPage() {
 
   const canSubmit = !!groupId && completePicks.length > 0 && !submitting && !pageState.loading;
 
+  // Opt-in "save these picks to every NFL group I'm in" toggle. Restores the
+  // heritage Svelte 'save for all groups' UX (PR #37, Aug 2025) that the React
+  // rewrite dropped. NFL pools include groups with poolType 'nfl_weekly' AND
+  // legacy groups created before #86 where poolType is null.
+  const [applyToAll, setApplyToAll] = useState(false);
+
   async function submit() {
     if (!groupId) return;
     // Client-side guard: each confidence value must be used at most once. The UI
@@ -202,16 +209,52 @@ export default function GamesPage() {
       seen.add(p.confidence);
     }
 
+    const body = {
+      season: year,
+      seasonType,
+      week,
+      picks: completePicks,
+      clearedGameIds: [],
+    };
+
     setSubmitting(true);
     try {
-      await savePicks(groupId, {
-        season: year,
-        seasonType,
-        week,
-        picks: completePicks,
-        clearedGameIds: [],
-      });
-      setToast({ open: true, message: 'Picks saved', variant: 'success' });
+      if (!applyToAll) {
+        await savePicks(groupId, body);
+        setToast({ open: true, message: 'Picks saved', variant: 'success' });
+        return;
+      }
+
+      // Fan-out: every NFL group the user belongs to. Treat null poolType
+      // (legacy groups predating the WC migration) as NFL.
+      const groups = await getMyGroups();
+      const targets = groups
+        .filter((g) => g.poolType !== 'world_cup_2026')
+        .map((g) => g.identifier);
+      if (!targets.includes(groupId)) targets.push(groupId);
+
+      const results = await Promise.allSettled(targets.map((id) => savePicks(id, body)));
+      const ok = results.filter((r) => r.status === 'fulfilled').length;
+      const fail = results.length - ok;
+      if (fail === 0) {
+        setToast({
+          open: true,
+          message: `Picks saved to ${ok} group${ok === 1 ? '' : 's'}`,
+          variant: 'success',
+        });
+      } else if (ok === 0) {
+        setToast({
+          open: true,
+          message: `Failed to save picks (0/${results.length})`,
+          variant: 'error',
+        });
+      } else {
+        setToast({
+          open: true,
+          message: `Saved to ${ok}/${results.length} groups (${fail} failed)`,
+          variant: 'error',
+        });
+      }
     } catch (err) {
       setToast({
         open: true,
@@ -338,14 +381,26 @@ export default function GamesPage() {
 
       {/* Submit bar */}
       {pageState.games.length > 0 && (
-        <div className="mt-lg flex items-center justify-between gap-md border-t border-border pt-md">
-          <div className="text-sm text-secondary">
-            {completePicks.length} of {totalGames} pick{totalGames === 1 ? '' : 's'} complete
-            {hasIncomplete && (
-              <span className="ml-sm text-warning-600 dark:text-warning-400">
-                Finish selecting a winner and confidence for highlighted games.
-              </span>
-            )}
+        <div className="mt-lg flex flex-col gap-sm border-t border-border pt-md sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-xxs text-sm text-secondary sm:flex-row sm:items-center sm:gap-md">
+            <span>
+              {completePicks.length} of {totalGames} pick{totalGames === 1 ? '' : 's'} complete
+              {hasIncomplete && (
+                <span className="ml-sm text-warning-600 dark:text-warning-400">
+                  Finish selecting a winner and confidence for highlighted games.
+                </span>
+              )}
+            </span>
+            <label className="flex items-center gap-xs">
+              <input
+                type="checkbox"
+                checked={applyToAll}
+                onChange={(e) => setApplyToAll(e.target.checked)}
+                aria-label="Save to all my NFL groups"
+                className="h-4 w-4"
+              />
+              Save to all my NFL groups
+            </label>
           </div>
           <div className="relative inline-toast-anchor">
             <InlineToast
@@ -361,7 +416,7 @@ export default function GamesPage() {
               disabled={!canSubmit}
               onClick={submit}
             >
-              {submitting ? 'Saving…' : 'Submit Picks'}
+              {submitting ? 'Saving…' : applyToAll ? 'Submit to All' : 'Submit Picks'}
             </Button>
           </div>
         </div>

--- a/frontend/src/pages/WorldCupPicksPage.test.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.test.tsx
@@ -8,10 +8,15 @@ vi.mock('../lib/worldCupService.js', () => ({
   getStageMatches: vi.fn(),
   submitWorldCupPicks: vi.fn(),
 }));
+vi.mock('../lib/groupsService.js', () => ({
+  getMyGroups: vi.fn(),
+}));
 
 import { getStageMatches, submitWorldCupPicks } from '../lib/worldCupService.js';
+import { getMyGroups } from '../lib/groupsService.js';
 const mockGetStageMatches = vi.mocked(getStageMatches);
 const mockSubmitPicks = vi.mocked(submitWorldCupPicks);
+const mockGetMyGroups = vi.mocked(getMyGroups);
 
 const mex = { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: '' };
 const usa = { id: '2', name: 'United States', abbreviation: 'USA', logo: '' };
@@ -148,6 +153,54 @@ describe('WorldCupPicksPage', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Submit Picks' }));
     expect(await screen.findByText('Server said no')).toBeInTheDocument();
+  });
+
+  it('fans the same picks out to every world_cup_2026 group when "Save to all" is checked', async () => {
+    // The user is in three groups: two WC + one NFL. The fan-out must hit
+    // both WC group identifiers (in addition to the source identifier when
+    // the source is itself a WC group) and skip the NFL one entirely.
+    mockGetMyGroups.mockResolvedValue([
+      { id: 1, identifier: 'la-crew', poolType: 'world_cup_2026' },
+      { id: 2, identifier: 'work-pool', poolType: 'world_cup_2026' },
+      { id: 3, identifier: 'family-nfl', poolType: 'nfl_weekly' },
+    ] as any);
+    mockSubmitPicks.mockResolvedValue({});
+
+    renderPage();
+    await screen.findByTestId('match-row-10');
+
+    fireEvent.click(
+      within(screen.getByTestId('match-row-10')).getByRole('button', { name: 'Pick Mexico to win' }),
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Save to all my World Cup groups' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to All' }));
+
+    await waitFor(() => expect(mockSubmitPicks).toHaveBeenCalledTimes(2));
+    const calledIdentifiers = mockSubmitPicks.mock.calls.map((c) => c[0]).sort();
+    expect(calledIdentifiers).toEqual(['la-crew', 'work-pool']);
+    expect(await screen.findByText('Picks saved to 2 groups')).toBeInTheDocument();
+  });
+
+  it('reports partial failure when some fan-out submits reject', async () => {
+    mockGetMyGroups.mockResolvedValue([
+      { id: 1, identifier: 'la-crew', poolType: 'world_cup_2026' },
+      { id: 2, identifier: 'work-pool', poolType: 'world_cup_2026' },
+    ] as any);
+    mockSubmitPicks.mockImplementation(async (groupId: string) => {
+      if (groupId === 'work-pool') throw new Error('boom');
+      return {};
+    });
+
+    renderPage();
+    await screen.findByTestId('match-row-10');
+
+    fireEvent.click(
+      within(screen.getByTestId('match-row-10')).getByRole('button', { name: 'Pick Mexico to win' }),
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Save to all my World Cup groups' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to All' }));
+
+    expect(await screen.findByText('Saved to 1/2 groups (1 failed)')).toBeInTheDocument();
   });
 
   it('toggles a pick off when the selected result is clicked again', async () => {

--- a/frontend/src/pages/WorldCupPicksPage.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.tsx
@@ -12,6 +12,7 @@ import {
   type WorldCupStage,
 } from '../lib/types';
 import { getStageMatches, submitWorldCupPicks } from '../lib/worldCupService.js';
+import { getMyGroups } from '../lib/groupsService.js';
 
 // World Cup sibling of GamesPage. A world_cup_2026 pool renders the WHOLE
 // tournament as one stage-grouped match list — there is NO week selector. The
@@ -142,12 +143,56 @@ export default function WorldCupPicksPage() {
 
   const canSubmit = !!groupId && picks.length > 0 && !submitting;
 
+  // Opt-in "save these picks to every World Cup group I'm in" toggle. Mirrors
+  // the heritage Svelte 'save for all groups' UX (PR #37, Aug 2025) that the
+  // React rewrite dropped. Backend has no fan-out endpoint; we iterate the
+  // user's groups client-side and submit per group.
+  const [applyToAll, setApplyToAll] = useState(false);
+
   async function submit() {
     if (!groupId || picks.length === 0) return;
     setSubmitting(true);
     try {
-      await submitWorldCupPicks(groupId, picks);
-      setToast({ open: true, message: 'Picks saved', variant: 'success' });
+      if (!applyToAll) {
+        await submitWorldCupPicks(groupId, picks);
+        setToast({ open: true, message: 'Picks saved', variant: 'success' });
+        return;
+      }
+
+      // Fan-out: every World Cup group the user belongs to. Always include the
+      // current `groupId` (the source group) — getMyGroups should list it, but
+      // if for some reason it doesn't, we still want a single-group save to
+      // succeed rather than silently no-op.
+      const groups = await getMyGroups();
+      const targets = groups
+        .filter((g) => g.poolType === 'world_cup_2026')
+        .map((g) => g.identifier);
+      if (!targets.includes(groupId)) targets.push(groupId);
+
+      const results = await Promise.allSettled(
+        targets.map((id) => submitWorldCupPicks(id, picks)),
+      );
+      const ok = results.filter((r) => r.status === 'fulfilled').length;
+      const fail = results.length - ok;
+      if (fail === 0) {
+        setToast({
+          open: true,
+          message: `Picks saved to ${ok} group${ok === 1 ? '' : 's'}`,
+          variant: 'success',
+        });
+      } else if (ok === 0) {
+        setToast({
+          open: true,
+          message: `Failed to save picks (0/${results.length})`,
+          variant: 'error',
+        });
+      } else {
+        setToast({
+          open: true,
+          message: `Saved to ${ok}/${results.length} groups (${fail} failed)`,
+          variant: 'error',
+        });
+      }
     } catch (err) {
       setToast({
         open: true,
@@ -207,9 +252,21 @@ export default function WorldCupPicksPage() {
 
       {/* Submit bar */}
       {pageState.matches.length > 0 && (
-        <div className="mt-lg flex items-center justify-between gap-md border-t border-border pt-md">
-          <div className="text-sm text-secondary">
-            {picks.length} pick{picks.length === 1 ? '' : 's'} selected
+        <div className="mt-lg flex flex-col gap-sm border-t border-border pt-md sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-xxs sm:flex-row sm:items-center sm:gap-md">
+            <span className="text-sm text-secondary">
+              {picks.length} pick{picks.length === 1 ? '' : 's'} selected
+            </span>
+            <label className="flex items-center gap-xs text-sm text-secondary">
+              <input
+                type="checkbox"
+                checked={applyToAll}
+                onChange={(e) => setApplyToAll(e.target.checked)}
+                aria-label="Save to all my World Cup groups"
+                className="h-4 w-4"
+              />
+              Save to all my World Cup groups
+            </label>
           </div>
           <div className="relative inline-toast-anchor">
             <InlineToast
@@ -225,7 +282,7 @@ export default function WorldCupPicksPage() {
               disabled={!canSubmit}
               onClick={submit}
             >
-              {submitting ? 'Saving…' : 'Submit Picks'}
+              {submitting ? 'Saving…' : applyToAll ? 'Submit to All' : 'Submit Picks'}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Heritage PR #37 'save picks for all groups' (Svelte, Aug 2025) didn't survive the React rewrite. This adds it back as an opt-in checkbox on both `GamesPage` (NFL) and `WorldCupPicksPage` (WC).

Client-side fan-out, matching the Svelte shape:
- Checkbox 'Save to all my {NFL,World Cup} groups' next to the submit button.
- On submit, `getMyGroups()` → filter by poolType → `Promise.allSettled` per-group submit.
- Toast reports `Saved to N groups`, or `Saved to N/M groups (M-N failed)` on partial failure.
- Source group is always included so a single-group user gets the same UX as before.

Backend untouched. `groupsService.getMyGroups` now forwards `poolType` (added by #86) so the partition is possible. NFL filter treats legacy `poolType=null` groups as NFL.

Tests: 3 new — happy fan-out for WC, partial-failure for WC, happy fan-out for NFL. Suites run 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)