### PR TITLE
fix(layout): drop Layout px-md on mobile (total gutter 28px → 12px)

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -8,7 +8,11 @@ export default function Layout() {
   return (
     <div className="min-h-screen">
       <Navigation />
-      <main className="mx-auto w-full max-w-6xl px-md py-lg">
+      {/* Mobile: no Layout-level horizontal padding so pages can use the full
+          viewport width. Page shells already contribute a 12px (px-sm) gutter
+          which is enough breathing room on a phone. Desktop (sm: and up)
+          stacks the original 16px back on so margins still match design. */}
+      <main className="mx-auto w-full max-w-6xl px-0 sm:px-md py-lg">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
Follow-up to #92. Mobile gutter goes 28px → 12px by dropping Layout's mobile horizontal padding. Page shells already contribute 12px which is the requested width. Desktop unchanged (px-md kicks in at sm:).

🤖 Generated with [Claude Code](https://claude.com/claude-code)