### PR TITLE
fix: render group leaderboard full-width without card or duplicate title

### DIFF
--- a/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import WorldCupLeaderboardTab from './WorldCupLeaderboardTab';
+import type { TournamentLeaderboardRow } from '../../lib/types';
+
+// Mock the world cup service so the leaderboard fetch is controllable per test.
+vi.mock('../../lib/worldCupService.js', () => ({
+  getWorldCupLeaderboard: vi.fn(),
+}));
+
+import { getWorldCupLeaderboard } from '../../lib/worldCupService.js';
+const mockGetWorldCupLeaderboard = vi.mocked(getWorldCupLeaderboard);
+
+const identifier = 'wc-group';
+
+const rows: TournamentLeaderboardRow[] = [
+  {
+    memberId: 'm1',
+    name: 'Alice',
+    points: 12,
+    wins_correct: 4,
+    losses: 1,
+    draws_correct: 2,
+    draws_incorrect: 1,
+  },
+  {
+    memberId: 'm2',
+    name: 'Bob',
+    points: 7,
+    wins_correct: 2,
+    losses: 2,
+    draws_correct: 1,
+    draws_incorrect: 2,
+  },
+];
+
+describe('WorldCupLeaderboardTab', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fetches and renders the tournament leaderboard table', async () => {
+    mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: rows });
+
+    render(<WorldCupLeaderboardTab identifier={identifier} />);
+
+    expect(mockGetWorldCupLeaderboard).toHaveBeenCalledWith(identifier);
+    expect(await screen.findByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('renders bare — no card wrapper and no duplicate "Leaderboard" heading', async () => {
+    mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: rows });
+
+    const { container } = render(<WorldCupLeaderboardTab identifier={identifier} />);
+    await screen.findByRole('table');
+
+    // The tab label already says "Leaderboard"; the body must not repeat it.
+    expect(screen.queryByRole('heading', { name: 'Leaderboard' })).not.toBeInTheDocument();
+
+    // The tab root is an unstyled div, not a bordered/padded card, so the table
+    // spans the page container's full width.
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toBe('');
+  });
+
+  it('shows the loading state while the fetch is pending', () => {
+    mockGetWorldCupLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    render(<WorldCupLeaderboardTab identifier={identifier} />);
+
+    expect(screen.getByText('Loading leaderboard…')).toBeInTheDocument();
+  });
+
+  it('surfaces a fetch error in place of the table', async () => {
+    mockGetWorldCupLeaderboard.mockRejectedValue(new Error('Leaderboard unavailable'));
+
+    render(<WorldCupLeaderboardTab identifier={identifier} />);
+
+    expect(await screen.findByText('Leaderboard unavailable')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.tsx
@@ -34,11 +34,10 @@ export default function WorldCupLeaderboardTab({ identifier }: WorldCupLeaderboa
     load();
   }, [load]);
 
+  // Rendered bare (no card, no "Leaderboard" heading): the active tab already
+  // names the section, and the table spans the page container's full width.
   return (
-    <div className="bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg p-lg">
-      <h2 className="text-xl font-heading font-semibold text-[var(--color-text-primary)] mb-sm">
-        Leaderboard
-      </h2>
+    <div>
       {loading ? (
         <p className="text-[var(--color-text-secondary)]">Loading leaderboard…</p>
       ) : error ? (

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -219,12 +219,9 @@ export default function GroupDetailsPage() {
           (isWorldCup ? (
             <WorldCupLeaderboardTab identifier={identifier} />
           ) : (
-            <div className="bg-neutral-0 dark:bg-secondary-800 border border-secondary-200 dark:border-secondary-700 rounded-lg p-lg">
-              <h2 className="text-xl font-heading font-semibold text-[var(--color-text-primary)] mb-sm">
-                Leaderboard
-              </h2>
-              <p className="text-[var(--color-text-secondary)]">Leaderboard coming soon</p>
-            </div>
+            // Bare placeholder — the active tab already names the section, so no
+            // card wrapper or duplicate "Leaderboard" heading.
+            <p className="text-[var(--color-text-secondary)]">Leaderboard coming soon</p>
           ))}
         {activeTab === 'picks' &&
           (isWorldCup ? (

--- a/frontend/tests/e2e/group-leaderboard-renders.spec.ts
+++ b/frontend/tests/e2e/group-leaderboard-renders.spec.ts
@@ -94,7 +94,11 @@ test('world cup group leaderboard tab renders member standings', async ({ page }
   // The detail page resolves, lands on the Leaderboard tab, and renders the
   // tournament table: member rows plus the four tiebreaker column headers.
   await expect(page.getByRole('heading', { name: 'World Cup Squad' })).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toBeVisible()
+
+  // The tab itself is the only "Leaderboard" label — the body renders the table
+  // bare, with no card wrapper repeating the heading.
+  await expect(page.getByRole('tab', { name: 'Leaderboard' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toHaveCount(0)
 
   await expect(page.getByRole('columnheader', { name: 'Points' })).toBeVisible()
   await expect(page.getByRole('columnheader', { name: 'Wins Correct' })).toBeVisible()


### PR DESCRIPTION
## Summary

The Leaderboard tab body wrapped the standings table in a bordered card that carried its own "Leaderboard" heading — duplicating the tab label and double-boxing the table (card border + the table's own border). This PR renders the tab body bare:

- `WorldCupLeaderboardTab` drops the card wrapper and duplicate heading, so the tournament table spans the page container's full width with the page gutters as padding.
- The NFL pool's "Leaderboard coming soon" placeholder gets the same treatment for consistency.

## Tests

- **Unit:** new `WorldCupLeaderboardTab.test.tsx` covering the fetch/render path, the loading and error states, and that the body renders with no card wrapper and no duplicate "Leaderboard" heading. Full suite: 504 passed.
- **E2E:** `group-leaderboard-renders.spec.ts` updated — asserts the tab is the only "Leaderboard" label (zero headings by that name) while the table, columns, and standings order still render. Playwright's browser CDN is blocked in my sandbox, so the e2e run is delegated to CI (`frontend-ci.yml` runs it).

https://claude.ai/code/session_01TuAkAdaywUfx7adouSw6Ls

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuAkAdaywUfx7adouSw6Ls)_