### PR TITLE
Pin @playwright/test to an exact version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "verify:coverage": "node scripts/check-page-spec-coverage.mjs"
   },
   "devDependencies": {
-    "@playwright/test": "^1",
+    "@playwright/test": "1.58.2",
     "@tailwindcss/typography": "0.5.16",
     "@testing-library/jest-dom": "^6",
     "@testing-library/react": "^16",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@playwright/test':
-        specifier: ^1
+        specifier: 1.58.2
         version: 1.58.2
       '@tailwindcss/typography':
         specifier: 0.5.16


### PR DESCRIPTION
Follow-up to #103.

## Problem
`frontend/package.json` declared the Playwright dev dependency as:

```json
"@playwright/test": "^1"
```

`^1` lets **any** `1.x` release resolve whenever the lockfile is regenerated. Playwright is unusual in that each package version is coupled to a specific bundled browser build — the CI step `playwright install --with-deps chromium` fetches the chromium revision that the resolved Playwright version demands. So a silent minor bump (e.g. `1.58 → 1.6x`) quietly changes the required browser revision, creating drift between `package.json`, the lockfile, and any environment that pre-bakes a browser image. (This is exactly the mismatch I hit while running the #103 e2e suite locally — the lockfile resolved 1.58.2 while the sandbox had a 1.56.x browser baked in.)

CI itself is unaffected today because it installs the browser fresh each run — this change is about **determinism and intent**, removing the loose range so the Playwright/browser pairing is explicit.

## Change
- Pin `@playwright/test` to `1.58.2` — **the exact version already resolved in the lockfile**, so nothing actually upgrades or downgrades.
- Only the lockfile `specifier:` field changes (`^1` → `1.58.2`); the resolved `version: 1.58.2` is untouched, the lockfile stays `lockfileVersion: 9.0`, and the diff is two lines.

## Verification
- `pnpm install --frozen-lockfile` passes under **pnpm 9** (the version CI uses) — lockfile validation is satisfied with no churn.
- `tsc --noEmit` clean; **523 unit tests pass**.
- E2e specs are byte-for-byte unchanged from `main` (already green in CI); CI downloads the matching chromium for the pinned version.

https://claude.ai/code/session_018nfRm3DD6tbUMQMpcs4DmS

---
_Generated by [Claude Code](https://claude.ai/code/session_018nfRm3DD6tbUMQMpcs4DmS)_