### PR TITLE
Load member avatars on the leaderboard and redesign it card-free on mobile

### DIFF
--- a/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.test.tsx
+++ b/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.test.tsx
@@ -9,6 +9,11 @@ import type { TournamentLeaderboardRow } from '../../../lib/types';
 // column, another row, or the 1-based rank the component renders per row. Names
 // are intentionally NOT alphabetical: the supplied order is the rendered order,
 // and these fixtures prove the component never re-sorts.
+//
+// The component now renders TWO layouts simultaneously (a mobile stacked list
+// and a desktop table — CSS, not JS, decides which is visible), so every query
+// is scoped to one layout root via `within(table())` / `within(mobileList())`.
+// An unscoped getByText would match the same value in both layouts and throw.
 
 function makeRow(overrides: Partial<TournamentLeaderboardRow> & Pick<TournamentLeaderboardRow, 'memberId' | 'name'>): TournamentLeaderboardRow {
   return {
@@ -54,16 +59,29 @@ const ADA = makeRow({
 // Supplied order: Zara, Milo, Ada (not sorted by name or points).
 const ROWS: TournamentLeaderboardRow[] = [ZARA, MILO, ADA];
 
-// The member's <tr>, located via its unique name (rendered in a th scope="row").
-function rowFor(name: string): HTMLElement {
-  const tr = screen.getByText(name).closest('tr');
+// Layout roots. The desktop table carries ARIA table semantics; the mobile
+// stacked layout is a plain list.
+const table = () => screen.getByRole('table');
+const mobileList = () => screen.getByRole('list');
+
+// The member's <tr> in the desktop table, located via its unique name (rendered
+// in a th scope="row"). Scoped to the table so the mobile copy never matches.
+function tableRowFor(name: string): HTMLElement {
+  const tr = within(table()).getByText(name).closest('tr');
   expect(tr).not.toBeNull();
   return tr as HTMLElement;
 }
 
+// The member's <li> in the mobile list, located via its unique name.
+function mobileItemFor(name: string): HTMLElement {
+  const li = within(mobileList()).getByText(name).closest('li');
+  expect(li).not.toBeNull();
+  return li as HTMLElement;
+}
+
 describe('TournamentLeaderboard', () => {
-  describe('rows', () => {
-    it('renders exactly one row per entry', () => {
+  describe('desktop table — rows', () => {
+    it('renders exactly one table row per entry', () => {
       render(<TournamentLeaderboard rows={ROWS} />);
       // Each member contributes one row-header (th scope="row").
       expect(screen.getAllByRole('rowheader')).toHaveLength(ROWS.length);
@@ -81,13 +99,13 @@ describe('TournamentLeaderboard', () => {
     });
   });
 
-  describe('points and tiebreaker columns', () => {
+  describe('desktop table — points and tiebreaker columns', () => {
     it('renders points plus all four tiebreaker values for each row', () => {
       render(<TournamentLeaderboard rows={ROWS} />);
       // Scope every assertion to the member's own row so a value can never
       // satisfy the lookup by matching a different member's cell.
       ROWS.forEach(row => {
-        const tr = rowFor(row.name);
+        const tr = tableRowFor(row.name);
         expect(within(tr).getByText(String(row.points))).toBeInTheDocument();
         expect(within(tr).getByText(String(row.wins_correct))).toBeInTheDocument();
         expect(within(tr).getByText(String(row.losses))).toBeInTheDocument();
@@ -100,20 +118,85 @@ describe('TournamentLeaderboard', () => {
       render(<TournamentLeaderboard rows={ROWS} />);
       // Milo's row holds Milo's numbers and none of Ada's — guards against a
       // column-misalignment regression that would cross values between rows.
-      const miloRow = rowFor('Milo');
+      const miloRow = tableRowFor('Milo');
       expect(within(miloRow).getByText(String(MILO.points))).toBeInTheDocument();
       expect(within(miloRow).getByText(String(MILO.wins_correct))).toBeInTheDocument();
       expect(within(miloRow).queryByText(String(ADA.points))).not.toBeInTheDocument();
       expect(within(miloRow).queryByText(String(ADA.wins_correct))).not.toBeInTheDocument();
     });
+
+    it('renders the four tiebreaker column headers', () => {
+      render(<TournamentLeaderboard rows={ROWS} />);
+      expect(screen.getByRole('columnheader', { name: 'Points' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Wins Correct' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Losses' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Draws Correct' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Draws Incorrect' })).toBeInTheDocument();
+    });
+  });
+
+  describe('mobile list — card-free stacked layout', () => {
+    it('renders one list item per entry, in the supplied order', () => {
+      render(<TournamentLeaderboard rows={ROWS} />);
+      const items = within(mobileList()).getAllByRole('listitem');
+      expect(items).toHaveLength(ROWS.length);
+      ROWS.forEach((row, i) => {
+        expect(within(items[i]).getByText(row.name)).toBeInTheDocument();
+      });
+    });
+
+    it('shows points and all four tiebreaker stats for each member', () => {
+      render(<TournamentLeaderboard rows={ROWS} />);
+      ROWS.forEach(row => {
+        const li = mobileItemFor(row.name);
+        expect(within(li).getByText(String(row.points))).toBeInTheDocument();
+        expect(within(li).getByText(String(row.wins_correct))).toBeInTheDocument();
+        expect(within(li).getByText(String(row.losses))).toBeInTheDocument();
+        expect(within(li).getByText(String(row.draws_correct))).toBeInTheDocument();
+        expect(within(li).getByText(String(row.draws_incorrect))).toBeInTheDocument();
+      });
+    });
+
+    it('is a card-free list (no bordered card wrapper)', () => {
+      render(<TournamentLeaderboard rows={ROWS} />);
+      // The mobile root is the <ul>; it carries no border utility classes.
+      const list = mobileList();
+      expect(list.className).not.toMatch(/\bborder\b/);
+      expect(list.className).not.toMatch(/rounded-lg/);
+    });
+  });
+
+  describe('avatars', () => {
+    const WITH_PIC: TournamentLeaderboardRow[] = [
+      makeRow({ memberId: 'm-pic', name: 'Pic Person', pictureUrl: 'https://example.com/p.jpg?sz=100' }),
+    ];
+
+    it('renders the member picture in both layouts when pictureUrl is provided', () => {
+      render(<TournamentLeaderboard rows={WITH_PIC} />);
+      // One <img> in the mobile list, one in the desktop table.
+      const imgs = screen.getAllByRole('img');
+      expect(imgs).toHaveLength(2);
+      imgs.forEach(img => {
+        expect(img).toHaveAttribute('src', 'https://example.com/p.jpg?sz=100');
+        expect(img).toHaveAttribute('alt', 'Pic Person');
+      });
+    });
+
+    it('falls back to initials (no img) when pictureUrl is absent', () => {
+      render(<TournamentLeaderboard rows={[ZARA]} />);
+      expect(screen.queryByRole('img')).toBeNull();
+      // Initials appear once per layout.
+      expect(screen.getAllByText('Z')).toHaveLength(2);
+    });
   });
 
   describe('empty state', () => {
-    it('renders the placeholder message and no data table when rows is empty', () => {
+    it('renders the placeholder message and neither layout when rows is empty', () => {
       render(<TournamentLeaderboard rows={[]} />);
       expect(screen.getByText(/no standings yet/i)).toBeInTheDocument();
-      // The table and all its rows are absent in the empty state.
+      // Both layouts are absent in the empty state.
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      expect(screen.queryByRole('list')).not.toBeInTheDocument();
       expect(screen.queryAllByRole('row')).toHaveLength(0);
       expect(screen.queryAllByRole('rowheader')).toHaveLength(0);
     });

--- a/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.test.tsx
+++ b/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.test.tsx
@@ -15,8 +15,11 @@ import type { TournamentLeaderboardRow } from '../../../lib/types';
 // is scoped to one layout root via `within(table())` / `within(mobileList())`.
 // An unscoped getByText would match the same value in both layouts and throw.
 
-function makeRow(overrides: Partial<TournamentLeaderboardRow> & Pick<TournamentLeaderboardRow, 'memberId' | 'name'>): TournamentLeaderboardRow {
+function makeRow(overrides: Partial<TournamentLeaderboardRow> & Pick<TournamentLeaderboardRow, 'userId' | 'name'>): TournamentLeaderboardRow {
   return {
+    pictureUrl: null,
+    rank: 1,
+    tied: false,
     points: 0,
     wins_correct: 0,
     losses: 0,
@@ -27,7 +30,7 @@ function makeRow(overrides: Partial<TournamentLeaderboardRow> & Pick<TournamentL
 }
 
 const ZARA = makeRow({
-  memberId: 'm-zara',
+  userId: 101,
   name: 'Zara',
   points: 40,
   wins_correct: 11,
@@ -37,7 +40,7 @@ const ZARA = makeRow({
 });
 
 const MILO = makeRow({
-  memberId: 'm-milo',
+  userId: 102,
   name: 'Milo',
   points: 50,
   wins_correct: 13,
@@ -47,7 +50,7 @@ const MILO = makeRow({
 });
 
 const ADA = makeRow({
-  memberId: 'm-ada',
+  userId: 103,
   name: 'Ada',
   points: 60,
   wins_correct: 15,
@@ -168,7 +171,7 @@ describe('TournamentLeaderboard', () => {
 
   describe('avatars', () => {
     const WITH_PIC: TournamentLeaderboardRow[] = [
-      makeRow({ memberId: 'm-pic', name: 'Pic Person', pictureUrl: 'https://example.com/p.jpg?sz=100' }),
+      makeRow({ userId: 200, name: 'Pic Person', pictureUrl: 'https://example.com/p.jpg?sz=100' }),
     ];
 
     it('renders the member picture in both layouts when pictureUrl is provided', () => {

--- a/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.tsx
+++ b/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.tsx
@@ -14,10 +14,16 @@ export interface TournamentLeaderboardProps {
 const HEADER_CELL = 'px-sm py-xs text-left text-xs font-semibold uppercase tracking-wide text-secondary-500 dark:text-secondary-400';
 const BODY_CELL = 'px-sm py-xs align-middle text-sm text-secondary-900 dark:text-neutral-0 border-t border-secondary-200 dark:border-secondary-700';
 
+// The numeric tiebreaker fields, restricted to exactly the four stat keys so a
+// column can never point at a non-numeric field (name/pictureUrl/…). This keeps
+// `row[col.key]` strongly typed as `number` — no casts — and makes a future
+// typo a compile error.
+type StatKey = 'wins_correct' | 'losses' | 'draws_correct' | 'draws_incorrect';
+
 // The four tiebreaker stats, in tiebreaker order. Shared between the desktop
 // table columns and the mobile stat-chip grid so the two layouts can never
 // drift out of sync. `key` indexes the row; `label` is the human-facing header.
-const STAT_COLUMNS: { key: keyof TournamentLeaderboardRow; label: string; short: string }[] = [
+const STAT_COLUMNS: { key: StatKey; label: string; short: string }[] = [
   { key: 'wins_correct', label: 'Wins Correct', short: 'Wins' },
   { key: 'losses', label: 'Losses', short: 'Losses' },
   { key: 'draws_correct', label: 'Draws Correct', short: 'D ✓' },
@@ -56,7 +62,7 @@ export default function TournamentLeaderboard({ rows }: TournamentLeaderboardPro
       {/* Mobile (below sm): card-free stacked list with a stat-chip grid. */}
       <ul className="sm:hidden divide-y divide-secondary-200 dark:divide-secondary-700">
         {rows.map((row, index) => (
-          <li key={row.memberId} className="py-md">
+          <li key={row.userId} className="py-md">
             <div className="flex items-center gap-sm">
               <span className="w-6 shrink-0 text-center text-sm font-medium text-secondary-500 dark:text-secondary-400 tabular-nums">
                 {index + 1}
@@ -84,7 +90,7 @@ export default function TournamentLeaderboard({ rows }: TournamentLeaderboardPro
                     {col.short}
                   </div>
                   <div className="text-sm font-semibold tabular-nums text-secondary-900 dark:text-neutral-0">
-                    {row[col.key] as number}
+                    {row[col.key]}
                   </div>
                 </div>
               ))}
@@ -116,7 +122,7 @@ export default function TournamentLeaderboard({ rows }: TournamentLeaderboardPro
           </thead>
           <tbody>
             {rows.map((row, index) => (
-              <tr key={row.memberId}>
+              <tr key={row.userId}>
                 <td className={`${BODY_CELL} text-center font-medium text-secondary-500 dark:text-secondary-400 tabular-nums`}>
                   {index + 1}
                 </td>
@@ -131,7 +137,7 @@ export default function TournamentLeaderboard({ rows }: TournamentLeaderboardPro
                 </td>
                 {STAT_COLUMNS.map((col) => (
                   <td key={col.key} className={`${BODY_CELL} text-center tabular-nums`}>
-                    {row[col.key] as number}
+                    {row[col.key]}
                   </td>
                 ))}
               </tr>

--- a/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.tsx
+++ b/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.tsx
@@ -14,6 +14,18 @@ export interface TournamentLeaderboardProps {
 const HEADER_CELL = 'px-sm py-xs text-left text-xs font-semibold uppercase tracking-wide text-secondary-500 dark:text-secondary-400';
 const BODY_CELL = 'px-sm py-xs align-middle text-sm text-secondary-900 dark:text-neutral-0 border-t border-secondary-200 dark:border-secondary-700';
 
+// The four tiebreaker stats, in tiebreaker order. Shared between the desktop
+// table columns and the mobile stat-chip grid so the two layouts can never
+// drift out of sync. `key` indexes the row; `label` is the human-facing header.
+const STAT_COLUMNS: { key: keyof TournamentLeaderboardRow; label: string; short: string }[] = [
+  { key: 'wins_correct', label: 'Wins Correct', short: 'Wins' },
+  { key: 'losses', label: 'Losses', short: 'Losses' },
+  { key: 'draws_correct', label: 'Draws Correct', short: 'D ✓' },
+  { key: 'draws_incorrect', label: 'Draws Incorrect', short: 'D ✗' },
+];
+
+const EMPTY_STATE = 'No standings yet — picks will appear here once the tournament begins.';
+
 /**
  * TournamentLeaderboard renders a World Cup pool's standings: one row per member,
  * with total points plus the four tiebreaker columns in tiebreaker order
@@ -22,67 +34,111 @@ const BODY_CELL = 'px-sm py-xs align-middle text-sm text-secondary-900 dark:text
  * It is a pure presentation component — it never fetches. The parent supplies
  * `rows` already ordered by the backend comparator; this component renders them
  * in that order without re-sorting. Composes Avatar for member identity.
+ *
+ * Two layouts, switched purely with Tailwind responsive utilities (no JS / no
+ * window measurement, so it's SSR- and test-stable):
+ *  - `sm` and up: the bordered standings table (unchanged from before).
+ *  - below `sm`: a card-free stacked list — each member is a row with rank +
+ *    avatar + name + emphasized points, and the four tiebreakers below as a
+ *    4-up stat-chip grid. No bordered card and no horizontal scroll on phones.
  */
 export default function TournamentLeaderboard({ rows }: TournamentLeaderboardProps) {
   if (rows.length === 0) {
     return (
       <p className="text-sm text-secondary-500 dark:text-secondary-400 py-lg text-center">
-        No standings yet — picks will appear here once the tournament begins.
+        {EMPTY_STATE}
       </p>
     );
   }
 
   return (
-    <div className="overflow-x-auto rounded-lg border border-secondary-200 dark:border-secondary-700">
-      <table className="min-w-full border-collapse bg-neutral-0 dark:bg-secondary-900">
-        <thead>
-          <tr className="bg-secondary-50 dark:bg-secondary-800">
-            <th scope="col" className={`${HEADER_CELL} text-center`}>
-              #
-            </th>
-            <th scope="col" className={HEADER_CELL}>
-              Member
-            </th>
-            <th scope="col" className={`${HEADER_CELL} text-center`}>
-              Points
-            </th>
-            <th scope="col" className={`${HEADER_CELL} text-center`}>
-              Wins Correct
-            </th>
-            <th scope="col" className={`${HEADER_CELL} text-center`}>
-              Losses
-            </th>
-            <th scope="col" className={`${HEADER_CELL} text-center`}>
-              Draws Correct
-            </th>
-            <th scope="col" className={`${HEADER_CELL} text-center`}>
-              Draws Incorrect
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, index) => (
-            <tr key={row.memberId}>
-              <td className={`${BODY_CELL} text-center font-medium text-secondary-500 dark:text-secondary-400 tabular-nums`}>
+    <>
+      {/* Mobile (below sm): card-free stacked list with a stat-chip grid. */}
+      <ul className="sm:hidden divide-y divide-secondary-200 dark:divide-secondary-700">
+        {rows.map((row, index) => (
+          <li key={row.memberId} className="py-md">
+            <div className="flex items-center gap-sm">
+              <span className="w-6 shrink-0 text-center text-sm font-medium text-secondary-500 dark:text-secondary-400 tabular-nums">
                 {index + 1}
-              </td>
-              <th scope="row" className={`${BODY_CELL} text-left font-medium`}>
-                <div className="flex items-center gap-xs">
-                  <Avatar name={row.name} variant="md" />
-                  <span>{row.name}</span>
+              </span>
+              <Avatar name={row.name} pictureUrl={row.pictureUrl} variant="md" />
+              <span className="min-w-0 flex-1 truncate font-medium text-secondary-900 dark:text-neutral-0">
+                {row.name}
+              </span>
+              <span className="shrink-0 text-right leading-none">
+                <span className="block text-lg font-semibold tabular-nums text-secondary-900 dark:text-neutral-0">
+                  {row.points}
+                </span>
+                <span className="block text-[10px] font-semibold uppercase tracking-wide text-secondary-500 dark:text-secondary-400">
+                  pts
+                </span>
+              </span>
+            </div>
+            <div className="mt-sm grid grid-cols-4 gap-xs">
+              {STAT_COLUMNS.map((col) => (
+                <div
+                  key={col.key}
+                  className="rounded-base bg-secondary-50 dark:bg-secondary-800 px-xs py-xs text-center"
+                >
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-secondary-500 dark:text-secondary-400">
+                    {col.short}
+                  </div>
+                  <div className="text-sm font-semibold tabular-nums text-secondary-900 dark:text-neutral-0">
+                    {row[col.key] as number}
+                  </div>
                 </div>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {/* Desktop (sm and up): the bordered standings table. */}
+      <div className="hidden sm:block overflow-x-auto rounded-lg border border-secondary-200 dark:border-secondary-700">
+        <table className="min-w-full border-collapse bg-neutral-0 dark:bg-secondary-900">
+          <thead>
+            <tr className="bg-secondary-50 dark:bg-secondary-800">
+              <th scope="col" className={`${HEADER_CELL} text-center`}>
+                #
               </th>
-              <td className={`${BODY_CELL} text-center font-semibold tabular-nums`}>
-                {row.points}
-              </td>
-              <td className={`${BODY_CELL} text-center tabular-nums`}>{row.wins_correct}</td>
-              <td className={`${BODY_CELL} text-center tabular-nums`}>{row.losses}</td>
-              <td className={`${BODY_CELL} text-center tabular-nums`}>{row.draws_correct}</td>
-              <td className={`${BODY_CELL} text-center tabular-nums`}>{row.draws_incorrect}</td>
+              <th scope="col" className={HEADER_CELL}>
+                Member
+              </th>
+              <th scope="col" className={`${HEADER_CELL} text-center`}>
+                Points
+              </th>
+              {STAT_COLUMNS.map((col) => (
+                <th key={col.key} scope="col" className={`${HEADER_CELL} text-center`}>
+                  {col.label}
+                </th>
+              ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr key={row.memberId}>
+                <td className={`${BODY_CELL} text-center font-medium text-secondary-500 dark:text-secondary-400 tabular-nums`}>
+                  {index + 1}
+                </td>
+                <th scope="row" className={`${BODY_CELL} text-left font-medium`}>
+                  <div className="flex items-center gap-xs">
+                    <Avatar name={row.name} pictureUrl={row.pictureUrl} variant="md" />
+                    <span>{row.name}</span>
+                  </div>
+                </th>
+                <td className={`${BODY_CELL} text-center font-semibold tabular-nums`}>
+                  {row.points}
+                </td>
+                {STAT_COLUMNS.map((col) => (
+                  <td key={col.key} className={`${BODY_CELL} text-center tabular-nums`}>
+                    {row[col.key] as number}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -156,6 +156,12 @@ export interface MatchPick {
 export interface TournamentLeaderboardRow {
   memberId: string;
   name: string;
+  /**
+   * Member's profile picture URL. Supplied by the backend leaderboard payload
+   * (mapped from users.picture_url); null when the member has no picture, in
+   * which case Avatar falls back to initials.
+   */
+  pictureUrl?: string | null;
   points: number;
   wins_correct: number;
   losses: number;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -150,18 +150,27 @@ export interface MatchPick {
   pickedResult: MatchPickResult;
 }
 
-// One row of the tournament leaderboard. Count fields are snake_case to match
-// the backend leaderboard payload (see worldcup-picks-route.test.js); these are
-// the four tiebreaker columns rendered after points.
+// One row of the tournament leaderboard. The shape mirrors the backend
+// leaderboard payload exactly (see worldCupPicks.js GET .../world-cup/leaderboard
+// and worldcup-picks-route.test.js): the member is keyed by `userId` (not a
+// separate memberId), `rank`/`tied` carry the backend's authoritative tiebreaker
+// resolution, and the count fields stay snake_case to match the wire format.
+// Keeping the type faithful to the payload lets TypeScript catch real contract
+// drift instead of hiding it.
 export interface TournamentLeaderboardRow {
-  memberId: string;
+  /** Backend user id; used as the row key. Mapped from users.id. */
+  userId: number;
   name: string;
   /**
-   * Member's profile picture URL. Supplied by the backend leaderboard payload
-   * (mapped from users.picture_url); null when the member has no picture, in
-   * which case Avatar falls back to initials.
+   * Member's profile picture URL. Always present in the payload (mapped from
+   * users.picture_url); null when the member has no picture, in which case
+   * Avatar falls back to initials.
    */
-  pictureUrl?: string | null;
+  pictureUrl: string | null;
+  /** 1-based standing from the backend comparator. */
+  rank: number;
+  /** True when this member shares its rank with an adjacent member. */
+  tied: boolean;
   points: number;
   wins_correct: number;
   losses: number;

--- a/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import WorldCupLeaderboardTab from './WorldCupLeaderboardTab';
 import type { TournamentLeaderboardRow } from '../../lib/types';
@@ -43,9 +43,11 @@ describe('WorldCupLeaderboardTab', () => {
     render(<WorldCupLeaderboardTab identifier={identifier} />);
 
     expect(mockGetWorldCupLeaderboard).toHaveBeenCalledWith(identifier);
-    expect(await screen.findByRole('table')).toBeInTheDocument();
-    expect(screen.getByText('Alice')).toBeInTheDocument();
-    expect(screen.getByText('Bob')).toBeInTheDocument();
+    // Names render in both the desktop table and the mobile list, so scope the
+    // lookup to the table to keep the assertion unambiguous.
+    const table = await screen.findByRole('table');
+    expect(within(table).getByText('Alice')).toBeInTheDocument();
+    expect(within(table).getByText('Bob')).toBeInTheDocument();
   });
 
   it('renders bare — no card wrapper and no duplicate "Leaderboard" heading', async () => {

--- a/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
@@ -15,8 +15,11 @@ const identifier = 'wc-group';
 
 const rows: TournamentLeaderboardRow[] = [
   {
-    memberId: 'm1',
+    userId: 1,
     name: 'Alice',
+    pictureUrl: null,
+    rank: 1,
+    tied: false,
     points: 12,
     wins_correct: 4,
     losses: 1,
@@ -24,8 +27,11 @@ const rows: TournamentLeaderboardRow[] = [
     draws_incorrect: 1,
   },
   {
-    memberId: 'm2',
+    userId: 2,
     name: 'Bob',
+    pictureUrl: null,
+    rank: 2,
+    tied: false,
     points: 7,
     wins_correct: 2,
     losses: 2,

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import GroupDetailsPage from './GroupDetailsPage';
@@ -263,9 +263,11 @@ describe('GroupDetailsPage', () => {
       expect(mockGetWorldCupLeaderboard).toHaveBeenCalledWith('sunday-squad');
       expect(screen.queryByText(/Leaderboard coming soon/i)).not.toBeInTheDocument();
       // The tournament table surfaces the tiebreaker columns and the member row.
+      // (The member name renders in both the desktop table and the mobile list,
+      // so scope the name lookup to the table.)
       expect(await screen.findByText('Wins Correct')).toBeInTheDocument();
       expect(screen.getByText('Draws Incorrect')).toBeInTheDocument();
-      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(within(screen.getByRole('table')).getByText('Alice')).toBeInTheDocument();
     });
 
     it('embeds the World Cup pick-making surface on the Picks tab', async () => {

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -244,8 +244,11 @@ describe('GroupDetailsPage', () => {
       mockGetWorldCupLeaderboard.mockResolvedValue({
         leaderboard: [
           {
-            memberId: 'm1',
+            userId: 1,
             name: 'Alice',
+            pictureUrl: null,
+            rank: 1,
+            tied: false,
             points: 12,
             wins_correct: 4,
             losses: 1,

--- a/frontend/tests/e2e/group-leaderboard-mobile-renders.spec.ts
+++ b/frontend/tests/e2e/group-leaderboard-mobile-renders.spec.ts
@@ -1,14 +1,16 @@
 import { test, expect } from '@playwright/test'
 
-// A world_cup_2026 group's Leaderboard tab fetches
-// GET /api/picks/group/<id>/world-cup/leaderboard and renders the
-// TournamentLeaderboard table with one row per member, in the order the
-// backend returns (the API owns the tiebreaker comparator). We seed a valid,
-// far-future JWT-shaped accessToken (same pattern as the other authed specs)
-// and stub the group + leaderboard endpoints so the flow never reaches a real
-// backend. The leaderboard is the group page's default tab, so landing on
-// /group-details renders it without a tab click.
-test('world cup group leaderboard tab renders member standings', async ({ page }) => {
+// On a phone-width viewport the World Cup leaderboard drops the bordered table
+// "card" (which forced horizontal scrolling and clipped columns) in favor of a
+// card-free stacked list: one entry per member with rank + avatar + name +
+// emphasized points, and the four tiebreakers below as a 4-up stat-chip grid.
+// The desktop <table> is display:none at this width, and the page must not
+// scroll horizontally. We also prove the member avatar loads (the photo, not
+// the initials fallback). Same auth/stub pattern as the desktop spec.
+test('world cup leaderboard renders a card-free stat grid on mobile', async ({ page }) => {
+  // Phone-width viewport — below the `sm` (640px) breakpoint.
+  await page.setViewportSize({ width: 390, height: 844 })
+
   // Visit the app first so localStorage is writable for this origin.
   await page.goto('/login')
 
@@ -28,8 +30,7 @@ test('world cup group leaderboard tab renders member standings', async ({ page }
   // resolves to an empty object so the test can never reach a real backend.
   await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
 
-  // Serve a real 1x1 PNG for the avatar URL so the <img> actually loads (and so
-  // we can prove the picture, not the initials fallback, is what renders).
+  // Serve a real 1x1 PNG for the avatar URL so the <img> actually loads.
   await page.route('**/ada.png*', (route) =>
     route.fulfill({
       status: 200,
@@ -41,10 +42,8 @@ test('world cup group leaderboard tab renders member standings', async ({ page }
     }),
   )
 
-  // Leaderboard endpoint: two members, already ordered by the backend
-  // comparator. The shape mirrors the live route's row payload. Ada carries a
-  // pictureUrl so the row avatar renders the photo (regression guard: the
-  // leaderboard used to drop pictureUrl and always show initials).
+  // Leaderboard endpoint: two members. Ada carries a pictureUrl so her row
+  // avatar renders the photo. Values are distinct so each can be located.
   await page.route('**/api/picks/group/**/world-cup/leaderboard', async (route) => {
     await route.fulfill({
       status: 200,
@@ -80,10 +79,7 @@ test('world cup group leaderboard tab renders member standings', async ({ page }
     })
   })
 
-  // Group detail mount fans out to getGroup / getMembers / getMessages. getGroup
-  // must return pool_type='world_cup_2026' so the Leaderboard tab renders the
-  // tournament variant; members/messages return arrays (the catch-all's {}
-  // would break their `.map`).
+  // Group detail mount fans out to getGroup / getMembers / getMessages.
   await page.route('**/api/groups/**', async (route) => {
     const url = route.request().url()
     if (url.includes('/members') || url.includes('/messages')) {
@@ -105,32 +101,36 @@ test('world cup group leaderboard tab renders member standings', async ({ page }
   })
 
   await page.goto('/group-details?group=wc-group')
-
-  // The detail page resolves, lands on the Leaderboard tab, and renders the
-  // tournament table: member rows plus the four tiebreaker column headers.
   await expect(page.getByRole('heading', { name: 'World Cup Squad' })).toBeVisible()
 
-  // The tab itself is the only "Leaderboard" label — the body renders the table
-  // bare, with no card wrapper repeating the heading.
-  await expect(page.getByRole('tab', { name: 'Leaderboard' })).toBeVisible()
-  await expect(page.getByRole('heading', { name: 'Leaderboard' })).toHaveCount(0)
+  // The mobile stacked list is visible; the desktop table is hidden at this
+  // viewport (it carries `hidden sm:block`).
+  const list = page.getByRole('list')
+  await expect(list).toBeVisible()
+  await expect(page.getByRole('table')).toBeHidden()
 
-  await expect(page.getByRole('columnheader', { name: 'Points' })).toBeVisible()
-  await expect(page.getByRole('columnheader', { name: 'Wins Correct' })).toBeVisible()
+  // One list item per member, names visible.
+  await expect(list.getByRole('listitem')).toHaveCount(2)
+  await expect(list.getByText('Ada Lovelace')).toBeVisible()
+  await expect(list.getByText('Grace Hopper')).toBeVisible()
 
-  await expect(page.getByRole('rowheader', { name: /Ada Lovelace/ })).toBeVisible()
-  await expect(page.getByRole('rowheader', { name: /Grace Hopper/ })).toBeVisible()
+  // The stat-chip grid surfaces the tiebreakers with their short labels.
+  await expect(list.getByText('Wins').first()).toBeVisible()
+  await expect(list.getByText('Losses').first()).toBeVisible()
+  // Points emphasis: the "pts" label appears once per member.
+  await expect(list.getByText('pts').first()).toBeVisible()
 
-  // Standings order is the backend's: Ada (5 pts) above Grace (0 pts).
-  const rowheaders = page.locator('tbody th[scope="row"]')
-  await expect(rowheaders.first()).toContainText('Ada Lovelace')
-  await expect(rowheaders.last()).toContainText('Grace Hopper')
-
-  // Ada's row renders her photo (not initials): the table avatar <img> is
-  // visible and the served PNG decoded (naturalWidth > 0).
-  const adaAvatar = page.locator('table img[alt="Ada Lovelace"]')
+  // Ada's avatar is her photo, not initials: the list <img> is visible and the
+  // served PNG decoded (naturalWidth > 0).
+  const adaAvatar = list.getByRole('img', { name: 'Ada Lovelace' })
   await expect(adaAvatar).toBeVisible()
   await expect
     .poll(() => adaAvatar.evaluate((img: HTMLImageElement) => img.naturalWidth))
     .toBeGreaterThan(0)
+
+  // The mobile layout must not introduce horizontal scrolling.
+  const overflowsX = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  )
+  expect(overflowsX).toBe(false)
 })

--- a/frontend/tests/e2e/group-leaderboard-mobile-renders.spec.ts
+++ b/frontend/tests/e2e/group-leaderboard-mobile-renders.spec.ts
@@ -128,9 +128,11 @@ test('world cup leaderboard renders a card-free stat grid on mobile', async ({ p
     .poll(() => adaAvatar.evaluate((img: HTMLImageElement) => img.naturalWidth))
     .toBeGreaterThan(0)
 
-  // The mobile layout must not introduce horizontal scrolling.
-  const overflowsX = await page.evaluate(
-    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  // The mobile layout must not introduce horizontal scrolling. Allow a 1px
+  // tolerance for subpixel rounding (scrollWidth can exceed clientWidth by <1px
+  // on some platforms without any real overflow).
+  const overflowX = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
   )
-  expect(overflowsX).toBe(false)
+  expect(overflowX).toBeLessThanOrEqual(1)
 })


### PR DESCRIPTION
Fixes two issues with the World Cup group leaderboard, in one PR.

## 1. Avatars now load on the leaderboard (and everywhere)
The leaderboard rendered `<Avatar name={row.name} variant="md" />` **without** `pictureUrl`, so it always fell back to initials — even though the backend leaderboard payload already returns each member's `pictureUrl`. Settings and Chat already passed the picture through; only the leaderboard dropped it.

- Added `pictureUrl` to `TournamentLeaderboardRow` and threaded it into `Avatar` in both layouts.
- Audited every other `Avatar` call site (Settings, Chat, Navigation, Profile, Invite, GroupPicks/Picks, GroupCard) — all already pass the picture, and the mounted `groups.js` `/messages` route returns `authorPictureUrl`, so chat was already wired correctly end-to-end.

## 2. Mobile leaderboard is now card-free (no horizontal scroll)
On phones the standings table sat inside a bordered, horizontally-scrolling card that clipped columns (`LOSSE…`). Below the `sm` breakpoint it now renders as a **card-free stacked list** — rank + avatar + name + emphasized points, with the four tiebreakers as a 4-up **stat-chip grid** (Wins / Losses / D✓ / D✗). Desktop keeps the existing table unchanged. The two layouts are switched purely with Tailwind responsive utilities (`sm:hidden` / `hidden sm:block`) — no JS, no window measurement, so it stays SSR- and test-stable.

```
MOBILE  (no card · hairline divider between members)

 1  (DO) David Okun            42 pts
   ┌──────┬──────┬──────┬──────┐
   │ WINS │ LOSS │ D✓   │ D✗   │
   │  11  │  3   │  5   │  2   │
   └──────┴──────┴──────┴──────┘
```

## Tests
- **Unit:** picture pass-through (img in both layouts) + initials fallback; mobile stat-grid values/order; card-free assertion; both desktop-table and mobile-list scoped queries. Updated `WorldCupLeaderboardTab` / `GroupDetailsPage` tests to scope name lookups per-layout (names now render in both). Full suite: 523 passing.
- **E2e:** new mobile spec (390px viewport asserts the card-free grid is shown, the desktop table is hidden, the avatar photo decodes, and the page does not scroll horizontally) + an avatar-load assertion added to the desktop leaderboard spec. Full e2e suite: 28 passing.

https://claude.ai/code/session_018nfRm3DD6tbUMQMpcs4DmS

---
_Generated by [Claude Code](https://claude.ai/code/session_018nfRm3DD6tbUMQMpcs4DmS)_