### PR TITLE
Generalize NFL-centric copy and explain per-pool scoring rules

### DIFF
--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -4,20 +4,48 @@ export default function AboutPage() {
       <h1 className='text-2xl font-bold'>About</h1>
       <section className='mt-md space-y-md text-base text-gray-600'>
         <p>
-          Confidence Picks is a weekly NFL confidence-picks pool for groups of
-          friends. Each week, every member ranks that week&apos;s games by how
-          confident they are in each outcome, assigning more points to the games
-          they feel surest about.
+          Confidence Picks is a sports pick&apos;em platform for groups of friends. Create or join a
+          group, make your picks before each game locks, and climb your group&apos;s leaderboard.
+          Each group runs one pool type, and the two pool types score differently — here&apos;s how
+          points work in each.
         </p>
+
+        <div className='space-y-xs'>
+          <h2 className='text-lg font-semibold text-gray-900'>NFL confidence pools</h2>
+          <p>
+            Each week you rank that week&apos;s games by how confident you are. With N games on the
+            slate, your surest pick is worth N points, the next is worth N−1, and so on down to 1.
+            Get a pick right and you bank the points you assigned it; get it wrong and you score
+            nothing for that game. Picks lock at kickoff, and scores accumulate across the season —
+            rewarding consistent accuracy over lucky one-off calls.
+          </p>
+        </div>
+
+        <div className='space-y-xs'>
+          <h2 className='text-lg font-semibold text-gray-900'>World Cup pools</h2>
+          <p>
+            There&apos;s no confidence ranking — every match is worth a flat point value based only
+            on the outcome you pick (home win, draw, or away win). Your tournament score is the sum
+            across every match you picked.
+          </p>
+          <ul className='list-disc space-y-xxs pl-lg'>
+            <li>
+              <span className='font-medium text-gray-900'>Group stage:</span> pick the winning team
+              → 3 points; pick a team that ends up drawing → 1; pick &ldquo;Draw&rdquo; and the match
+              draws → 2; pick &ldquo;Draw&rdquo; but a team wins → 1; pick the losing team → 0.
+            </li>
+            <li>
+              <span className='font-medium text-gray-900'>Knockout stage:</span> a match always
+              produces a team that advances — extra time or a penalty shootout decides it — so there
+              is no draw. Pick the advancing team → 3 points; pick anyone else → 0. The
+              &ldquo;Draw&rdquo; option is disabled for knockout matches.
+            </li>
+          </ul>
+        </div>
+
         <p>
-          Picks lock at kickoff, so everyone commits before the action starts.
-          Get a high-confidence pick right and you bank its full point value;
-          get it wrong and you forfeit those points to the rest of the group.
-        </p>
-        <p>
-          Scores accumulate across the season, rewarding consistent accuracy
-          over lucky one-off calls. Track the standings, see where you rank
-          against your group, and chase the title all the way to the Super Bowl.
+          Whichever pool you&apos;re in, track the standings, see where you rank against your group,
+          and chase the title to the final whistle.
         </p>
       </section>
     </div>

--- a/frontend/src/pages/GamesPage.tsx
+++ b/frontend/src/pages/GamesPage.tsx
@@ -324,6 +324,14 @@ export default function GamesPage() {
     <div className="mx-auto max-w-4xl px-sm py-lg sm:p-lg">
       <h1 className="text-2xl font-bold text-secondary-900 dark:text-neutral-0">NFL Games</h1>
 
+      {/* How scoring works — confidence pools assign each game a rank, so the
+          point value of a pick isn't obvious from the row UI alone. */}
+      <p className="mt-xs text-sm text-secondary">
+        Rank each game by confidence: your surest pick is worth the most points (down to 1 for your
+        least sure). Win the game and you bank the points you assigned it; lose and you score
+        nothing. Picks lock at kickoff.
+      </p>
+
       {/* Selector controls */}
       <div className="mt-md flex flex-wrap items-end gap-md rounded-md border border-border bg-surface p-md">
         <label className="flex flex-col gap-xxs text-sm">

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -259,6 +259,28 @@ export default function WorldCupPicksTab({ identifier }: WorldCupPicksTabProps) 
 
   return (
     <div>
+      {/* How scoring works — World Cup pools are flat-per-match (no confidence)
+          and the group and knockout stages score differently, so the rules
+          aren't obvious from the Home/Draw/Away row alone. */}
+      <div className="mb-lg rounded-md border border-border bg-surface p-sm text-sm text-secondary">
+        <p>
+          Pick an outcome for every match — there&apos;s no confidence ranking, and your score is
+          the sum across every match you pick.
+        </p>
+        <ul className="mt-xs list-disc space-y-xxs pl-lg">
+          <li>
+            <span className="font-medium text-secondary-900 dark:text-neutral-0">Group stage:</span>{' '}
+            winning team = 3 pts · a team that draws = 1 · pick &ldquo;Draw&rdquo; = 2 if it draws (1
+            if a team wins) · losing team = 0.
+          </li>
+          <li>
+            <span className="font-medium text-secondary-900 dark:text-neutral-0">Knockout:</span>{' '}
+            the team that advances = 3 pts, everyone else = 0. Penalties still count as advancing, so
+            &ldquo;Draw&rdquo; is disabled.
+          </li>
+        </ul>
+      </div>
+
       {/* Match list, grouped by stage */}
       <div className="space-y-lg">
         {fetchState.loading ? (

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -51,7 +51,9 @@ describe('HomePage', () => {
 
     it('renders the tagline', () => {
       renderHome();
-      expect(screen.getByText(/Your destination for NFL confidence picks/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Your home for sports pick.?em pools/)
+      ).toBeInTheDocument();
     });
 
     it('renders all three feature cards', () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -21,7 +21,7 @@ interface Feature {
 const FEATURES: Feature[] = [
   {
     title: 'Weekly Games',
-    description: 'Browse NFL games by week and make your confidence picks for each matchup.',
+    description: 'Browse games by week or tournament stage and make a pick for every matchup.',
     iconWrapper: 'bg-primary-100 dark:bg-primary-900',
     iconColor: 'text-primary-600 dark:text-primary-400',
     iconPath:
@@ -37,7 +37,7 @@ const FEATURES: Feature[] = [
   },
   {
     title: 'Leaderboards',
-    description: 'Compete with friends and track your ranking throughout the season.',
+    description: 'Compete with friends and track your ranking all season — or all tournament — long.',
     iconWrapper: 'bg-warning-100 dark:bg-warning-900',
     iconColor: 'text-warning-600 dark:text-warning-400',
     iconPath:
@@ -57,8 +57,8 @@ export default function HomePage() {
             Welcome to Confidence Picks!
           </h1>
           <p className="text-xl text-[var(--color-text-secondary)] max-w-2xl mx-auto">
-            Your destination for NFL confidence picks. Compete with friends, track your
-            performance, and climb the leaderboard.
+            Your home for sports pick&apos;em pools — from NFL confidence picks to the World Cup.
+            Compete with friends, track your performance, and climb the leaderboard.
           </p>
         </header>
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -82,7 +82,7 @@ export default function LoginPage() {
               Login
             </h1>
             <p className="text-lg text-[var(--color-text-secondary)]">
-              Welcome to Confidence Picks — sign in to start making your NFL picks and compete with
+              Welcome to Confidence Picks — sign in to start making your picks and compete with
               friends.
             </p>
           </div>


### PR DESCRIPTION
## Why

The site was written when NFL confidence pools were the only pool type. Now that **World Cup pools** exist (and more sports may follow), some copy is locally incorrect — it tells users the product is NFL-only — and the app **never explains how points are scored** for either pool type, even though the two score very differently.

This PR (1) de-NFL-ifies the incorrect copy so it reads as a multi-sport pick'em platform, and (2) explains the scoring rules clearly, both on a shared About page and inline where picks are actually made.

No new "places" for copy were invented beyond where context was genuinely missing — the only additions are the two inline scoring notes, placed exactly at the point a user picks.

## 1. Incorrect / NFL-only copy → generalized

| Where | Before | After |
|---|---|---|
| `HomePage.tsx` hero | "Your destination for **NFL** confidence picks." | "Your home for sports pick'em pools — from NFL confidence picks to the World Cup." |
| `HomePage.tsx` "Weekly Games" card | "Browse **NFL** games by week…" | "Browse games by week or tournament stage and make a pick for every matchup." |
| `HomePage.tsx` "Leaderboards" card | "…track your ranking throughout the **season**." | "…track your ranking all season — or all tournament — long." |
| `LoginPage.tsx` subtitle | "sign in to start making your **NFL** picks…" | "sign in to start making your picks…" |

## 2. Rules explained clearly (different per pool type)

**`AboutPage.tsx` — rewritten.** Previously described only the weekly NFL pool and ended at "the Super Bowl." Now it frames the product as a multi-sport platform and spells out **both** scoring systems:
- **NFL confidence pools** — rank the week's games; surest pick worth N points down to 1; right = bank the assigned points, wrong = 0; locks at kickoff; accumulates across the season.
- **World Cup pools** — flat per match, no confidence. Group stage: win 3 / picked team drew 1 / "Draw" pick = 2 if it draws (1 if not) / loss 0. Knockout: advancing team 3 / else 0, "Draw" disabled (penalties still count as advancing).

**Inline scoring notes at the point of picking** (this is where "how do points work per game?" actually gets asked):
- **`GamesPage.tsx` (NFL)** — a one-line note under the header explaining confidence ranking and that picks lock at kickoff.
- **`WorldCupPicksTab.tsx` (World Cup)** — a compact group-vs-knockout scoring box above the match list. This component is shared by both the group **Picks** tab and the standalone `/world-cup` page, so both surfaces get it from one change.

## Tests
- Updated the one assertion coupled to the old hero tagline (`HomePage.test.tsx`).
- `tsc --noEmit` clean; full suite green (**500 passed**, 5 todo).

https://claude.ai/code/session_01JzRHw44tQyR5sqeKTxAnfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzRHw44tQyR5sqeKTxAnfE)_