### PR TITLE
perf: serve World Cup leaderboard from cached games instead of 7 live ESPN fetches

### DIFF
--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -318,6 +318,23 @@ BEGIN
   END IF;
 END $$;
 
+-- Persisted match winner. ESPN's competitor.winner flag is the only signal of the
+-- advancing side on a knockout PK shootout and was previously lost between fetches,
+-- forcing every leaderboard read through the live ESPN API. Stored on refresh so
+-- cached stage reads can score knockouts without a network call.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'games' AND column_name = 'winner_team_id'
+  ) THEN
+    ALTER TABLE games ADD COLUMN winner_team_id VARCHAR(50) NULL;
+  END IF;
+END $$;
+
+-- Serves the cache-first stage reads in GameService.getWorldCupStage.
+CREATE INDEX IF NOT EXISTS idx_games_league_stage ON games(league, stage);
+
 -- Fix duplicate confidence constraint issue (remove incorrect constraint that lacks group_id)
 DO $$
 BEGIN

--- a/backend/src/models/Game.js
+++ b/backend/src/models/Game.js
@@ -33,6 +33,10 @@ export class Game {
     // League/stage carry soccer awareness. NFL games leave these null/undefined.
     this.league = data.league;
     this.stage = data.stage;
+    // Resolved match winner (soccer knockouts). Persisted because ESPN's
+    // competitor.winner flag — the only signal on a PK shootout — is not
+    // recoverable from a cached row's scores alone.
+    this.winnerTeamId = data.winnerTeamId ?? null;
     this.lastUpdated = data.lastUpdated;
     this.createdAt = data.createdAt;
   }
@@ -46,11 +50,7 @@ static fromESPNData(espnGame, opts = {}) {
   // with an explicit NULL (which is what landed pre-fix and 500'd every NFL save).
   const { league = 'nfl', stage = null } = opts;
 
-  console.log('ESPN Game Data:', JSON.stringify(espnGame, null, 2));
-  
   const competition = espnGame.competitions[0];
-  console.log('Competition:', JSON.stringify(competition, null, 2));
-  
   const competitors = competition.competitors;
   
   const homeTeam = competitors.find(c => c.homeAway === 'home');
@@ -198,8 +198,8 @@ async save() {
       espn_id, home_team, away_team, game_date, status,
       period, display_clock, status_detail,
       home_score, away_score, week, season, season_type, odds, probability, last_updated,
-      league, stage
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+      league, stage, winner_team_id
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
     ON CONFLICT (espn_id)
     DO UPDATE SET
       home_team = $2,
@@ -218,16 +218,10 @@ async save() {
       probability = $15,
       last_updated = $16,
       league = $17,
-      stage = $18
+      stage = $18,
+      winner_team_id = $19
     RETURNING *
   `;
-
-  // Add debugging
-  console.log('Saving game with values:');
-  console.log('homeTeam:', this.homeTeam);
-  console.log('awayTeam:', this.awayTeam);
-  console.log('homeTeam JSON:', JSON.stringify(this.homeTeam));
-  console.log('awayTeam JSON:', JSON.stringify(this.awayTeam));
 
   const values = [
     this.espnId,
@@ -247,7 +241,8 @@ async save() {
     JSON.stringify(this.probability || null),
     this.lastUpdated,
     this.league || null,
-    this.stage || null
+    this.stage || null,
+    this.winnerTeamId || null
   ];
 
   const result = await pool.query(query, values);
@@ -255,65 +250,10 @@ async save() {
   return this;
 }
 
-// Find game by ESPN ID
-static async findByESPNId(espnId) {
-  const query = 'SELECT * FROM games WHERE espn_id = $1';
-  const result = await pool.query(query, [espnId]);
-  
-  if (result.rows.length === 0) return null;
-  
-  const row = result.rows[0];
-  
-  // Add debugging to see what's in the database
-  console.log('Raw database row:', row);
-  console.log('home_team type:', typeof row.home_team);
-  console.log('home_team value:', row.home_team);
-  console.log('away_team type:', typeof row.away_team);
-  console.log('away_team value:', row.away_team);
-  
-  // Safe JSON parsing
-  let homeTeam, awayTeam;
-  try {
-    homeTeam = typeof row.home_team === 'string' ? JSON.parse(row.home_team) : row.home_team;
-    awayTeam = typeof row.away_team === 'string' ? JSON.parse(row.away_team) : row.away_team;
-  } catch (error) {
-    console.error('JSON parsing error:', error);
-    console.error('home_team:', row.home_team);
-    console.error('away_team:', row.away_team);
-    throw new Error('Failed to parse team data from database');
-  }
-  
+// Build a Game from a raw games-table row, shared by every finder so they all
+// parse JSONB columns and carry winner_team_id identically.
+static fromDbRow(row) {
   return new Game({
-    id: row.id,
-    espnId: row.espn_id,
-    homeTeam: homeTeam,
-    awayTeam: awayTeam,
-    gameDate: new Date(row.game_date),
-  status: row.status, // already normalized after migration; if legacy, frontend can still interpret
-  rawStatus: row.status, // fallback
-  period: row.period,
-  displayClock: row.display_clock,
-  statusDetail: row.status_detail,
-    homeScore: row.home_score,
-  odds: row.odds ? (typeof row.odds === 'string' ? JSON.parse(row.odds) : row.odds) : null,
-  probability: row.probability ? (typeof row.probability === 'string' ? JSON.parse(row.probability) : row.probability) : null,
-    awayScore: row.away_score,
-    week: row.week,
-    season: row.season,
-    seasonType: row.season_type,
-    league: row.league,
-    stage: row.stage,
-    lastUpdated: new Date(row.last_updated),
-    createdAt: new Date(row.created_at)
-  });
-}
-
-// Find all games for a given week/season/seasonType
-static async findByWeekSeason(season, seasonType, week) {
-  const query = `SELECT * FROM games WHERE season = $1 AND season_type = $2 AND week = $3`;
-  const result = await pool.query(query, [season, seasonType, week]);
-  if (result.rows.length === 0) return [];
-  return result.rows.map(row => new Game({
     id: row.id,
     espnId: row.espn_id,
     homeTeam: typeof row.home_team === 'string' ? JSON.parse(row.home_team) : row.home_team,
@@ -321,21 +261,60 @@ static async findByWeekSeason(season, seasonType, week) {
     gameDate: new Date(row.game_date),
     status: row.status,
     rawStatus: row.status,
-  period: row.period,
-  displayClock: row.display_clock,
-  statusDetail: row.status_detail,
+    period: row.period,
+    displayClock: row.display_clock,
+    statusDetail: row.status_detail,
     homeScore: row.home_score,
-  odds: row.odds ? (typeof row.odds === 'string' ? JSON.parse(row.odds) : row.odds) : null,
-  probability: row.probability ? (typeof row.probability === 'string' ? JSON.parse(row.probability) : row.probability) : null,
+    odds: row.odds ? (typeof row.odds === 'string' ? JSON.parse(row.odds) : row.odds) : null,
+    probability: row.probability ? (typeof row.probability === 'string' ? JSON.parse(row.probability) : row.probability) : null,
     awayScore: row.away_score,
     week: row.week,
     season: row.season,
     seasonType: row.season_type,
     league: row.league,
     stage: row.stage,
+    winnerTeamId: row.winner_team_id ?? null,
     lastUpdated: new Date(row.last_updated),
     createdAt: new Date(row.created_at)
-  }));
+  });
+}
+
+// Find game by ESPN ID
+static async findByESPNId(espnId) {
+  const query = 'SELECT * FROM games WHERE espn_id = $1';
+  const result = await pool.query(query, [espnId]);
+
+  if (result.rows.length === 0) return null;
+
+  return Game.fromDbRow(result.rows[0]);
+}
+
+// Batch variant of findByESPNId: one query for a whole slate of ESPN ids.
+// Returns a Map keyed by espn_id (string). Replaces the per-event lookup loop
+// in the World Cup refresh path, which issued one query per match.
+static async findByESPNIds(espnIds) {
+  const byId = new Map();
+  if (!Array.isArray(espnIds) || espnIds.length === 0) return byId;
+  const query = 'SELECT * FROM games WHERE espn_id = ANY($1::varchar[])';
+  const result = await pool.query(query, [espnIds.map(String)]);
+  for (const row of result.rows) {
+    byId.set(String(row.espn_id), Game.fromDbRow(row));
+  }
+  return byId;
+}
+
+// Find all games for a given week/season/seasonType
+static async findByWeekSeason(season, seasonType, week) {
+  const query = `SELECT * FROM games WHERE season = $1 AND season_type = $2 AND week = $3`;
+  const result = await pool.query(query, [season, seasonType, week]);
+  return result.rows.map(row => Game.fromDbRow(row));
+}
+
+// Find the persisted slate for a tournament stage (cache-first stage reads).
+static async findByLeagueStage(league, stage) {
+  const query = `SELECT * FROM games WHERE league = $1 AND stage = $2 ORDER BY game_date ASC, id ASC`;
+  const result = await pool.query(query, [league, stage]);
+  return result.rows.map(row => Game.fromDbRow(row));
 }
 
   toJSON() {
@@ -364,6 +343,7 @@ static async findByWeekSeason(season, seasonType, week) {
       seasonType: this.seasonType,
       league: this.league,
       stage: this.stage,
+      winnerTeamId: this.winnerTeamId ?? null,
       lastUpdated: this.lastUpdated,
       createdAt: this.createdAt
     };

--- a/backend/src/routes/worldCupPicks.js
+++ b/backend/src/routes/worldCupPicks.js
@@ -165,12 +165,13 @@ router.get('/group/:groupId/world-cup/leaderboard', authenticateToken, async (re
     const group = await ensureMembership(groupId, req.user.id);
 
     // Resolved games for every stage. winnerTeamId is grafted on by GameService
-    // and is the only signal of the advancing side on a PK shootout.
-    const games = [];
-    for (const stage of WORLD_CUP_STAGES) {
-      const stageGames = await GameService.getWorldCupStage(stage);
-      games.push(...stageGames);
-    }
+    // and is the only signal of the advancing side on a PK shootout. The stages
+    // are independent, so fetch them concurrently — sequentially this was seven
+    // back-to-back round trips and dominated the endpoint's latency.
+    const stageSlates = await Promise.all(
+      WORLD_CUP_STAGES.map((stage) => GameService.getWorldCupStage(stage))
+    );
+    const games = stageSlates.flat();
     const gameById = new Map(games.map(g => [g.id, g]));
     const wcGameIds = [...gameById.keys()];
 

--- a/backend/src/services/GameService.js
+++ b/backend/src/services/GameService.js
@@ -158,40 +158,81 @@ export class GameService {
   // group stage is the only World Cup phase where a 'draw' is a terminal result.
   static KNOCKOUT_STAGES = new Set(['r32', 'r16', 'qf', 'sf', 'third', 'final']);
 
-  // Get World Cup matches for a tournament stage, with the same per-event
-  // cache/save flow getGamesForWeek uses. Soccer-only: routes through
-  // fetchSoccerWeek('fifa.world', stage) and stamps league/stage on each Game.
-  // Each returned Game carries a resolved `winnerTeamId` (null when undecided)
-  // that the WC games route consumes for scoring.
+  // Decide whether a persisted World Cup stage slate can be served without an
+  // ESPN refresh. Mirrors getGamesForWeek's freshness rules: in-progress games
+  // tolerate a cache up to 60s old, SCHEDULED games at/past their start time
+  // (with a 2-minute look-ahead) force a refresh unless we refreshed within the
+  // last minute, and otherwise the 24h isStale() rule applies.
+  static isStageCacheFresh(cachedSet, now = Date.now()) {
+    if (cachedSet.length === 0) return false;
+
+    const startWindowMs = 2 * 60 * 1000;
+    const needStartRefresh = cachedSet.some(g => {
+      try {
+        const gameTime = new Date(g.gameDate).getTime();
+        const lastUpdated = g.lastUpdated ? new Date(g.lastUpdated).getTime() : 0;
+        const recentlyUpdated = now - lastUpdated < 60 * 1000;
+        return g.status === 'SCHEDULED' && gameTime <= now + startWindowMs && !recentlyUpdated;
+      } catch (e) { return false; }
+    });
+    if (needStartRefresh) return false;
+
+    const anyInProgress = cachedSet.some(g => g.status === 'IN_PROGRESS');
+    if (anyInProgress) {
+      const oldestUpdated = Math.min(...cachedSet.map(g => g.lastUpdated ? new Date(g.lastUpdated).getTime() : 0));
+      return now - oldestUpdated < 60 * 1000;
+    }
+
+    return !cachedSet.some(g => g.isStale());
+  }
+
+  // Get World Cup matches for a tournament stage. Cache-first, mirroring
+  // getGamesForWeek: a fresh persisted slate is served straight from the DB
+  // (one query, no ESPN call) — this is what keeps the leaderboard fast, since
+  // it sweeps all seven stages per request. Only a stale/live/imminent slate
+  // routes through fetchSoccerWeek('fifa.world', stage), and that refresh path
+  // batches the cache lookup (one query per slate, not per event) and persists
+  // the resolved `winnerTeamId` so cached reads can score knockout PK shootouts
+  // (ESPN's competitor.winner flag is otherwise only visible on the live event).
   static async getWorldCupStage(stage, forceRefresh = false) {
-    const games = [];
     try {
+      if (!forceRefresh) {
+        const cachedSet = await Game.findByLeagueStage('world_cup', stage);
+        if (GameService.isStageCacheFresh(cachedSet)) {
+          for (const g of cachedSet) {
+            // Persisted winner wins; recompute from scores for rows written
+            // before winner_team_id existed (regulation results only — a PK
+            // shootout stays unresolved until the next live refresh).
+            g.winnerTeamId = g.winnerTeamId ?? GameService.resolveWinnerTeamId(g, stage, null);
+          }
+          return cachedSet;
+        }
+      }
+
       const service = getESPNService();
       const espnEvents = await service.fetchSoccerWeek('fifa.world', stage);
+      const cachedById = await Game.findByESPNIds(espnEvents.map(e => e.id));
 
+      const games = [];
       for (const espnEvent of espnEvents) {
         const espnId = espnEvent.id;
-        const cachedGame = await Game.findByESPNId(espnId);
+        const cachedGame = cachedById.get(String(espnId));
         const freshGame = Game.fromESPNData(espnEvent, { league: 'world_cup', stage });
-        // The advancing-side flag (ESPN competitor.winner, set on PK shootouts)
-        // is not carried on the persisted Game, so read it from the live event.
         const winnerHomeAway = GameService.winnerHomeAwayFromESPN(espnEvent);
+        // Resolve BEFORE save so the winner persists with the row.
+        freshGame.winnerTeamId = GameService.resolveWinnerTeamId(freshGame, stage, winnerHomeAway);
 
         if (!cachedGame) {
-          console.log(`Creating new World Cup game: ${espnId}`);
           await freshGame.save();
-          freshGame.winnerTeamId = GameService.resolveWinnerTeamId(freshGame, stage, winnerHomeAway);
           games.push(freshGame);
           continue;
         }
 
-        if (forceRefresh || cachedGame.isStale() || freshGame.isDifferentFrom(cachedGame)) {
-          console.log(`Saving refresh for World Cup game: ${espnId}`);
+        const winnerChanged = freshGame.winnerTeamId !== (cachedGame.winnerTeamId ?? null);
+        if (forceRefresh || cachedGame.isStale() || freshGame.isDifferentFrom(cachedGame) || winnerChanged) {
           await freshGame.save();
-          freshGame.winnerTeamId = GameService.resolveWinnerTeamId(freshGame, stage, winnerHomeAway);
           games.push(freshGame);
         } else {
-          cachedGame.winnerTeamId = GameService.resolveWinnerTeamId(cachedGame, stage, winnerHomeAway);
           games.push(cachedGame);
         }
       }

--- a/backend/tests/api-worldcup-route.test.js
+++ b/backend/tests/api-worldcup-route.test.js
@@ -33,7 +33,8 @@ describe('GET /api/games/world-cup-2026/stage/:stage', () => {
   beforeEach(() => {
     process.env.USE_MOCK_ESPN = 'true';
     MockESPNService.configure();
-    mock.method(Game, 'findByESPNId', async () => null);
+    mock.method(Game, 'findByLeagueStage', async () => []);
+    mock.method(Game, 'findByESPNIds', async () => new Map());
     mock.method(Game.prototype, 'save', async function save() {
       this.id = this.id || 1;
       return this;

--- a/backend/tests/espn-soccer.test.js
+++ b/backend/tests/espn-soccer.test.js
@@ -37,18 +37,28 @@ describe('ESPNService.fetchSoccerWeek', () => {
       assert.ok(lastUrl.startsWith(SOCCER_SCOREBOARD), `URL should target the fifa.world scoreboard, got ${lastUrl}`);
     });
 
-    test('maps a group stage key to ?groups=1', async () => {
+    // Known stage keys fetch by tournament date window (+ limit=200 so the group
+    // slate clears ESPN's default 25-event cap) — the `?groups=` filter only
+    // returns today's matches, so it can't serve a whole-stage fetch.
+    test('maps a group stage key to its tournament date window', async () => {
       stubFetch();
       await ESPNService.fetchSoccerWeek('fifa.world', 'group');
-      assert.strictEqual(lastUrl, `${SOCCER_SCOREBOARD}?groups=1`);
+      assert.strictEqual(lastUrl, `${SOCCER_SCOREBOARD}?dates=20260611-20260627&limit=200`);
     });
 
-    test('maps knockout stage keys to their groups value', async () => {
-      const expected = { r32: '2', r16: '3', qf: '4', sf: '5', third: '6', final: '7' };
-      for (const [stage, groups] of Object.entries(expected)) {
+    test('maps knockout stage keys to their date windows', async () => {
+      const expected = {
+        r32: '20260628-20260703',
+        r16: '20260704-20260707',
+        qf: '20260709-20260711',
+        sf: '20260714-20260715',
+        third: '20260718-20260718',
+        final: '20260719-20260719',
+      };
+      for (const [stage, dates] of Object.entries(expected)) {
         stubFetch();
         await ESPNService.fetchSoccerWeek('fifa.world', stage);
-        assert.strictEqual(lastUrl, `${SOCCER_SCOREBOARD}?groups=${groups}`, `${stage} should map to groups=${groups}`);
+        assert.strictEqual(lastUrl, `${SOCCER_SCOREBOARD}?dates=${dates}&limit=200`, `${stage} should map to dates=${dates}`);
       }
     });
 
@@ -67,7 +77,7 @@ describe('ESPNService.fetchSoccerWeek', () => {
     test('supports a date-only fetch with no group filter', async () => {
       stubFetch();
       await ESPNService.fetchSoccerWeek('fifa.world', { dates: '20260611' });
-      assert.strictEqual(lastUrl, `${SOCCER_SCOREBOARD}?dates=20260611`);
+      assert.strictEqual(lastUrl, `${SOCCER_SCOREBOARD}?dates=20260611&limit=200`);
     });
   });
 

--- a/backend/tests/game-soccer.test.js
+++ b/backend/tests/game-soccer.test.js
@@ -26,11 +26,13 @@ describe('Game.fromESPNData league/stage stamping', () => {
     assert.strictEqual(game.stage, 'r16');
   });
 
-  test('leaves league and stage null for an NFL event (no opts)', () => {
+  // League defaults to 'nfl' (not null) so the games.league NOT NULL DEFAULT
+  // isn't bypassed with an explicit NULL on save — see fromESPNData.
+  test("defaults league to 'nfl' and stage to null for an NFL event (no opts)", () => {
     const [nflGame] = generateMockWeek();
     const game = Game.fromESPNData(nflGame);
 
-    assert.strictEqual(game.league, null);
+    assert.strictEqual(game.league, 'nfl');
     assert.strictEqual(game.stage, null);
   });
 
@@ -88,13 +90,13 @@ describe('Game.toJSON surfaces league and stage', () => {
     assert.strictEqual(json.stage, 'group');
   });
 
-  test('includes the fields as null for an NFL game', () => {
+  test("includes league 'nfl' and a null stage for an NFL game", () => {
     const [nflGame] = generateMockWeek();
     const json = Game.fromESPNData(nflGame).toJSON();
 
     assert.ok('league' in json, 'toJSON should always include the league field');
     assert.ok('stage' in json, 'toJSON should always include the stage field');
-    assert.strictEqual(json.league, null);
+    assert.strictEqual(json.league, 'nfl');
     assert.strictEqual(json.stage, null);
   });
 });

--- a/backend/tests/gameservice-worldcup.test.js
+++ b/backend/tests/gameservice-worldcup.test.js
@@ -16,9 +16,10 @@ describe('GameService.getWorldCupStage winner resolution', () => {
     process.env.USE_MOCK_ESPN = 'true';
     MockESPNService.configure(); // enables the mock + seeds mockGames
 
-    // Stub persistence: treat every event as new (no cache) and make save a no-op
-    // that returns the Game unchanged, so no DB connection is needed.
-    mock.method(Game, 'findByESPNId', async () => null);
+    // Stub persistence: an empty stage cache (forces the ESPN refresh path),
+    // no per-event cache hits, and a no-op save, so no DB connection is needed.
+    mock.method(Game, 'findByLeagueStage', async () => []);
+    mock.method(Game, 'findByESPNIds', async () => new Map());
     mock.method(Game.prototype, 'save', async function save() {
       this.id = this.id || 1;
       return this;
@@ -62,6 +63,129 @@ describe('GameService.getWorldCupStage winner resolution', () => {
     assert.ok(pk, 'knockout slate should include the MEX vs USA shootout');
     assert.strictEqual(pk.homeScore, pk.awayScore, 'PK match should be level after regulation');
     assert.strictEqual(pk.winnerTeamId, WORLD_CUP_2026_TEAMS.USA.id, 'away advances on the ESPN winner flag');
+  });
+});
+
+describe('GameService.getWorldCupStage cache behavior', () => {
+  // A persisted Game row as the finders would return it. Defaults to a fresh,
+  // completed group-stage regulation result (home 2-1).
+  const cachedGame = (overrides = {}) => new Game({
+    id: 1,
+    espnId: '760601',
+    homeTeam: { id: WORLD_CUP_2026_TEAMS.MEX.id, abbreviation: 'MEX' },
+    awayTeam: { id: WORLD_CUP_2026_TEAMS.USA.id, abbreviation: 'USA' },
+    gameDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    status: 'FINAL',
+    homeScore: 2,
+    awayScore: 1,
+    week: 1,
+    season: 2026,
+    seasonType: 1,
+    league: 'world_cup',
+    stage: 'group',
+    lastUpdated: new Date(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    process.env.USE_MOCK_ESPN = 'true';
+    MockESPNService.configure();
+    mock.method(Game, 'findByESPNIds', async () => new Map());
+    mock.method(Game.prototype, 'save', async function save() {
+      this.id = this.id || 1;
+      return this;
+    });
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    MockESPNService.reset();
+    delete process.env.USE_MOCK_ESPN;
+  });
+
+  test('serves a fresh cached slate without touching ESPN', async () => {
+    const cached = cachedGame();
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    const games = await GameService.getWorldCupStage('group');
+
+    assert.strictEqual(espn.mock.callCount(), 0, 'fresh cache must not hit ESPN');
+    assert.strictEqual(games.length, 1);
+    assert.strictEqual(games[0], cached, 'the cached Game is returned as-is');
+    // No stored winner (pre-migration row): a completed regulation result still
+    // resolves from the persisted scores.
+    assert.strictEqual(games[0].winnerTeamId, WORLD_CUP_2026_TEAMS.MEX.id);
+  });
+
+  test('prefers the persisted winner for a cached PK-shootout knockout', async () => {
+    // Level 90' scoreline — only the stored winner_team_id knows who advanced.
+    const cached = cachedGame({
+      stage: 'r16',
+      homeScore: 1,
+      awayScore: 1,
+      winnerTeamId: WORLD_CUP_2026_TEAMS.USA.id,
+    });
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    const games = await GameService.getWorldCupStage('r16');
+
+    assert.strictEqual(espn.mock.callCount(), 0);
+    assert.strictEqual(games[0].winnerTeamId, WORLD_CUP_2026_TEAMS.USA.id);
+  });
+
+  test('an in-progress slate older than 60s refreshes from ESPN', async () => {
+    const cached = cachedGame({
+      status: 'IN_PROGRESS',
+      lastUpdated: new Date(Date.now() - 2 * 60 * 1000),
+    });
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    await GameService.getWorldCupStage('group');
+
+    assert.strictEqual(espn.mock.callCount(), 1, 'stale live slate must refresh');
+  });
+
+  test('a SCHEDULED game at/past its start time forces a refresh', async () => {
+    const cached = cachedGame({
+      status: 'SCHEDULED',
+      gameDate: new Date(Date.now() - 5 * 60 * 1000), // kicked off 5 minutes ago
+      lastUpdated: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    await GameService.getWorldCupStage('group');
+
+    assert.strictEqual(espn.mock.callCount(), 1, 'an unstarted-but-due slate must refresh');
+  });
+
+  test('forceRefresh skips the cache entirely', async () => {
+    const finder = mock.method(Game, 'findByLeagueStage', async () => [cachedGame()]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    await GameService.getWorldCupStage('group', true);
+
+    assert.strictEqual(finder.mock.callCount(), 0, 'forceRefresh must not read the stage cache');
+    assert.strictEqual(espn.mock.callCount(), 1);
+  });
+
+  test('the refresh path persists the resolved winner with the row', async () => {
+    mock.method(Game, 'findByLeagueStage', async () => []);
+    const savedWinners = new Map();
+    mock.method(Game.prototype, 'save', async function save() {
+      savedWinners.set(`${this.homeTeam.abbreviation}-${this.awayTeam.abbreviation}`, this.winnerTeamId);
+      this.id = this.id || 1;
+      return this;
+    });
+
+    await GameService.getWorldCupStage('r16');
+
+    // Fixture: MEX 1-1 USA decided on penalties — the winner must already be on
+    // the Game at save time, otherwise a cached read can never score the match.
+    assert.strictEqual(savedWinners.get('MEX-USA'), WORLD_CUP_2026_TEAMS.USA.id);
   });
 });
 

--- a/frontend/tests/e2e/group-leaderboard-renders.spec.ts
+++ b/frontend/tests/e2e/group-leaderboard-renders.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test'
+
+// A world_cup_2026 group's Leaderboard tab fetches
+// GET /api/picks/group/<id>/world-cup/leaderboard and renders the
+// TournamentLeaderboard table with one row per member, in the order the
+// backend returns (the API owns the tiebreaker comparator). We seed a valid,
+// far-future JWT-shaped accessToken (same pattern as the other authed specs)
+// and stub the group + leaderboard endpoints so the flow never reaches a real
+// backend. The leaderboard is the group page's default tab, so landing on
+// /group-details renders it without a tab click.
+test('world cup group leaderboard tab renders member standings', async ({ page }) => {
+  // Visit the app first so localStorage is writable for this origin.
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Catch-all safety net first (lowest precedence): any unstubbed API call
+  // resolves to an empty object so the test can never reach a real backend.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  // Leaderboard endpoint: two members, already ordered by the backend
+  // comparator. The shape mirrors the live route's row payload.
+  await page.route('**/api/picks/group/**/world-cup/leaderboard', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        leaderboard: [
+          {
+            userId: 1,
+            name: 'Ada Lovelace',
+            pictureUrl: null,
+            rank: 1,
+            tied: false,
+            points: 5,
+            wins_correct: 1,
+            losses: 0,
+            draws_correct: 1,
+            draws_incorrect: 0,
+          },
+          {
+            userId: 2,
+            name: 'Grace Hopper',
+            pictureUrl: null,
+            rank: 2,
+            tied: false,
+            points: 0,
+            wins_correct: 0,
+            losses: 1,
+            draws_correct: 0,
+            draws_incorrect: 0,
+          },
+        ],
+      }),
+    })
+  })
+
+  // Group detail mount fans out to getGroup / getMembers / getMessages. getGroup
+  // must return pool_type='world_cup_2026' so the Leaderboard tab renders the
+  // tournament variant; members/messages return arrays (the catch-all's {}
+  // would break their `.map`).
+  await page.route('**/api/groups/**', async (route) => {
+    const url = route.request().url()
+    if (url.includes('/members') || url.includes('/messages')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        name: 'World Cup Squad',
+        identifier: 'wc-group',
+        memberCount: 2,
+        userRole: 'member',
+        pool_type: 'world_cup_2026',
+      }),
+    })
+  })
+
+  await page.goto('/group-details?group=wc-group')
+
+  // The detail page resolves, lands on the Leaderboard tab, and renders the
+  // tournament table: member rows plus the four tiebreaker column headers.
+  await expect(page.getByRole('heading', { name: 'World Cup Squad' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible()
+
+  await expect(page.getByRole('columnheader', { name: 'Points' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Wins Correct' })).toBeVisible()
+
+  await expect(page.getByRole('rowheader', { name: /Ada Lovelace/ })).toBeVisible()
+  await expect(page.getByRole('rowheader', { name: /Grace Hopper/ })).toBeVisible()
+
+  // Standings order is the backend's: Ada (5 pts) above Grace (0 pts).
+  const rowheaders = page.locator('tbody th[scope="row"]')
+  await expect(rowheaders.first()).toContainText('Ada Lovelace')
+  await expect(rowheaders.last()).toContainText('Grace Hopper')
+})


### PR DESCRIPTION
## Why the leaderboard was slow

`GET /api/picks/group/:groupId/world-cup/leaderboard` swept all seven tournament stages through `GameService.getWorldCupStage` **sequentially**, and — unlike the NFL path (`getGamesForWeek`), which serves fresh DB cache — that method hit the **live ESPN scoreboard API on every call**. On top of that it issued one `findByESPNId` DB query per match (~104 for the full tournament) and the Game model logged full JSON payloads per game on the hot path. Every leaderboard load paid for 7 back-to-back network round trips plus ~100 serial DB queries before a single pick could be scored.

## The fix

- **Cache-first stage reads**: `getWorldCupStage` now serves a fresh persisted slate from one DB query with no ESPN call, mirroring `getGamesForWeek`'s freshness rules (60s tolerance while matches are live, refresh on imminent/overdue kickoffs, 24h staleness otherwise). The common case is now 7 small parallel DB queries and zero network calls.
- **Persisted winners**: `games.winner_team_id` is added via an idempotent schema migration and written on every ESPN refresh, so cached reads can score knockout PK shootouts — ESPN's `competitor.winner` flag was previously only visible on the live event and lost between fetches.
- **Concurrent stage sweep**: the leaderboard route fetches the seven stages with `Promise.all`, so even a cold/stale cache pays for one ESPN round trip, not seven.
- **Batched refresh lookups**: the ESPN refresh path loads its cached rows with one `Game.findByESPNIds` query per slate instead of one query per match.
- **Hot-path logging removed**: no more per-game `JSON.stringify` dumps in `fromESPNData`/`save`/`findByESPNId`; row→model mapping is deduplicated into `Game.fromDbRow`.

The `/api/games/world-cup-2026/stage/:stage` endpoint (used by the picks page) gets the same cache-first speedup for free.

## Tests

- New unit coverage for the cache-first serve, in-progress/overdue refresh triggers, `forceRefresh` bypass, persisted-winner preference for PK shootouts, and winner persistence on save.
- Updated the stale `espn-soccer` URL-construction and `game-soccer` league-default expectations that predated the documented date-range fetch and `league='nfl'` default (they were failing on `main`).
- New Playwright e2e: a World Cup group's Leaderboard tab renders member standings in backend order.

`backend npm test`: all suites pass except the pre-existing Postgres-dependent ones that require the CI database service. Frontend: 497 unit tests and 25 e2e tests pass.

https://claude.ai/code/session_01WMDdnRss3ep9mhKVdeoLYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMDdnRss3ep9mhKVdeoLYV)_