### PR TITLE
fix(layout): relax page-level horizontal padding on mobile

### DIFF
--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,6 +1,6 @@
 export default function AboutPage() {
   return (
-    <div className='p-lg'>
+    <div className='px-sm py-lg sm:p-lg'>
       <h1 className='text-2xl font-bold'>About</h1>
       <section className='mt-md space-y-md text-base text-gray-600'>
         <p>

--- a/frontend/src/pages/CreateGroupPage.tsx
+++ b/frontend/src/pages/CreateGroupPage.tsx
@@ -24,7 +24,7 @@ export default function CreateGroupPage() {
 
   return (
     <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-      <div className="max-w-2xl mx-auto px-lg py-lg space-y-lg">
+      <div className="max-w-2xl mx-auto px-sm py-lg sm:px-lg space-y-lg">
         <header className="space-y-sm">
           <h1 className="text-3xl font-heading font-bold text-[var(--color-text-primary)]">
             Create Group

--- a/frontend/src/pages/EditGroupPage.tsx
+++ b/frontend/src/pages/EditGroupPage.tsx
@@ -65,7 +65,7 @@ export default function EditGroupPage() {
 
   return (
     <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-      <div className="max-w-2xl mx-auto px-lg py-lg space-y-lg">
+      <div className="max-w-2xl mx-auto px-sm py-lg sm:px-lg space-y-lg">
         <header className="space-y-sm">
           <h1 className="text-3xl font-heading font-bold text-[var(--color-text-primary)]">
             Edit Group

--- a/frontend/src/pages/GamesPage.tsx
+++ b/frontend/src/pages/GamesPage.tsx
@@ -321,7 +321,7 @@ export default function GamesPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl p-lg">
+    <div className="mx-auto max-w-4xl px-sm py-lg sm:p-lg">
       <h1 className="text-2xl font-bold text-secondary-900 dark:text-neutral-0">NFL Games</h1>
 
       {/* Selector controls */}
@@ -441,7 +441,7 @@ export default function GamesPage() {
           a groupId (button stays disabled) so the no-group hint copy stays
           discoverable at the bottom. */}
       {pageState.games.length > 0 && (
-        <div className="sticky bottom-0 -mx-lg mt-lg border-t border-border bg-neutral-0/95 px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
+        <div className="sticky bottom-0 -mx-sm sm:-mx-lg mt-lg border-t border-border bg-neutral-0/95 px-sm sm:px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
           <div className="mx-auto flex max-w-4xl flex-col gap-sm sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-col gap-xxs text-sm text-secondary sm:flex-row sm:items-center sm:gap-md">
               <span>

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -40,7 +40,7 @@ const TABS: { key: TabKey; label: string }[] = [
 function GroupNotFound({ message, onBack }: { message: string; onBack: () => void }) {
   return (
     <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-      <div className="max-w-4xl mx-auto px-lg py-lg">
+      <div className="max-w-4xl mx-auto px-sm py-lg sm:px-lg">
         <div className="text-center space-y-md">
           <h1 className="text-3xl font-heading font-bold text-[var(--color-text-primary)]">
             Group Not Found
@@ -118,7 +118,7 @@ export default function GroupDetailsPage() {
     // Spinner markup mirrors GroupsPage's loading state.
     return (
       <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-        <div className="max-w-6xl mx-auto px-lg py-lg">
+        <div className="max-w-6xl mx-auto px-sm py-lg sm:px-lg">
           <div className="flex justify-center items-center py-12">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600" />
             <span className="ml-3 text-[var(--color-text-secondary)]">Loading group...</span>
@@ -145,7 +145,7 @@ export default function GroupDetailsPage() {
 
   return (
     <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-      <div className="max-w-6xl mx-auto px-lg py-lg space-y-lg">
+      <div className="max-w-6xl mx-auto px-sm py-lg sm:px-lg space-y-lg">
         {/* Header */}
         <div className="space-y-md">
           <button

--- a/frontend/src/pages/GroupsPage.tsx
+++ b/frontend/src/pages/GroupsPage.tsx
@@ -69,7 +69,7 @@ export default function GroupsPage() {
 
   return (
     <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-      <div className="max-w-6xl mx-auto px-lg py-lg space-y-lg">
+      <div className="max-w-6xl mx-auto px-sm py-lg sm:px-lg space-y-lg">
         <header className="space-y-sm">
           <h1 className="text-3xl font-heading font-bold text-[var(--color-text-primary)]">
             My Groups

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -50,7 +50,7 @@ export default function HomePage() {
   const { isAuthenticated } = useAuth();
 
   return (
-    <div className="max-w-4xl mx-auto px-lg py-lg">
+    <div className="max-w-4xl mx-auto px-sm py-lg sm:px-lg">
       <div className="text-center space-y-lg">
         <header className="space-y-md">
           <h1 className="text-4xl font-heading font-bold text-[var(--color-text-primary)]">

--- a/frontend/src/pages/JoinGroupPage.tsx
+++ b/frontend/src/pages/JoinGroupPage.tsx
@@ -55,7 +55,7 @@ export default function JoinGroupPage() {
 
   return (
     <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-      <div className="max-w-2xl mx-auto px-lg py-lg space-y-lg">
+      <div className="max-w-2xl mx-auto px-sm py-lg sm:px-lg space-y-lg">
         <header className="space-y-sm">
           <h1 className="text-3xl font-heading font-bold text-[var(--color-text-primary)]">
             Join Group

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -56,7 +56,7 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
-      <div className="mx-auto w-full max-w-md px-lg py-lg">
+      <div className="mx-auto w-full max-w-md px-sm py-lg sm:px-lg">
         <div className="space-y-lg text-center">
           {/* Logo */}
           <div className="space-y-md">

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -5,7 +5,7 @@ export default function NotFoundPage() {
   const navigate = useNavigate();
 
   return (
-    <div className='p-lg'>
+    <div className='px-sm py-lg sm:p-lg'>
       <h1 className='text-2xl font-bold'>Page not found</h1>
       <section className='mt-md space-y-md text-base text-gray-600'>
         <p>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -32,7 +32,7 @@ export default function ProfilePage() {
 
   if (!user) {
     return (
-      <div className="max-w-3xl mx-auto px-lg py-xl text-center text-[var(--color-text-secondary)]">
+      <div className="max-w-3xl mx-auto px-sm py-xl sm:px-lg text-center text-[var(--color-text-secondary)]">
         No user data.
       </div>
     );
@@ -75,7 +75,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-lg py-lg space-y-xl">
+    <div className="max-w-4xl mx-auto px-sm py-lg sm:px-lg space-y-xl">
       <header className="flex flex-col sm:flex-row items-center sm:items-end gap-md">
         <Avatar
           name={user.name}

--- a/frontend/src/pages/WorldCupPicksPage.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.tsx
@@ -61,7 +61,7 @@ interface ToastState {
 function GroupNotFound({ message, onBack }: { message: string; onBack: () => void }) {
   return (
     <div className="min-h-screen bg-neutral-0 dark:bg-secondary-900">
-      <div className="max-w-4xl mx-auto px-lg py-lg">
+      <div className="max-w-4xl mx-auto px-sm py-lg sm:px-lg">
         <div className="text-center space-y-md">
           <h1 className="text-3xl font-heading font-bold text-[var(--color-text-primary)]">
             Group Not Found
@@ -265,7 +265,7 @@ export default function WorldCupPicksPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl p-lg">
+    <div className="mx-auto max-w-4xl px-sm py-lg sm:p-lg">
       <h1 className="text-2xl font-bold text-secondary-900 dark:text-neutral-0">
         World Cup 2026 Picks
       </h1>
@@ -310,7 +310,7 @@ export default function WorldCupPicksPage() {
           user can submit from anywhere in the stage list without scrolling
           to the page end. */}
       {pageState.matches.length > 0 && (
-        <div className="sticky bottom-0 -mx-lg mt-lg border-t border-border bg-neutral-0/95 px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
+        <div className="sticky bottom-0 -mx-sm sm:-mx-lg mt-lg border-t border-border bg-neutral-0/95 px-sm sm:px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
           <div className="mx-auto flex max-w-4xl flex-col gap-sm sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-col gap-xxs sm:flex-row sm:items-center sm:gap-md">
               <span className="text-sm text-secondary">


### PR DESCRIPTION
Two horizontal paddings stack on every page on mobile (Layout's `px-md` + each page's `px-lg`) → ~40px gutter on a 390px viewport, which is what made buttons look cramped in the live shots.

Make page-level `px-lg` responsive: `px-sm` (12px) mobile, `px-lg` (24px) from `sm:` up. Desktop unchanged. Mobile total gutter: 16+24 → 16+12 = 28px.

Touched 16 page shells + both sticky submit bars (their `-mx-lg` must mirror the parent's padding or the bar over-corrects mobile).

Vertical paddings unchanged. Tests: 455/455 vitest, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)