### PR TITLE
fix: show only country code on pick buttons and gate picks on assigned teams

### DIFF
--- a/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
+++ b/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
@@ -44,6 +44,14 @@ describe('MatchPickRow', () => {
     expect(screen.getByRole('button', { name: 'Pick United States to win' })).toBeInTheDocument();
   });
 
+  it('labels the team buttons with just the country code — no "(Home)"/"(Away)" suffix', () => {
+    render(<MatchPickRow {...baseProps()} />);
+    expect(screen.getByRole('button', { name: 'Pick Mexico to win' })).toHaveTextContent(/^MEX$/);
+    expect(screen.getByRole('button', { name: 'Pick United States to win' })).toHaveTextContent(
+      /^USA$/
+    );
+  });
+
   it('disables the Draw button for a knockout match', () => {
     render(<MatchPickRow {...baseProps()} match={knockoutMatch()} />);
     expect(screen.getByRole('button', { name: 'Pick a draw' })).toBeDisabled();
@@ -107,6 +115,25 @@ describe('MatchPickRow', () => {
     render(<MatchPickRow {...props} />);
     fireEvent.click(screen.getByRole('button', { name: 'Pick Mexico to win' }));
     expect(props.onPick).not.toHaveBeenCalled();
+  });
+
+  it('disables every outcome while a team slot is an unassigned TBD placeholder', () => {
+    const tbd: TeamData = { id: 'tbd-1', name: 'TBD', abbreviation: 'TBD', logo: '' };
+    const props = { ...baseProps(), match: knockoutMatch({ awayTeam: tbd }) };
+    render(<MatchPickRow {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Pick Mexico to win' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Pick a draw' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Pick TBD to win' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pick Mexico to win' }));
+    expect(props.onPick).not.toHaveBeenCalled();
+  });
+
+  it('keeps picks enabled once both knockout slots hold real teams', () => {
+    render(<MatchPickRow {...baseProps()} match={knockoutMatch()} />);
+    expect(screen.getByRole('button', { name: 'Pick Mexico to win' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Pick United States to win' })).toBeEnabled();
   });
 
   it('locks all picks once the match is final', () => {

--- a/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.tsx
+++ b/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.tsx
@@ -1,10 +1,13 @@
 import Button from '../Button';
+import { hasBothTeamsAssigned } from '../../../lib/teamUtils';
 import type { MatchPickResult, TeamData, WorldCupMatch } from '../../../lib/types';
 
 // Soccer sibling of GamePickRow. A World Cup pick is one of three outcomes —
 // Home / Draw / Away — with NO confidence selector (World Cup scoring is
 // flat-per-match). The Draw button is disabled for knockout matches, where a
-// match always resolves to an advancing team (see world-cup-picks-rules.md).
+// match always resolves to an advancing team (see world-cup-picks-rules.md),
+// and every outcome is disabled until both slots hold real teams (knockout
+// fixtures are scheduled with TBD placeholders before participants are known).
 // This row is presentational: it surfaces the three choices and emits intent
 // up via `onPick`. The parent owns the draft and persistence; the row never
 // fetches.
@@ -69,7 +72,10 @@ export default function MatchPickRow({
   const status = deriveStatus(match.status);
   // Once a match leaves the scheduled state it can no longer be picked.
   const locked = status !== 'not started';
-  const editable = !locked && !disabled;
+  // Knockout fixtures appear in the schedule before their participants are
+  // decided; until both slots hold real teams there is nothing to pick.
+  const teamsAssigned = hasBothTeamsAssigned(match);
+  const editable = !locked && !disabled && teamsAssigned;
   const dateLabel = formatGameDate(match.gameDate);
 
   function pickButton(result: MatchPickResult, label: string, ariaLabel: string, extraDisabled = false) {
@@ -121,9 +127,9 @@ export default function MatchPickRow({
       </div>
 
       <div className="flex items-stretch gap-xs" role="group" aria-label="Select match result">
-        {pickButton('home', `${homeLabel} (Home)`, `Pick ${match.homeTeam.name} to win`)}
+        {pickButton('home', homeLabel, `Pick ${match.homeTeam.name} to win`)}
         {pickButton('draw', 'Draw', 'Pick a draw', match.isKnockout)}
-        {pickButton('away', `${awayLabel} (Away)`, `Pick ${match.awayTeam.name} to win`)}
+        {pickButton('away', awayLabel, `Pick ${match.awayTeam.name} to win`)}
       </div>
     </div>
   );

--- a/frontend/src/lib/teamUtils.test.ts
+++ b/frontend/src/lib/teamUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { isTeamAssigned, hasBothTeamsAssigned } from './teamUtils';
+import type { TeamData } from './types';
+
+const mexico: TeamData = { id: '203', name: 'Mexico', abbreviation: 'MEX', logo: '' };
+const canada: TeamData = { id: '204', name: 'Canada', abbreviation: 'CAN', logo: '' };
+
+function tbdTeam(overrides: Partial<TeamData> = {}): TeamData {
+  return { id: 'tbd-1', name: 'TBD', abbreviation: 'TBD', logo: '', ...overrides };
+}
+
+describe('isTeamAssigned', () => {
+  it('accepts a real team', () => {
+    expect(isTeamAssigned(mexico)).toBe(true);
+  });
+
+  it('rejects a missing team slot', () => {
+    expect(isTeamAssigned(null)).toBe(false);
+    expect(isTeamAssigned(undefined)).toBe(false);
+  });
+
+  it('rejects a team without an id', () => {
+    expect(isTeamAssigned({ ...mexico, id: '' })).toBe(false);
+  });
+
+  it('rejects ESPN TBD placeholders regardless of case or padding', () => {
+    expect(isTeamAssigned(tbdTeam())).toBe(false);
+    expect(isTeamAssigned(tbdTeam({ name: 'tbd', abbreviation: ' TBD ' }))).toBe(false);
+    expect(isTeamAssigned(tbdTeam({ name: 'To Be Determined', abbreviation: '' }))).toBe(false);
+    expect(isTeamAssigned(tbdTeam({ name: 'To Be Announced', abbreviation: 'TBA' }))).toBe(false);
+  });
+
+  it('rejects a team with no name and no abbreviation', () => {
+    expect(isTeamAssigned(tbdTeam({ name: '', abbreviation: '' }))).toBe(false);
+  });
+
+  it('accepts a team when either label is real', () => {
+    // A real name with a placeholder/missing abbreviation is still a real team.
+    expect(isTeamAssigned(tbdTeam({ name: 'Mexico', abbreviation: '' }))).toBe(true);
+    expect(isTeamAssigned(tbdTeam({ name: '', abbreviation: 'MEX' }))).toBe(true);
+  });
+});
+
+describe('hasBothTeamsAssigned', () => {
+  it('is true when both slots hold real teams', () => {
+    expect(hasBothTeamsAssigned({ homeTeam: mexico, awayTeam: canada })).toBe(true);
+  });
+
+  it('is false when either slot is a TBD placeholder', () => {
+    expect(hasBothTeamsAssigned({ homeTeam: mexico, awayTeam: tbdTeam() })).toBe(false);
+    expect(hasBothTeamsAssigned({ homeTeam: tbdTeam(), awayTeam: canada })).toBe(false);
+    expect(hasBothTeamsAssigned({ homeTeam: tbdTeam(), awayTeam: tbdTeam() })).toBe(false);
+  });
+});

--- a/frontend/src/lib/teamUtils.ts
+++ b/frontend/src/lib/teamUtils.ts
@@ -1,0 +1,34 @@
+import type { TeamData, WorldCupMatch } from './types';
+
+// Knockout fixtures exist in the schedule before their participants are known
+// (e.g. a Round of 32 slot waiting on group-stage results). ESPN fills those
+// slots with placeholder "team" entries — typically named/abbreviated "TBD" —
+// rather than omitting them, so a fixture being present does NOT mean both
+// teams are assigned. Picks must be gated on real assignments: a pick against
+// a placeholder can never be scored.
+
+/** Placeholder names ESPN uses for an unassigned knockout slot. */
+const PLACEHOLDER_NAMES = new Set(['tbd', 'to be determined', 'to be announced', 'tba']);
+
+function isPlaceholderLabel(label: string | null | undefined): boolean {
+  return !label || PLACEHOLDER_NAMES.has(label.trim().toLowerCase());
+}
+
+/**
+ * Whether a team slot holds a real, scheduled team — present, identified, and
+ * not an ESPN "TBD"-style placeholder.
+ */
+export function isTeamAssigned(team: TeamData | null | undefined): boolean {
+  if (!team || !team.id) return false;
+  return !(isPlaceholderLabel(team.name) && isPlaceholderLabel(team.abbreviation));
+}
+
+/**
+ * Whether both of a match's team slots are filled with real teams. Matches
+ * failing this are not pickable: there is nothing concrete to pick yet.
+ */
+export function hasBothTeamsAssigned(
+  match: Pick<WorldCupMatch, 'homeTeam' | 'awayTeam'>,
+): boolean {
+  return isTeamAssigned(match.homeTeam) && isTeamAssigned(match.awayTeam);
+}

--- a/frontend/tests/e2e/world-cup-picks-renders.spec.ts
+++ b/frontend/tests/e2e/world-cup-picks-renders.spec.ts
@@ -37,37 +37,64 @@ test('world cup picks page renders the stage match list with pick buttons', asyn
   // precedence — the specific stage stub below must win over this catch-all.
   await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
 
-  // Stub the per-stage endpoint. The page fetches all seven stages; return the
-  // group-stage match only for the group request and an empty list otherwise so
-  // the match renders exactly once.
+  // Stub the per-stage endpoint. The page fetches all seven stages; the group
+  // request returns the playable match, the r32 request returns a knockout
+  // fixture whose away slot is still ESPN's TBD placeholder, and every other
+  // stage returns an empty list so each match renders exactly once.
   await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
-    const isGroup = route.request().url().includes('/stage/group')
-    const games = isGroup
-      ? [
-          {
-            id: 101,
-            stage: 'group',
-            isKnockout: false,
-            status: 'SCHEDULED',
-            homeScore: 0,
-            awayScore: 0,
-            gameDate: '2026-06-11T19:00:00.000Z',
-            winnerTeamId: null,
-            homeTeam: {
-              id: '1',
-              name: 'Mexico',
-              abbreviation: 'MEX',
-              logo: 'https://example.test/mex.png',
-            },
-            awayTeam: {
-              id: '2',
-              name: 'Canada',
-              abbreviation: 'CAN',
-              logo: 'https://example.test/can.png',
-            },
+    const url = route.request().url()
+    let games: object[] = []
+    if (url.includes('/stage/group')) {
+      games = [
+        {
+          id: 101,
+          stage: 'group',
+          isKnockout: false,
+          status: 'SCHEDULED',
+          homeScore: 0,
+          awayScore: 0,
+          gameDate: '2026-06-11T19:00:00.000Z',
+          winnerTeamId: null,
+          homeTeam: {
+            id: '1',
+            name: 'Mexico',
+            abbreviation: 'MEX',
+            logo: 'https://example.test/mex.png',
           },
-        ]
-      : []
+          awayTeam: {
+            id: '2',
+            name: 'Canada',
+            abbreviation: 'CAN',
+            logo: 'https://example.test/can.png',
+          },
+        },
+      ]
+    } else if (url.includes('/stage/r32')) {
+      games = [
+        {
+          id: 201,
+          stage: 'r32',
+          isKnockout: true,
+          status: 'SCHEDULED',
+          homeScore: 0,
+          awayScore: 0,
+          gameDate: '2026-06-29T19:00:00.000Z',
+          winnerTeamId: null,
+          homeTeam: {
+            id: '3',
+            name: 'France',
+            abbreviation: 'FRA',
+            logo: 'https://example.test/fra.png',
+          },
+          awayTeam: {
+            id: 'tbd-1',
+            name: 'TBD',
+            abbreviation: 'TBD',
+            logo: '',
+          },
+        },
+      ]
+    }
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -82,10 +109,19 @@ test('world cup picks page renders the stage match list with pick buttons', asyn
   await expect(page.getByRole('heading', { name: 'World Cup 2026 Picks' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Group Stage' })).toBeVisible()
 
-  // MatchPickRow surfaces the three outcomes as buttons keyed by accessible name.
-  await expect(page.getByRole('button', { name: 'Pick Mexico to win' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Pick a draw' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Pick Canada to win' })).toBeVisible()
+  // MatchPickRow surfaces the three outcomes as buttons keyed by accessible
+  // name; the visible label is just the country code — no "(Home)"/"(Away)".
+  const groupRow = page.getByTestId('match-row-101')
+  await expect(groupRow.getByRole('button', { name: 'Pick Mexico to win' })).toHaveText('MEX')
+  await expect(groupRow.getByRole('button', { name: 'Pick a draw' })).toBeVisible()
+  await expect(groupRow.getByRole('button', { name: 'Pick Canada to win' })).toHaveText('CAN')
+
+  // The r32 fixture's away slot is still TBD, so the whole match is unpickable
+  // until both teams are assigned.
+  const tbdRow = page.getByTestId('match-row-201')
+  await expect(tbdRow.getByRole('button', { name: 'Pick France to win' })).toBeDisabled()
+  await expect(tbdRow.getByRole('button', { name: 'Pick a draw' })).toBeDisabled()
+  await expect(tbdRow.getByRole('button', { name: 'Pick TBD to win' })).toBeDisabled()
 })
 
 // A world_cup_2026 group surfaces the tournament-shaped tabs on its detail page:


### PR DESCRIPTION
## Summary

Two changes to the World Cup match pick rows:

1. **Country code only on the buttons.** The outcome buttons read "MEX (Home)" / "RSA (Away)"; the suffix is dropped so the buttons show just the country code. The row above the buttons already lays out which side is home vs away, and the accessible names ("Pick Mexico to win") are unchanged.
2. **Picks are gated on both teams being assigned.** Knockout fixtures exist in the schedule before their participants are known — ESPN fills the open slots with "TBD"-style placeholder teams, so a fixture being present doesn't mean it's pickable. New `lib/teamUtils.ts` adds `isTeamAssigned` / `hasBothTeamsAssigned` (handles missing teams, missing ids, empty labels, and TBD/To Be Determined/TBA placeholders case-insensitively), and `MatchPickRow` now disables every outcome until both slots hold real teams.

## Tests

- **Unit:** new `teamUtils.test.ts` covering the assignment predicate edge cases; `MatchPickRow.test.tsx` gains tests for the exact country-code label (no "(Home)"/"(Away)") and for the all-outcomes-disabled behavior on a TBD fixture, plus a guard that fully-assigned knockouts stay pickable. Full suite: 511 passed.
- **E2E:** `world-cup-picks-renders.spec.ts` extended — the stage stub now also returns an r32 fixture with a TBD away slot; the spec asserts the group-stage buttons show exactly "MEX"/"CAN" and that all three buttons on the TBD fixture are disabled. Playwright's browser CDN is blocked in my sandbox, so the e2e run is delegated to CI (`frontend-ci.yml` runs it).

https://claude.ai/code/session_01TuAkAdaywUfx7adouSw6Ls

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuAkAdaywUfx7adouSw6Ls)_