### PR TITLE
feat(picks): multi-select save-to dropdown + sticky submit bar (NFL + WC)

### DIFF
--- a/frontend/src/components/SaveTargetsDropdown.tsx
+++ b/frontend/src/components/SaveTargetsDropdown.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from 'react';
+import Button from '../designsystem/components/Button';
+
+// One group entry the dropdown can target. The picker pages pre-filter the
+// caller's groups by poolType so this component does not need to know about
+// NFL vs World Cup.
+export interface SaveTarget {
+  identifier: string;
+  name: string;
+}
+
+interface SaveTargetsDropdownProps {
+  /** Every group of the right poolType the user belongs to. */
+  groups: SaveTarget[];
+  /** Identifier of the group that owns the picks page. Always selected, cannot
+   * be unchecked — submitting picks without the source group is never useful. */
+  sourceIdentifier: string;
+  /** Set of identifiers currently selected. */
+  selected: Set<string>;
+  /** Called with the next selection on every checkbox toggle. */
+  onChange: (next: Set<string>) => void;
+  /** Optional label suffix, e.g. "World Cup" → "Save to N World Cup groups". */
+  label?: string;
+  /** True while the parent is loading its group list. */
+  loading?: boolean;
+  /** Disable interactions (during a submit, etc.). */
+  disabled?: boolean;
+}
+
+/**
+ * Compact "save to N group(s)" dropdown — restores the heritage multi-select
+ * UX (Svelte PR #37) that the React rewrite collapsed to a single "all or
+ * one" checkbox. Click the button to open a popover with one checkbox per
+ * group; the source group is always selected and cannot be unticked.
+ */
+export default function SaveTargetsDropdown({
+  groups,
+  sourceIdentifier,
+  selected,
+  onChange,
+  label,
+  loading,
+  disabled,
+}: SaveTargetsDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click. Escape also closes for keyboard users.
+  useEffect(() => {
+    if (!open) return;
+    function handleDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleDown);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleDown);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  function toggleOne(identifier: string) {
+    if (identifier === sourceIdentifier) return; // never unselect the source
+    const next = new Set(selected);
+    if (next.has(identifier)) next.delete(identifier);
+    else next.add(identifier);
+    onChange(next);
+  }
+
+  function selectAll() {
+    onChange(new Set(groups.map((g) => g.identifier).concat(sourceIdentifier)));
+  }
+
+  function selectOnlySource() {
+    onChange(new Set([sourceIdentifier]));
+  }
+
+  const count = selected.size;
+  const suffix = label ? ` ${label}` : '';
+  const buttonText = loading
+    ? `Save to:${suffix} groups (loading…)`
+    : `Save to: ${count}${suffix} group${count === 1 ? '' : 's'}`;
+
+  return (
+    <div ref={rootRef} className="relative inline-block">
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => setOpen((o) => !o)}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label="Choose groups to save picks to"
+      >
+        {buttonText} ▾
+      </Button>
+      {open && (
+        <div
+          role="listbox"
+          aria-multiselectable="true"
+          className="absolute bottom-full left-0 mb-xs z-20 w-72 max-h-80 overflow-y-auto rounded-md border border-border bg-neutral-0 p-sm shadow-md dark:bg-secondary-800"
+        >
+          {/* Bulk actions */}
+          {groups.length > 1 && (
+            <div className="mb-xs flex justify-between gap-sm border-b border-border pb-xs text-xs">
+              <button
+                type="button"
+                onClick={selectAll}
+                className="text-primary-600 hover:underline dark:text-primary-400"
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                onClick={selectOnlySource}
+                className="text-secondary hover:underline"
+              >
+                Only this group
+              </button>
+            </div>
+          )}
+          {loading ? (
+            <p className="px-xs py-sm text-sm text-secondary">Loading your groups…</p>
+          ) : groups.length === 0 ? (
+            <p className="px-xs py-sm text-sm text-secondary">
+              You're only in this one group.
+            </p>
+          ) : (
+            <ul className="space-y-xxs">
+              {groups.map((g) => {
+                const isSource = g.identifier === sourceIdentifier;
+                const isChecked = selected.has(g.identifier);
+                return (
+                  <li key={g.identifier}>
+                    <label
+                      className={`flex cursor-pointer items-center gap-xs rounded-base px-xs py-xxs text-sm hover:bg-secondary-50 dark:hover:bg-secondary-700 ${
+                        isSource ? 'opacity-90' : ''
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isChecked}
+                        disabled={isSource}
+                        onChange={() => toggleOne(g.identifier)}
+                        aria-label={isSource ? `${g.name} (current group)` : g.name}
+                        className="h-4 w-4"
+                      />
+                      <span className="flex-1 truncate">
+                        {g.name}
+                        {isSource && (
+                          <span className="ml-xs text-xs text-secondary">(current)</span>
+                        )}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/designsystem/components/GroupCard/GroupCard.tsx
+++ b/frontend/src/designsystem/components/GroupCard/GroupCard.tsx
@@ -11,6 +11,10 @@ export interface GroupData {
   createdAt: string;
   createdByName?: string;
   createdByPictureUrl?: string | null;
+  // Pool flavor — 'nfl_weekly' | 'world_cup_2026' | null for legacy groups
+  // predating #86. Forwarded by groupsService.getMyGroups so callers can
+  // partition by pool type.
+  poolType?: 'nfl_weekly' | 'world_cup_2026' | null;
 }
 
 export interface GroupCardProps {

--- a/frontend/src/pages/GamesPage.test.tsx
+++ b/frontend/src/pages/GamesPage.test.tsx
@@ -52,6 +52,11 @@ describe('GamesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal('fetch', mockFetchOk(gamesPayload()));
+    // Default: source group is the user's only NFL group. Tests exercising
+    // the dropdown re-mock with multiple groups.
+    mockGetMyGroups.mockResolvedValue([
+      { id: 1, identifier: 'sunday-squad', name: 'Sunday Squad', poolType: 'nfl_weekly' },
+    ] as any);
   });
   afterEach(() => vi.unstubAllGlobals());
 
@@ -173,13 +178,14 @@ describe('GamesPage', () => {
     expect(await screen.findByText('Server said no')).toBeInTheDocument();
   });
 
-  it('fans the same picks out to every NFL group when "Save to all" is checked', async () => {
-    // Three groups: two NFL (one explicit poolType, one legacy null) + one WC.
-    // Fan-out must call savePicks for both NFL identifiers and skip the WC one.
+  it('fans the same picks out to selected NFL groups via the dropdown', async () => {
+    // Three groups: source NFL + a legacy null-poolType NFL + a WC group. The
+    // dropdown only surfaces the two NFL groups; ticking the non-source one
+    // produces a 2-target fan-out.
     mockGetMyGroups.mockResolvedValue([
-      { id: 1, identifier: 'sunday-squad', poolType: 'nfl_weekly' },
-      { id: 2, identifier: 'office-pool', poolType: null }, // legacy pre-#86
-      { id: 3, identifier: 'wc-crew', poolType: 'world_cup_2026' },
+      { id: 1, identifier: 'sunday-squad', name: 'Sunday Squad', poolType: 'nfl_weekly' },
+      { id: 2, identifier: 'office-pool', name: 'Office Pool', poolType: null }, // legacy pre-#86
+      { id: 3, identifier: 'wc-crew', name: 'WC Crew', poolType: 'world_cup_2026' },
     ] as any);
     mockSavePicks.mockResolvedValue({ games: [] });
 
@@ -191,8 +197,9 @@ describe('GamesPage', () => {
     fireEvent.click(within(row10).getByRole('button', { name: /Confidence for BUF at NE/ }));
     fireEvent.click(within(row10).getByRole('option', { name: '1' }));
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Save to all my NFL groups' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to All' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Choose groups to save picks to' }));
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Office Pool' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to 2' }));
 
     await waitFor(() => expect(mockSavePicks).toHaveBeenCalledTimes(2));
     const calledIdentifiers = mockSavePicks.mock.calls.map((c) => c[0]).sort();

--- a/frontend/src/pages/GamesPage.tsx
+++ b/frontend/src/pages/GamesPage.tsx
@@ -9,6 +9,7 @@ import AuthService from '../lib/authService.js';
 import { getCurrentNFLSeason } from '../lib/nflSeasonUtils.js';
 import { savePicks } from '../lib/picksService.js';
 import { getMyGroups } from '../lib/groupsService.js';
+import SaveTargetsDropdown, { type SaveTarget } from '../components/SaveTargetsDropdown';
 
 // Ported from GamesPage.svelte + GamePickRow.svelte (commit d6b2566^). The page
 // owns the year/season-type/week selector, fetches the public games endpoint,
@@ -186,11 +187,40 @@ export default function GamesPage() {
 
   const canSubmit = !!groupId && completePicks.length > 0 && !submitting && !pageState.loading;
 
-  // Opt-in "save these picks to every NFL group I'm in" toggle. Restores the
-  // heritage Svelte 'save for all groups' UX (PR #37, Aug 2025) that the React
-  // rewrite dropped. NFL pools include groups with poolType 'nfl_weekly' AND
-  // legacy groups created before #86 where poolType is null.
-  const [applyToAll, setApplyToAll] = useState(false);
+  // Multi-select "save to which NFL groups?" — restores the heritage Svelte PR
+  // #37 dropdown. NFL pools include explicit poolType='nfl_weekly' AND legacy
+  // poolType=null groups predating the #86 plumbing fix.
+  const [myGroups, setMyGroups] = useState<SaveTarget[]>([]);
+  const [groupsLoading, setGroupsLoading] = useState(false);
+  const [selectedTargets, setSelectedTargets] = useState<Set<string>>(
+    () => new Set(groupId ? [groupId] : []),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!groupId) return;
+    setGroupsLoading(true);
+    getMyGroups()
+      .then((groups) => {
+        if (cancelled) return;
+        const nfl: SaveTarget[] = groups
+          .filter((g) => g.poolType !== 'world_cup_2026')
+          .map((g) => ({ identifier: g.identifier, name: g.name }));
+        if (!nfl.some((g) => g.identifier === groupId)) {
+          nfl.unshift({ identifier: groupId, name: groupId });
+        }
+        setMyGroups(nfl);
+      })
+      .catch(() => {
+        if (!cancelled) setMyGroups([{ identifier: groupId, name: groupId }]);
+      })
+      .finally(() => {
+        if (!cancelled) setGroupsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId]);
 
   async function submit() {
     if (!groupId) return;
@@ -219,20 +249,13 @@ export default function GamesPage() {
 
     setSubmitting(true);
     try {
-      if (!applyToAll) {
-        await savePicks(groupId, body);
+      const targets = Array.from(selectedTargets);
+      if (!targets.includes(groupId)) targets.push(groupId);
+      if (targets.length === 1) {
+        await savePicks(targets[0], body);
         setToast({ open: true, message: 'Picks saved', variant: 'success' });
         return;
       }
-
-      // Fan-out: every NFL group the user belongs to. Treat null poolType
-      // (legacy groups predating the WC migration) as NFL.
-      const groups = await getMyGroups();
-      const targets = groups
-        .filter((g) => g.poolType !== 'world_cup_2026')
-        .map((g) => g.identifier);
-      if (!targets.includes(groupId)) targets.push(groupId);
-
       const results = await Promise.allSettled(targets.map((id) => savePicks(id, body)));
       const ok = results.filter((r) => r.status === 'fulfilled').length;
       const fail = results.length - ok;
@@ -379,45 +402,58 @@ export default function GamesPage() {
         )}
       </div>
 
-      {/* Submit bar */}
+      {/* Spacer so the sticky bar never covers the last game row. */}
+      {pageState.games.length > 0 && <div className="h-20" aria-hidden="true" />}
+
+      {/* Sticky submit bar — pinned to the bottom of the viewport so submitting
+          doesn't require a long scroll on the games list. Renders even without
+          a groupId (button stays disabled) so the no-group hint copy stays
+          discoverable at the bottom. */}
       {pageState.games.length > 0 && (
-        <div className="mt-lg flex flex-col gap-sm border-t border-border pt-md sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-col gap-xxs text-sm text-secondary sm:flex-row sm:items-center sm:gap-md">
-            <span>
-              {completePicks.length} of {totalGames} pick{totalGames === 1 ? '' : 's'} complete
-              {hasIncomplete && (
-                <span className="ml-sm text-warning-600 dark:text-warning-400">
-                  Finish selecting a winner and confidence for highlighted games.
-                </span>
+        <div className="sticky bottom-0 -mx-lg mt-lg border-t border-border bg-neutral-0/95 px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
+          <div className="mx-auto flex max-w-4xl flex-col gap-sm sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-xxs text-sm text-secondary sm:flex-row sm:items-center sm:gap-md">
+              <span>
+                {completePicks.length} of {totalGames} pick{totalGames === 1 ? '' : 's'} complete
+                {hasIncomplete && (
+                  <span className="ml-sm text-warning-600 dark:text-warning-400">
+                    Finish selecting a winner and confidence for highlighted games.
+                  </span>
+                )}
+              </span>
+              {groupId && (
+                <SaveTargetsDropdown
+                  groups={myGroups}
+                  sourceIdentifier={groupId}
+                  selected={selectedTargets}
+                  onChange={setSelectedTargets}
+                  label="NFL"
+                  loading={groupsLoading}
+                  disabled={submitting}
+                />
               )}
-            </span>
-            <label className="flex items-center gap-xs">
-              <input
-                type="checkbox"
-                checked={applyToAll}
-                onChange={(e) => setApplyToAll(e.target.checked)}
-                aria-label="Save to all my NFL groups"
-                className="h-4 w-4"
+            </div>
+            <div className="relative inline-toast-anchor">
+              <InlineToast
+                open={toast.open}
+                message={toast.message}
+                variant={toast.variant}
+                onClose={() => setToast((t) => ({ ...t, open: false }))}
               />
-              Save to all my NFL groups
-            </label>
-          </div>
-          <div className="relative inline-toast-anchor">
-            <InlineToast
-              open={toast.open}
-              message={toast.message}
-              variant={toast.variant}
-              onClose={() => setToast((t) => ({ ...t, open: false }))}
-            />
-            <Button
-              variant="primary"
-              size="md"
-              loading={submitting}
-              disabled={!canSubmit}
-              onClick={submit}
-            >
-              {submitting ? 'Saving…' : applyToAll ? 'Submit to All' : 'Submit Picks'}
-            </Button>
+              <Button
+                variant="primary"
+                size="md"
+                loading={submitting}
+                disabled={!canSubmit}
+                onClick={submit}
+              >
+                {submitting
+                  ? 'Saving…'
+                  : selectedTargets.size > 1
+                    ? `Submit to ${selectedTargets.size}`
+                    : 'Submit Picks'}
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/WorldCupPicksPage.test.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.test.tsx
@@ -62,6 +62,11 @@ describe('WorldCupPicksPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetStageMatches.mockImplementation(stageResponder([groupMatch, r16Match]));
+    // Default: source group is the user's only WC group. Tests exercising the
+    // dropdown re-mock with multiple groups.
+    mockGetMyGroups.mockResolvedValue([
+      { id: 1, identifier: 'la-crew', name: 'LA Crew', poolType: 'world_cup_2026' },
+    ] as any);
   });
 
   it('shows the not-found UI when no group query param is present', () => {
@@ -155,14 +160,13 @@ describe('WorldCupPicksPage', () => {
     expect(await screen.findByText('Server said no')).toBeInTheDocument();
   });
 
-  it('fans the same picks out to every world_cup_2026 group when "Save to all" is checked', async () => {
-    // The user is in three groups: two WC + one NFL. The fan-out must hit
-    // both WC group identifiers (in addition to the source identifier when
-    // the source is itself a WC group) and skip the NFL one entirely.
+  it('fans the same picks out to every selected World Cup group via the dropdown', async () => {
+    // Three groups: two WC (source + another) + one NFL. The dropdown only
+    // surfaces the two WC groups; ticking the non-source one fans-out to both.
     mockGetMyGroups.mockResolvedValue([
-      { id: 1, identifier: 'la-crew', poolType: 'world_cup_2026' },
-      { id: 2, identifier: 'work-pool', poolType: 'world_cup_2026' },
-      { id: 3, identifier: 'family-nfl', poolType: 'nfl_weekly' },
+      { id: 1, identifier: 'la-crew', name: 'LA Crew', poolType: 'world_cup_2026' },
+      { id: 2, identifier: 'work-pool', name: 'Work Pool', poolType: 'world_cup_2026' },
+      { id: 3, identifier: 'family-nfl', name: 'Family NFL', poolType: 'nfl_weekly' },
     ] as any);
     mockSubmitPicks.mockResolvedValue({});
 
@@ -172,8 +176,13 @@ describe('WorldCupPicksPage', () => {
     fireEvent.click(
       within(screen.getByTestId('match-row-10')).getByRole('button', { name: 'Pick Mexico to win' }),
     );
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Save to all my World Cup groups' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to All' }));
+
+    // Open dropdown, tick the second WC group. The source 'la-crew' is
+    // disabled-and-checked by SaveTargetsDropdown so we don't touch it.
+    fireEvent.click(screen.getByRole('button', { name: 'Choose groups to save picks to' }));
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Work Pool' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to 2' }));
 
     await waitFor(() => expect(mockSubmitPicks).toHaveBeenCalledTimes(2));
     const calledIdentifiers = mockSubmitPicks.mock.calls.map((c) => c[0]).sort();
@@ -183,8 +192,8 @@ describe('WorldCupPicksPage', () => {
 
   it('reports partial failure when some fan-out submits reject', async () => {
     mockGetMyGroups.mockResolvedValue([
-      { id: 1, identifier: 'la-crew', poolType: 'world_cup_2026' },
-      { id: 2, identifier: 'work-pool', poolType: 'world_cup_2026' },
+      { id: 1, identifier: 'la-crew', name: 'LA Crew', poolType: 'world_cup_2026' },
+      { id: 2, identifier: 'work-pool', name: 'Work Pool', poolType: 'world_cup_2026' },
     ] as any);
     mockSubmitPicks.mockImplementation(async (groupId: string) => {
       if (groupId === 'work-pool') throw new Error('boom');
@@ -197,8 +206,9 @@ describe('WorldCupPicksPage', () => {
     fireEvent.click(
       within(screen.getByTestId('match-row-10')).getByRole('button', { name: 'Pick Mexico to win' }),
     );
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Save to all my World Cup groups' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to All' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Choose groups to save picks to' }));
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Work Pool' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to 2' }));
 
     expect(await screen.findByText('Saved to 1/2 groups (1 failed)')).toBeInTheDocument();
   });

--- a/frontend/src/pages/WorldCupPicksPage.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../lib/types';
 import { getStageMatches, submitWorldCupPicks } from '../lib/worldCupService.js';
 import { getMyGroups } from '../lib/groupsService.js';
+import SaveTargetsDropdown, { type SaveTarget } from '../components/SaveTargetsDropdown';
 
 // World Cup sibling of GamesPage. A world_cup_2026 pool renders the WHOLE
 // tournament as one stage-grouped match list — there is NO week selector. The
@@ -143,32 +144,55 @@ export default function WorldCupPicksPage() {
 
   const canSubmit = !!groupId && picks.length > 0 && !submitting;
 
-  // Opt-in "save these picks to every World Cup group I'm in" toggle. Mirrors
-  // the heritage Svelte 'save for all groups' UX (PR #37, Aug 2025) that the
-  // React rewrite dropped. Backend has no fan-out endpoint; we iterate the
-  // user's groups client-side and submit per group.
-  const [applyToAll, setApplyToAll] = useState(false);
+  // Multi-select "save to which World Cup groups?" — restores the heritage
+  // Svelte PR #37 dropdown UX. We eagerly load the user's groups on mount so
+  // the dropdown shows a real count without waiting for the first click.
+  const [myGroups, setMyGroups] = useState<SaveTarget[]>([]);
+  const [groupsLoading, setGroupsLoading] = useState(false);
+  const [selectedTargets, setSelectedTargets] = useState<Set<string>>(
+    () => new Set(groupId ? [groupId] : []),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!groupId) return;
+    setGroupsLoading(true);
+    getMyGroups()
+      .then((groups) => {
+        if (cancelled) return;
+        const wc: SaveTarget[] = groups
+          .filter((g) => g.poolType === 'world_cup_2026')
+          .map((g) => ({ identifier: g.identifier, name: g.name }));
+        // Ensure source group is in the list even if the backend didn't return
+        // it (offline-cached state, race with create-group, etc.).
+        if (!wc.some((g) => g.identifier === groupId)) {
+          wc.unshift({ identifier: groupId, name: groupId });
+        }
+        setMyGroups(wc);
+      })
+      .catch(() => {
+        // Fall back to a single-group dropdown — the source group always works.
+        if (!cancelled) setMyGroups([{ identifier: groupId, name: groupId }]);
+      })
+      .finally(() => {
+        if (!cancelled) setGroupsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId]);
 
   async function submit() {
     if (!groupId || picks.length === 0) return;
     setSubmitting(true);
     try {
-      if (!applyToAll) {
-        await submitWorldCupPicks(groupId, picks);
+      const targets = Array.from(selectedTargets);
+      if (!targets.includes(groupId)) targets.push(groupId);
+      if (targets.length === 1) {
+        await submitWorldCupPicks(targets[0], picks);
         setToast({ open: true, message: 'Picks saved', variant: 'success' });
         return;
       }
-
-      // Fan-out: every World Cup group the user belongs to. Always include the
-      // current `groupId` (the source group) — getMyGroups should list it, but
-      // if for some reason it doesn't, we still want a single-group save to
-      // succeed rather than silently no-op.
-      const groups = await getMyGroups();
-      const targets = groups
-        .filter((g) => g.poolType === 'world_cup_2026')
-        .map((g) => g.identifier);
-      if (!targets.includes(groupId)) targets.push(groupId);
-
       const results = await Promise.allSettled(
         targets.map((id) => submitWorldCupPicks(id, picks)),
       );
@@ -250,40 +274,52 @@ export default function WorldCupPicksPage() {
         )}
       </div>
 
-      {/* Submit bar */}
+      {/* Spacer so the sticky bar never covers the last match row. */}
+      {pageState.matches.length > 0 && <div className="h-20" aria-hidden="true" />}
+
+      {/* Sticky submit bar — pinned to the bottom of the viewport so the
+          user can submit from anywhere in the stage list without scrolling
+          to the page end. */}
       {pageState.matches.length > 0 && (
-        <div className="mt-lg flex flex-col gap-sm border-t border-border pt-md sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-col gap-xxs sm:flex-row sm:items-center sm:gap-md">
-            <span className="text-sm text-secondary">
-              {picks.length} pick{picks.length === 1 ? '' : 's'} selected
-            </span>
-            <label className="flex items-center gap-xs text-sm text-secondary">
-              <input
-                type="checkbox"
-                checked={applyToAll}
-                onChange={(e) => setApplyToAll(e.target.checked)}
-                aria-label="Save to all my World Cup groups"
-                className="h-4 w-4"
+        <div className="sticky bottom-0 -mx-lg mt-lg border-t border-border bg-neutral-0/95 px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
+          <div className="mx-auto flex max-w-4xl flex-col gap-sm sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-xxs sm:flex-row sm:items-center sm:gap-md">
+              <span className="text-sm text-secondary">
+                {picks.length} pick{picks.length === 1 ? '' : 's'} selected
+              </span>
+              {groupId && (
+                <SaveTargetsDropdown
+                  groups={myGroups}
+                  sourceIdentifier={groupId}
+                  selected={selectedTargets}
+                  onChange={setSelectedTargets}
+                  label="World Cup"
+                  loading={groupsLoading}
+                  disabled={submitting}
+                />
+              )}
+            </div>
+            <div className="relative inline-toast-anchor">
+              <InlineToast
+                open={toast.open}
+                message={toast.message}
+                variant={toast.variant}
+                onClose={() => setToast((t) => ({ ...t, open: false }))}
               />
-              Save to all my World Cup groups
-            </label>
-          </div>
-          <div className="relative inline-toast-anchor">
-            <InlineToast
-              open={toast.open}
-              message={toast.message}
-              variant={toast.variant}
-              onClose={() => setToast((t) => ({ ...t, open: false }))}
-            />
-            <Button
-              variant="primary"
-              size="md"
-              loading={submitting}
-              disabled={!canSubmit}
-              onClick={submit}
-            >
-              {submitting ? 'Saving…' : applyToAll ? 'Submit to All' : 'Submit Picks'}
-            </Button>
+              <Button
+                variant="primary"
+                size="md"
+                loading={submitting}
+                disabled={!canSubmit}
+                onClick={submit}
+              >
+                {submitting
+                  ? 'Saving…'
+                  : selectedTargets.size > 1
+                    ? `Submit to ${selectedTargets.size}`
+                    : 'Submit Picks'}
+              </Button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Two changes called out live:

1. **Multi-select group dropdown.** Heritage Svelte (PR #37) had a dropdown with per-group checkboxes; #89 collapsed it to a single `Save to all` toggle. This restores the dropdown shape as a reusable `SaveTargetsDropdown` component, used by both NFL (`GamesPage`) and WC (`WorldCupPicksPage`). Source group is always selected and disabled. `Select all` / `Only this group` bulk actions appear when there are 2+ groups.

2. **Sticky submit bar.** Submit bar was at the doc bottom — full week/tournament scroll required to submit. Both pages now wrap the bar in `sticky bottom-0` with backdrop blur + a top-side spacer.

groupsService.getMyGroups loads eagerly on mount so the dropdown count is right from first render; a fallback uses just the source group on request failure. `GroupData.poolType` is now an exported field on the design-system type so the inline filter typechecks.

Tests updated; full suite 453/453 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)