### PR TITLE
Remove member email addresses from group settings view

### DIFF
--- a/frontend/src/pages/GroupDetails/SettingsTab.tsx
+++ b/frontend/src/pages/GroupDetails/SettingsTab.tsx
@@ -101,16 +101,13 @@ export default function SettingsTab(props: SettingsTabProps) {
             {members.map(member => (
               <div key={member.id} className='flex items-center gap-md'>
                 <Avatar name={member.name} pictureUrl={member.pictureUrl} />
-                <div className='min-w-0 flex-1'>
-                  <div className='flex items-center gap-md'>
-                    <span className='font-medium'>{member.name}</span>
-                    {member.isOwner && (
-                      <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800'>
-                        Owner
-                      </span>
-                    )}
-                  </div>
-                  <p className='text-sm text-secondary truncate'>{member.email}</p>
+                <div className='min-w-0 flex-1 flex items-center gap-md'>
+                  <span className='font-medium'>{member.name}</span>
+                  {member.isOwner && (
+                    <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800'>
+                      Owner
+                    </span>
+                  )}
                 </div>
                 <span className='text-xs text-secondary whitespace-nowrap'>
                   Joined {new Date(member.joinedAt).toLocaleDateString()}

--- a/frontend/tests/e2e/group-settings-renders.spec.ts
+++ b/frontend/tests/e2e/group-settings-renders.spec.ts
@@ -80,8 +80,6 @@ test('group settings tab renders the member roster outside a card', async ({ pag
   // Enter the Settings tab: the roster, invite, and manage sections render.
   await page.getByRole('tab', { name: 'Settings' }).click()
   await expect(page.getByRole('heading', { name: 'Members' })).toBeVisible()
-  await expect(page.getByText('ada@example.com')).toBeVisible()
-  await expect(page.getByText('grace@example.com')).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Invite Link' })).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Manage Group' })).toBeVisible()
 


### PR DESCRIPTION
## Summary

- Removes member email addresses from the group Settings tab member roster — displaying other members' emails is a privacy/safety concern
- Flattens the name row layout so the member name (and Owner badge) remains vertically centred with the avatar now that the two-line stacked layout is gone
- Updates the e2e test to remove assertions that email addresses are visible

## Test plan

- [ ] Open a group's Settings tab and confirm member emails are no longer shown
- [ ] Confirm member names and Owner badges still display and are vertically centred with their avatars
- [ ] Confirm the e2e test `group-settings-renders` still passes

https://claude.ai/code/session_01HJg6ad4pPoNEb5zbjtzrRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJg6ad4pPoNEb5zbjtzrRj)_