### PR TITLE
Retry frontend Vercel deploy on transient upload errors

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -38,8 +38,28 @@ jobs:
     - name: Deploy to Vercel
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       working-directory: ./frontend
-      run: pnpm dlx vercel --prod --token ${{ secrets.VERCEL_TOKEN }}
+      # Retry the deploy: the Vercel upload API intermittently returns a non-JSON
+      # 5xx body (e.g. "Internal Server Error"), which the CLI surfaces as
+      # "FetchError: invalid json response body ... Unexpected token I in JSON at
+      # position 0" and exits 1 — failing an otherwise-healthy build. Retry up to
+      # 3 times with backoff so a transient blip no longer sinks the whole deploy.
+      run: |
+        for attempt in 1 2 3; do
+          echo "::group::Vercel deploy attempt $attempt"
+          if pnpm dlx vercel --prod --token "$VERCEL_TOKEN"; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "Deploy attempt $attempt failed."
+          if [ "$attempt" -lt 3 ]; then
+            sleep $((attempt * 10))
+          fi
+        done
+        echo "::error::Vercel deploy failed after 3 attempts."
+        exit 1
       env:
+        VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
         VERCEL_PROJECT_ID: ${{ secrets.VERCEL_FRONTEND_PROJECT_ID }}
         VITE_API_URL: https://api.confidence-picks.com


### PR DESCRIPTION
## Why

The frontend deploy for the #106 merge failed **after a clean build and a 100% artifact upload**, at the Vercel upload step:

```
Error: FetchError: invalid json response body at
https://api.vercel.com/v2/files?teamId=*** reason: Unexpected token I in JSON at position 0
```

Vercel's `/v2/files` endpoint intermittently returns a non-JSON 5xx body (e.g. `Internal Server Error`), which the CLI can't parse and exits 1 — sinking an otherwise-healthy deploy. The workflow had no retry, so a single transient blip failed the whole job.

## What

- Wrap the `vercel --prod` call in a **3-attempt retry with backoff** (10s, 20s). A transient upload error now retries instead of failing the deploy; a genuine failure still exits 1 after 3 attempts with a clear `::error::`.
- Move the Vercel token into a `VERCEL_TOKEN` **env var** instead of interpolating the secret directly into the `run:` command, so it isn't embedded in the logged command line.

No behavior change on a healthy deploy — it succeeds on the first attempt exactly as before.

https://claude.ai/code/session_017JMPMG7psRymSDAC7bCD6i

---
_Generated by [Claude Code](https://claude.ai/code/session_017JMPMG7psRymSDAC7bCD6i)_