### PR TITLE
fix(auth): silently refresh expired access tokens on app load

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -11,6 +11,9 @@ import { AuthProvider } from './contexts/AuthContext';
 vi.mock('./lib/authService.js', () => ({
   default: {
     getUser: vi.fn(),
+    // Returns undefined → AuthProvider skips the silent-refresh path, keeping
+    // these routing tests synchronous.
+    getRefreshToken: vi.fn(),
     setTokens: vi.fn(),
     getCurrentUser: vi.fn(),
   },

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -6,6 +6,7 @@ vi.mock('../contexts/AuthContext', () => {
   const mockUseAuth = vi.fn<() => AuthContextValue>(() => ({
     isAuthenticated: false,
     user: null,
+    isRestoring: false,
     setAuthUser: vi.fn(),
     clearAuth: vi.fn(),
   }));

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -2,6 +2,10 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function ProtectedRoute() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isRestoring } = useAuth();
+  // While the silent token refresh runs on app load, render nothing rather
+  // than redirecting — otherwise a returning user with a valid refresh token
+  // gets bounced to /login before the session is restored.
+  if (isRestoring) return null;
   return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
 }

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AuthProvider, useAuth } from './AuthContext';
 import type { User } from './AuthContext';
@@ -7,11 +7,19 @@ import type { User } from './AuthContext';
 vi.mock('../lib/authService.js', () => ({
   default: {
     getUser: vi.fn(),
+    getRefreshToken: vi.fn(),
+    refreshToken: vi.fn(),
+    getCurrentUser: vi.fn(),
+    clearTokens: vi.fn(),
   },
 }));
 
 import AuthService from '../lib/authService.js';
 const mockGetUser = vi.mocked(AuthService.getUser);
+const mockGetRefreshToken = vi.mocked(AuthService.getRefreshToken);
+const mockRefreshToken = vi.mocked(AuthService.refreshToken);
+const mockGetCurrentUser = vi.mocked(AuthService.getCurrentUser);
+const mockClearTokens = vi.mocked(AuthService.clearTokens);
 
 const testUser: User = {
   id: 1,
@@ -99,6 +107,83 @@ describe('AuthContext', () => {
 
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.user?.pictureUrl).toBeNull();
+  });
+
+  // Silent session restore on mount (expired access token + valid refresh token)
+
+  it('silently refreshes and restores the session when the access token is expired but a refresh token exists', async () => {
+    // First getUser() call (state init) sees an expired access token; after a
+    // successful refresh the second call returns the user again.
+    mockGetUser.mockReturnValueOnce(null).mockReturnValue(testUser as any);
+    mockGetRefreshToken.mockReturnValue('valid-refresh-token');
+    mockRefreshToken.mockResolvedValue('new-access-token');
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    // Refresh is in flight: not yet authenticated, but flagged as restoring
+    // so route guards don't redirect to /login.
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isRestoring).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+    expect(result.current.user).toEqual(testUser);
+    expect(result.current.isRestoring).toBe(false);
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    expect(mockClearTokens).not.toHaveBeenCalled();
+  });
+
+  it('falls back to getCurrentUser() when getUser() is still null after refresh', async () => {
+    mockGetUser.mockReturnValue(null);
+    mockGetRefreshToken.mockReturnValue('valid-refresh-token');
+    mockRefreshToken.mockResolvedValue('new-access-token');
+    mockGetCurrentUser.mockResolvedValue(testUser as any);
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+    expect(result.current.user).toEqual(testUser);
+    expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears tokens and stays unauthenticated when the silent refresh fails', async () => {
+    mockGetUser.mockReturnValue(null);
+    mockGetRefreshToken.mockReturnValue('revoked-refresh-token');
+    mockRefreshToken.mockRejectedValue(new Error('Failed to refresh token'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    await waitFor(() => {
+      expect(result.current.isRestoring).toBe(false);
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(mockClearTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt a refresh when there is no refresh token', () => {
+    mockGetUser.mockReturnValue(null);
+    mockGetRefreshToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    expect(result.current.isRestoring).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt a refresh when the access token is still valid', () => {
+    mockGetUser.mockReturnValue(testUser as any);
+    mockGetRefreshToken.mockReturnValue('valid-refresh-token');
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    expect(result.current.isRestoring).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(mockRefreshToken).not.toHaveBeenCalled();
   });
 
   it('setAuthUser followed by clearAuth returns to unauthenticated state', () => {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import AuthService from '../lib/authService.js';
 
 export interface User {
@@ -12,6 +12,10 @@ export interface User {
 export interface AuthContextValue {
   isAuthenticated: boolean;
   user: User | null;
+  /** True while a silent token refresh is in flight on app load. Consumers
+      that would redirect unauthenticated users (e.g. ProtectedRoute) should
+      wait for this to settle instead of bouncing to /login. */
+  isRestoring: boolean;
   setAuthUser: (user: User) => void;
   clearAuth: () => void;
 }
@@ -24,6 +28,49 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return { isAuthenticated: !!user, user };
   });
 
+  // getUser() returns null once the short-lived access token expires, even
+  // though the long-lived refresh token may still be valid. The pre-React app
+  // silently refreshed on startup (App.svelte's checkAuthStatus); without
+  // that, returning to the site after ~15 minutes looks like a logout.
+  const [isRestoring, setIsRestoring] = useState<boolean>(
+    () => !auth.isAuthenticated && !!AuthService.getRefreshToken()
+  );
+
+  useEffect(() => {
+    if (!isRestoring) return;
+    let cancelled = false;
+
+    async function restoreSession() {
+      try {
+        await AuthService.refreshToken();
+        const user =
+          (AuthService.getUser() as User | null) ??
+          ((await AuthService.getCurrentUser()) as User | null);
+        if (cancelled) return;
+        if (user) {
+          setAuth({ isAuthenticated: true, user });
+        } else {
+          AuthService.clearTokens();
+        }
+      } catch {
+        if (!cancelled) {
+          AuthService.clearTokens();
+        }
+      } finally {
+        if (!cancelled) {
+          setIsRestoring(false);
+        }
+      }
+    }
+
+    restoreSession();
+    return () => {
+      cancelled = true;
+    };
+    // Runs once on mount; isRestoring can only go true→false after this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   function setAuthUser(user: User) {
     setAuth({ isAuthenticated: true, user });
   }
@@ -33,7 +80,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ ...auth, setAuthUser, clearAuth }}>
+    <AuthContext.Provider value={{ ...auth, isRestoring, setAuthUser, clearAuth }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/designsystem/components/Navigation/Navigation.test.tsx
+++ b/frontend/src/designsystem/components/Navigation/Navigation.test.tsx
@@ -44,7 +44,7 @@ function renderNav(opts: RenderOptions = {}) {
     showThemeToggle = true,
   } = opts;
 
-  const auth = { isAuthenticated, user, clearAuth: vi.fn(), setAuthUser: vi.fn() };
+  const auth = { isAuthenticated, user, isRestoring: false, clearAuth: vi.fn(), setAuthUser: vi.fn() };
   const theme = { isDark, toggle: vi.fn() };
   mockedUseAuth.mockReturnValue(auth);
   mockedUseDarkMode.mockReturnValue(theme);

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -20,6 +20,7 @@ function renderHome({ isAuthenticated = false } = {}) {
   mockedUseAuth.mockReturnValue({
     isAuthenticated,
     user: null,
+    isRestoring: false,
     setAuthUser: vi.fn(),
     clearAuth: vi.fn(),
   });


### PR DESCRIPTION
## Problem

Since the React rewrite, returning to the site after a few minutes appears to log you out, even though nothing changed on the backend (access tokens are 15 minutes, refresh tokens are 30 days).

## Root cause

The old Svelte app ran a `checkAuthStatus()` bootstrap on mount (`App.svelte`) that **silently refreshed** an expired access token using the stored refresh token. The React rewrite dropped that step: `AuthProvider` derives its state solely from `AuthService.getUser()`, which returns `null` the moment the 15-minute access token's `exp` passes. With `isAuthenticated: false`, `ProtectedRoute` immediately bounces to `/login` — the valid 30-day refresh token sitting in localStorage is never used. Net effect: sessions went from effectively 30 days to 15 minutes.

(The in-request refresh in `makeAuthenticatedRequest` only helps for 401s *during* a session — it never runs on a fresh page load because the redirect happens first.)

## Fix

- **`AuthContext.tsx`**: on mount, if the access token is expired but a refresh token exists, set a new `isRestoring` flag and run the refresh flow (`AuthService.refreshToken()`, falling back to `getCurrentUser()` for the profile). Tokens are cleared only if the refresh genuinely fails. This restores the exact behavior the Svelte app had.
- **`ProtectedRoute.tsx`**: render nothing while `isRestoring` is true instead of redirecting, so the returning user isn't bounced to `/login` mid-refresh.

## Unit test coverage

Five new tests in `AuthContext.test.tsx` cover the restore flow:
1. expired access token + valid refresh token → session silently restored (`isRestoring` true while in flight, then authenticated)
2. `getUser()` still null after refresh → falls back to `getCurrentUser()`
3. refresh fails → tokens cleared, stays unauthenticated
4. no refresh token → no refresh attempted
5. access token still valid → no refresh attempted

Full suite: **460 passed** (vitest), `tsc --noEmit` clean.

## End-to-end verification

Ran the app (Vite dev server + a mock of the backend auth API) under Playwright, seeding localStorage with an access token expired 10 minutes ago plus a valid refresh token, then navigating to the protected `/profile` route:

| | Final URL | `POST /auth/refresh` called | Result |
|---|---|---|---|
| `main` | `/login` | never | bounced — bug reproduced |
| this branch | `/profile` | yes | session restored, profile renders |

(The refresh request fires twice in dev due to `React.StrictMode` double-invoking effects; production mounts run it once, and the effect handles cancellation.)

https://claude.ai/code/session_01Byzr5bE67xq5RdQdK6pfMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byzr5bE67xq5RdQdK6pfMw)_