### PR TITLE
Verify hardened frontend deploy pipeline (no-op)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Deploy pipeline note: the Vercel deploy step retries transient upload errors (see .github/workflows/deploy-frontend.yml). -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Live-verification of PR #107: a no-op HTML comment in `frontend/index.html` so this commit lands under the deploy workflow's `frontend/**` path filter, triggering a real Vercel deploy that exercises the new 3-attempt retry step end-to-end.

No functional change — the comment is invisible in the rendered page.

https://claude.ai/code/session_017JMPMG7psRymSDAC7bCD6i

---
_Generated by [Claude Code](https://claude.ai/code/session_017JMPMG7psRymSDAC7bCD6i)_