### PR TITLE
fix(picks): hydrate draft from saved picks on refresh (NFL + WC)

### DIFF
--- a/backend/src/routes/picks.js
+++ b/backend/src/routes/picks.js
@@ -45,6 +45,57 @@ function deriveGamePickMeta(gameJson, pick) {
   };
 }
 
+/**
+ * Read the authenticated user's own picks for a week, in the same shape POST
+ * /:identifier/picks accepts. GamesPage hydrates its draft from this on
+ * mount + on every selector change so a refresh doesn't blank out picks the
+ * user already submitted. Scoped to the auth'd user only — no fan-out, no
+ * other members.
+ */
+router.get('/:identifier/picks/me', authenticateToken, async (req, res) => {
+  try {
+    const { identifier } = req.params;
+    const season = parseInt(req.query.season);
+    const seasonType = parseInt(req.query.seasonType);
+    const weekRaw = req.query.week;
+    const week = weekRaw === '0' ? 0 : parseInt(weekRaw);
+    if (Number.isNaN(season) || Number.isNaN(seasonType) || Number.isNaN(week)) {
+      return res.status(400).json({ error: 'season, seasonType and week are required' });
+    }
+    const group = await ensureMembership(identifier, req.user.id);
+    // Mirror the existing /picks GET's preseason→week0 mapping so the row the
+    // upsert wrote (under the mapped slot) is the row we read back.
+    let fetchSeasonType = seasonType;
+    let fetchWeek = week;
+    if (seasonType === 2 && week === 0 && season !== 2025) {
+      fetchSeasonType = 1;
+      fetchWeek = 4;
+    }
+    const picks = await UserPick.findForUserWeek({
+      userId: req.user.id,
+      groupId: group.id,
+      season,
+      seasonType: fetchSeasonType,
+      week: fetchWeek,
+    });
+    res.json({
+      picks: picks
+        .filter((p) => p.pickedTeamId != null || p.confidence != null)
+        .map((p) => ({
+          gameId: p.gameId,
+          pickedTeamId: p.pickedTeamId,
+          confidence: p.confidence,
+        })),
+    });
+  } catch (e) {
+    if (e.message === 'NOT_MEMBER' || e.message === 'GROUP_NOT_FOUND') {
+      return res.status(404).json({ error: 'Group not found' });
+    }
+    console.error('GET /:identifier/picks/me error', e);
+    res.status(500).json({ error: 'Failed to load picks' });
+  }
+});
+
 router.get('/:identifier/picks', authenticateToken, async (req, res) => {
   try {
     const { identifier } = req.params;

--- a/backend/src/routes/worldCupPicks.js
+++ b/backend/src/routes/worldCupPicks.js
@@ -114,6 +114,41 @@ router.post('/group/:groupId/world-cup', authenticateToken, async (req, res) => 
 });
 
 /**
+ * Read the authenticated user's own World Cup picks for a group.
+ *
+ * Returns the same shape POST accepts and writes: `{ picks: [{ gameId,
+ * pickedResult }] }`, scoped to WC games (league='world_cup') so an NFL pick
+ * row from a shared user can never leak in. Picks page hydrates the draft
+ * state from this so a refresh doesn't blank out a previously-saved choice.
+ */
+router.get('/group/:groupId/world-cup/me', authenticateToken, async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const group = await ensureMembership(groupId, req.user.id);
+
+    const { rows } = await pool.query(
+      `SELECT up.game_id, up.picked_result
+       FROM user_picks up
+       JOIN games g ON g.id = up.game_id
+       WHERE up.user_id = $1
+         AND up.group_id = $2
+         AND g.league = 'world_cup'
+         AND up.picked_result IS NOT NULL`,
+      [req.user.id, group.id]
+    );
+
+    res.json({
+      picks: rows.map((r) => ({ gameId: r.game_id, pickedResult: r.picked_result })),
+    });
+  } catch (e) {
+    if (e.message === 'GROUP_NOT_FOUND') return res.status(404).json({ error: 'Group not found' });
+    if (e.message === 'NOT_MEMBER') return res.status(403).json({ error: 'Not a group member' });
+    console.error('GET world-cup picks error', e);
+    res.status(500).json({ error: 'Failed to load World Cup picks' });
+  }
+});
+
+/**
  * World Cup tournament leaderboard for a group.
  *
  * Loads every member's World Cup picks, joins them to the stage-resolved games

--- a/frontend/src/lib/picksService.d.ts
+++ b/frontend/src/lib/picksService.d.ts
@@ -55,6 +55,21 @@ export function getPicks(
   query: { season: number; seasonType: number; week: number },
 ): Promise<GetPicksResponse>;
 
+/** Response shape of GET /:identifier/picks/me. */
+export interface MyPicksResponse {
+  picks: Array<{ gameId: number; pickedTeamId: number | null; confidence: number | null }>;
+}
+
+/**
+ * Fetch the authenticated user's own picks for a week, in the same shape POST
+ * /:identifier/picks accepts. Used by GamesPage to hydrate the draft on mount
+ * + every selector change so a refresh doesn't blank out picks.
+ */
+export function getMyPicks(
+  groupIdentifier: string,
+  query: { season: number; seasonType: number; week: number },
+): Promise<MyPicksResponse>;
+
 /** One pick in a save payload: which team, with what confidence, for a game. */
 export interface PickInput {
   gameId: number;

--- a/frontend/src/lib/picksService.js
+++ b/frontend/src/lib/picksService.js
@@ -42,6 +42,22 @@ export async function getPicks(groupIdentifier, { season, seasonType, week }) {
   return res.json();
 }
 
+/**
+ * Read the authenticated user's own picks for a week. Returns
+ * `{ picks: [{ gameId, pickedTeamId, confidence }] }` — same shape POST
+ * /:identifier/picks expects. GamesPage hydrates its draft state with this
+ * so a refresh doesn't blank out previously-saved picks.
+ */
+export async function getMyPicks(groupIdentifier, { season, seasonType, week }) {
+  const params = new URLSearchParams({ season, seasonType, week });
+  const res = await authFetch(`${apiBase()}/${groupIdentifier}/picks/me?${params}`);
+  if (!res.ok) {
+    const data = await res.json().catch(()=>({}));
+    throw new Error(data.error || 'Failed to load my picks');
+  }
+  return res.json();
+}
+
 export async function savePicks(groupIdentifier, body) {
   const res = await authFetch(`${apiBase()}/${groupIdentifier}/picks`, { method: 'POST', body: JSON.stringify(body) });
   if (!res.ok) {

--- a/frontend/src/lib/worldCupService.d.ts
+++ b/frontend/src/lib/worldCupService.d.ts
@@ -39,4 +39,16 @@ export function submitWorldCupPicks(
 /** Fetch the tournament-shaped leaderboard (with tiebreaker columns) for a group. */
 export function getWorldCupLeaderboard(groupId: string): Promise<LeaderboardResponse>;
 
+/** Response shape of GET /api/picks/group/:groupId/world-cup/me. */
+export interface MyWorldCupPicksResponse {
+  picks: MatchPick[];
+}
+
+/**
+ * Fetch the authenticated user's own World Cup picks for a group, in the
+ * same shape POST submitWorldCupPicks accepts. Used by WorldCupPicksPage to
+ * hydrate the draft state on mount so a refresh doesn't blank out picks.
+ */
+export function getMyWorldCupPicks(groupId: string): Promise<MyWorldCupPicksResponse>;
+
 export type { MatchPickResult };

--- a/frontend/src/lib/worldCupService.js
+++ b/frontend/src/lib/worldCupService.js
@@ -40,6 +40,21 @@ export async function submitWorldCupPicks(groupId, picks) {
   return res.json();
 }
 
+/**
+ * Read the authenticated user's own World Cup picks for a group.
+ * Returns { picks: [{ gameId, pickedResult }] } — same shape as the POST
+ * response. The picker page hydrates its draft state with this so a refresh
+ * doesn't blank out previously-saved choices.
+ */
+export async function getMyWorldCupPicks(groupId) {
+  const res = await authFetch(`${apiBase()}/api/picks/group/${groupId}/world-cup/me`);
+  if (!res.ok) {
+    const data = await res.json().catch(()=>({}));
+    throw new Error(data.error || 'Failed to load World Cup picks');
+  }
+  return res.json();
+}
+
 export async function getWorldCupLeaderboard(groupId) {
   const res = await authFetch(`${apiBase()}/api/picks/group/${groupId}/world-cup/leaderboard`);
   if (!res.ok) {

--- a/frontend/src/pages/GamesPage.test.tsx
+++ b/frontend/src/pages/GamesPage.test.tsx
@@ -8,12 +8,13 @@ vi.mock('../lib/nflSeasonUtils.js', () => ({ getCurrentNFLSeason: vi.fn(() => 20
 vi.mock('../lib/authService.js', () => ({
   default: { getApiBaseUrl: () => 'http://test' },
 }));
-vi.mock('../lib/picksService.js', () => ({ savePicks: vi.fn() }));
+vi.mock('../lib/picksService.js', () => ({ savePicks: vi.fn(), getMyPicks: vi.fn() }));
 vi.mock('../lib/groupsService.js', () => ({ getMyGroups: vi.fn() }));
 
-import { savePicks } from '../lib/picksService.js';
+import { savePicks, getMyPicks } from '../lib/picksService.js';
 import { getMyGroups } from '../lib/groupsService.js';
 const mockSavePicks = vi.mocked(savePicks);
+const mockGetMyPicks = vi.mocked(getMyPicks);
 const mockGetMyGroups = vi.mocked(getMyGroups);
 
 const buf = { id: '1', name: 'Bills', abbreviation: 'BUF', logo: '' };
@@ -57,6 +58,8 @@ describe('GamesPage', () => {
     mockGetMyGroups.mockResolvedValue([
       { id: 1, identifier: 'sunday-squad', name: 'Sunday Squad', poolType: 'nfl_weekly' },
     ] as any);
+    // Default: no previously-saved picks. The hydration test below re-mocks.
+    mockGetMyPicks.mockResolvedValue({ picks: [] });
   });
   afterEach(() => vi.unstubAllGlobals());
 
@@ -205,5 +208,34 @@ describe('GamesPage', () => {
     const calledIdentifiers = mockSavePicks.mock.calls.map((c) => c[0]).sort();
     expect(calledIdentifiers).toEqual(['office-pool', 'sunday-squad']);
     expect(await screen.findByText('Picks saved to 2 groups')).toBeInTheDocument();
+  });
+
+  it('hydrates the draft from previously-saved picks on mount', async () => {
+    // Regression: GamesPage used to setDraft({}) on every fetch, so a refresh
+    // blanked out picks the user had successfully saved. Now we re-fetch the
+    // user's row and seed the draft from it.
+    mockGetMyPicks.mockResolvedValue({
+      picks: [{ gameId: 10, pickedTeamId: 1, confidence: 2 }],
+    });
+    mockSavePicks.mockResolvedValue({ games: [] });
+
+    renderPage();
+    await screen.findByText('Bills');
+
+    // Submit should already be enabled — the pick was hydrated.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Submit Picks' })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Picks' }));
+    await waitFor(() =>
+      expect(mockSavePicks).toHaveBeenCalledWith('sunday-squad', {
+        season: 2025,
+        seasonType: 2,
+        week: 1,
+        picks: [{ gameId: 10, pickedTeamId: 1, confidence: 2 }],
+        clearedGameIds: [],
+      }),
+    );
   });
 });

--- a/frontend/src/pages/GamesPage.tsx
+++ b/frontend/src/pages/GamesPage.tsx
@@ -7,7 +7,7 @@ import type { ToastVariant } from '../designsystem/components/InlineToast/Inline
 import GamePickRow, { type DraftPick, type PickGame } from '../components/GamePickRow';
 import AuthService from '../lib/authService.js';
 import { getCurrentNFLSeason } from '../lib/nflSeasonUtils.js';
-import { savePicks } from '../lib/picksService.js';
+import { savePicks, getMyPicks } from '../lib/picksService.js';
 import { getMyGroups } from '../lib/groupsService.js';
 import SaveTargetsDropdown, { type SaveTarget } from '../components/SaveTargetsDropdown';
 
@@ -81,9 +81,6 @@ export default function GamesPage() {
         const data = await res.json();
         const games: PickGame[] = Array.isArray(data?.games) ? data.games : [];
         setPageState({ loading: false, error: '', games });
-        // A fresh week starts with an empty draft — the public endpoint carries
-        // no per-user pick to prefill.
-        setDraft({});
       } catch (err) {
         setPageState((s) => ({
           ...s,
@@ -99,6 +96,40 @@ export default function GamesPage() {
   useEffect(() => {
     fetchGames();
   }, [fetchGames]);
+
+  // Hydrate the draft from the user's already-saved picks for the current
+  // (group × season × seasonType × week). Without this a refresh blanks out
+  // picks that successfully persisted to the DB. Runs independently of
+  // fetchGames so a transient picks-endpoint failure can't block the games
+  // list — the draft just stays empty in that case.
+  useEffect(() => {
+    if (!groupId) {
+      setDraft({});
+      return;
+    }
+    let cancelled = false;
+    setDraft({});
+    getMyPicks(groupId, { season: year, seasonType, week })
+      .then((resp) => {
+        if (cancelled) return;
+        const next: DraftMap = {};
+        for (const p of resp.picks ?? []) {
+          if (p && p.gameId != null) {
+            next[p.gameId] = {
+              pickedTeamId: p.pickedTeamId,
+              confidence: p.confidence,
+            };
+          }
+        }
+        setDraft(next);
+      })
+      .catch(() => {
+        // Best-effort — leave draft empty on failure.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId, year, seasonType, week]);
 
   // N for the confidence range is the number of games in the loaded week.
   const totalGames = pageState.games.length;

--- a/frontend/src/pages/WorldCupPicksPage.test.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.test.tsx
@@ -7,15 +7,21 @@ import type { WorldCupMatch, WorldCupStage } from '../lib/types';
 vi.mock('../lib/worldCupService.js', () => ({
   getStageMatches: vi.fn(),
   submitWorldCupPicks: vi.fn(),
+  getMyWorldCupPicks: vi.fn(),
 }));
 vi.mock('../lib/groupsService.js', () => ({
   getMyGroups: vi.fn(),
 }));
 
-import { getStageMatches, submitWorldCupPicks } from '../lib/worldCupService.js';
+import {
+  getStageMatches,
+  submitWorldCupPicks,
+  getMyWorldCupPicks,
+} from '../lib/worldCupService.js';
 import { getMyGroups } from '../lib/groupsService.js';
 const mockGetStageMatches = vi.mocked(getStageMatches);
 const mockSubmitPicks = vi.mocked(submitWorldCupPicks);
+const mockGetMyWorldCupPicks = vi.mocked(getMyWorldCupPicks);
 const mockGetMyGroups = vi.mocked(getMyGroups);
 
 const mex = { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: '' };
@@ -67,6 +73,8 @@ describe('WorldCupPicksPage', () => {
     mockGetMyGroups.mockResolvedValue([
       { id: 1, identifier: 'la-crew', name: 'LA Crew', poolType: 'world_cup_2026' },
     ] as any);
+    // Default: no previously-saved picks. The hydration test below re-mocks.
+    mockGetMyWorldCupPicks.mockResolvedValue({ picks: [] });
   });
 
   it('shows the not-found UI when no group query param is present', () => {
@@ -211,6 +219,34 @@ describe('WorldCupPicksPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Submit to 2' }));
 
     expect(await screen.findByText('Saved to 1/2 groups (1 failed)')).toBeInTheDocument();
+  });
+
+  it('hydrates the draft from previously-saved picks on mount', async () => {
+    // The user already submitted Mexico-home for game 10. After a refresh the
+    // page must reflect that — the source of the bug was the draft initializing
+    // to {} regardless of what the DB held for this user.
+    mockGetMyWorldCupPicks.mockResolvedValue({
+      picks: [{ gameId: 10, pickedResult: 'home' }],
+    });
+    mockSubmitPicks.mockResolvedValue({});
+
+    renderPage();
+    await screen.findByTestId('match-row-10');
+
+    // The submit button should be enabled because the draft now has 1 pick,
+    // and the pick count line reflects it.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Submit Picks' })).toBeEnabled(),
+    );
+    expect(screen.getByText('1 pick selected')).toBeInTheDocument();
+
+    // Submitting without touching anything sends the hydrated pick verbatim.
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Picks' }));
+    await waitFor(() =>
+      expect(mockSubmitPicks).toHaveBeenCalledWith('la-crew', [
+        { gameId: 10, pickedResult: 'home' },
+      ]),
+    );
   });
 
   it('toggles a pick off when the selected result is clicked again', async () => {

--- a/frontend/src/pages/WorldCupPicksPage.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.tsx
@@ -11,7 +11,11 @@ import {
   type WorldCupMatch,
   type WorldCupStage,
 } from '../lib/types';
-import { getStageMatches, submitWorldCupPicks } from '../lib/worldCupService.js';
+import {
+  getStageMatches,
+  submitWorldCupPicks,
+  getMyWorldCupPicks,
+} from '../lib/worldCupService.js';
 import { getMyGroups } from '../lib/groupsService.js';
 import SaveTargetsDropdown, { type SaveTarget } from '../components/SaveTargetsDropdown';
 
@@ -95,9 +99,6 @@ export default function WorldCupPicksPage() {
       const responses = await Promise.all(WORLD_CUP_STAGES.map((stage) => getStageMatches(stage)));
       const matches = responses.flatMap((r) => (Array.isArray(r?.games) ? r.games : []));
       setPageState({ loading: false, error: '', matches });
-      // A fresh load starts with an empty draft — the public stage endpoint
-      // carries no per-user pick to prefill.
-      setDraft({});
     } catch (err) {
       setPageState((s) => ({
         ...s,
@@ -111,6 +112,34 @@ export default function WorldCupPicksPage() {
     if (!identifier) return;
     fetchMatches();
   }, [identifier, fetchMatches]);
+
+  // Hydrate the draft from the user's already-saved picks on this group so
+  // a refresh doesn't blank them out. Runs independently of the stage fetch
+  // so a transient picks-endpoint failure can't block the matches from
+  // rendering — the draft just stays empty in that case.
+  useEffect(() => {
+    if (!groupId) {
+      setDraft({});
+      return;
+    }
+    let cancelled = false;
+    getMyWorldCupPicks(groupId)
+      .then((resp) => {
+        if (cancelled) return;
+        const next: DraftMap = {};
+        for (const p of resp.picks ?? []) {
+          if (p && p.gameId != null && p.pickedResult) next[p.gameId] = p.pickedResult;
+        }
+        setDraft(next);
+      })
+      .catch(() => {
+        // Best-effort — don't surface a toast for the silent hydrate; the user
+        // can still re-pick and submit. Leaving draft as whatever it currently is.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupId]);
 
   function pickResult(matchId: number, result: MatchPickResult) {
     setDraft((prev) => {


### PR DESCRIPTION
Reproed live: user saved two WC picks, refreshed, picks were gone visually — but both rows were safely in user_picks. The bug was on the read side, not the write: GamesPage and WorldCupPicksPage both initialised draft to {} on mount and never re-fetched.

Adds:
- Backend GET /api/picks/group/:groupId/world-cup/me + /api/picks/:identifier/picks/me, both scoped to the auth'd user and shaped like the POST body for symmetry.
- Frontend services: getMyWorldCupPicks, getMyPicks.
- Page hydrate useEffects on the right deps (groupId for WC; groupId/year/seasonType/week for NFL). Best-effort: a 5xx on the hydrate leaves draft empty rather than blocking the games render.

Tests: 2 new regression cases pinning the bug (one per page). 24/24 in touched suites. Full vitest + tsc green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)