### PR TITLE
fix: let group chat flow under the tab without card or duplicate title

### DIFF
--- a/frontend/src/pages/GroupDetails/ChatTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/ChatTab.test.tsx
@@ -62,10 +62,14 @@ describe('ChatTab', () => {
     // The tab label already says "Chat"; the body must not repeat it.
     expect(screen.queryByRole('heading', { name: 'Chat' })).not.toBeInTheDocument();
 
-    // The tab root is an unstyled div, not a bordered/padded card, and the
-    // message log flows with the page instead of a max-height scroll container.
+    // The tab root must not be a bordered/padded card (assert the specific card
+    // classes are absent rather than requiring an empty class attribute, so
+    // unrelated layout classes can be added later without breaking this), and
+    // the message log flows with the page instead of a max-height scroll box.
     const root = container.firstElementChild as HTMLElement;
-    expect(root.className).toBe('');
+    for (const cardClass of ['border', 'rounded-md', 'bg-surface', 'p-lg']) {
+      expect(root).not.toHaveClass(cardClass);
+    }
     expect(container.querySelector('.max-h-96')).toBeNull();
   });
 

--- a/frontend/src/pages/GroupDetails/ChatTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/ChatTab.test.tsx
@@ -56,6 +56,19 @@ describe('ChatTab', () => {
     vi.clearAllMocks();
   });
 
+  it('renders bare — no card wrapper, no duplicate "Chat" heading, no scroll box', () => {
+    const { container } = renderChat();
+
+    // The tab label already says "Chat"; the body must not repeat it.
+    expect(screen.queryByRole('heading', { name: 'Chat' })).not.toBeInTheDocument();
+
+    // The tab root is an unstyled div, not a bordered/padded card, and the
+    // message log flows with the page instead of a max-height scroll container.
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toBe('');
+    expect(container.querySelector('.max-h-96')).toBeNull();
+  });
+
   it('renders each seeded message author and content from initialMessages', () => {
     renderChat();
     for (const msg of initialMessages) {

--- a/frontend/src/pages/GroupDetails/ChatTab.tsx
+++ b/frontend/src/pages/GroupDetails/ChatTab.tsx
@@ -64,10 +64,12 @@ export default function ChatTab(props: ChatTabProps) {
     }
   }
 
+  // Rendered bare (no card, no "Chat" heading): the active tab already names
+  // the section, and the message log flows freely with the page instead of
+  // scrolling inside a fixed-height box.
   return (
-    <div className='rounded-md border border-border bg-surface p-lg'>
-      <h2 className='text-lg font-semibold mb-lg'>Chat</h2>
-      <div className='max-h-96 overflow-y-auto space-y-lg'>
+    <div>
+      <div className='space-y-lg'>
         {messages.length === 0 ? (
           <p className='text-secondary'>No messages yet.</p>
         ) : (

--- a/frontend/tests/e2e/group-chat-renders.spec.ts
+++ b/frontend/tests/e2e/group-chat-renders.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test'
+
+// The group detail Chat tab renders the message log seeded by the page mount's
+// getMessages fetch, flowing freely under the tab bar — no enclosing card and
+// no duplicate "Chat" heading (the tab itself is the only "Chat" label). We
+// seed a valid, far-future JWT-shaped accessToken (same pattern as the other
+// authed specs) and stub the group endpoints so the flow never reaches a real
+// backend. The page lands on /group-details, so reaching chat takes one tab
+// click.
+test('group chat tab renders the message log without a card or duplicate title', async ({ page }) => {
+  // Visit the app first so localStorage is writable for this origin.
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Catch-all safety net first (lowest precedence): any unstubbed API call
+  // resolves to an empty object so the test can never reach a real backend.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  // Group detail mount fans out to getGroup / getMembers / getMessages.
+  // getMessages seeds the chat log; members returns an empty array (the
+  // catch-all's {} would break its `.map`).
+  await page.route('**/api/groups/**', async (route) => {
+    const url = route.request().url()
+    if (url.includes('/messages')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'msg1',
+            authorId: 'u2',
+            authorName: 'Grace Hopper',
+            authorPictureUrl: null,
+            content: 'Who do we like for the final?',
+            createdAt: '2026-06-09T18:00:00.000Z',
+          },
+        ]),
+      })
+      return
+    }
+    if (url.includes('/members')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        name: 'World Cup Squad',
+        identifier: 'wc-group',
+        memberCount: 2,
+        userRole: 'member',
+        pool_type: 'world_cup_2026',
+      }),
+    })
+  })
+
+  await page.goto('/group-details?group=wc-group')
+  await expect(page.getByRole('heading', { name: 'World Cup Squad' })).toBeVisible()
+
+  // Enter the Chat tab: the seeded message and the composer render.
+  await page.getByRole('tab', { name: 'Chat' }).click()
+  await expect(page.getByText('Who do we like for the final?')).toBeVisible()
+  await expect(page.getByText('Grace Hopper')).toBeVisible()
+  await expect(page.getByPlaceholder('Type your message...')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Send' })).toBeVisible()
+
+  // The tab itself is the only "Chat" label — the body renders the log bare,
+  // with no card wrapper repeating the heading.
+  await expect(page.getByRole('tab', { name: 'Chat' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Chat' })).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

The Chat tab enclosed the message log and composer in a bordered card with its own "Chat" heading, duplicating the tab label. This PR renders the tab body bare so the conversation flows freely under the tab bar:

- `ChatTab` drops the card wrapper and the duplicate "Chat" heading.
- The `max-h-96` scroll box is removed — the log now flows with the page instead of scrolling inside a fixed-height container.

## Tests

- **Unit:** `ChatTab.test.tsx` gains a test asserting no duplicate "Chat" heading, no card classes on the tab root, and no max-height scroll container; all existing message/post/optimistic-rollback tests still pass. Full suite: 501 passed.
- **E2E:** new `group-chat-renders.spec.ts` — drives the group detail page to the Chat tab with stubbed endpoints and asserts the seeded message and composer render with the tab as the only "Chat" label. Playwright's browser CDN is blocked in my sandbox, so the e2e run is delegated to CI (`frontend-ci.yml` runs it).

https://claude.ai/code/session_01TuAkAdaywUfx7adouSw6Ls

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuAkAdaywUfx7adouSw6Ls)_