### PR TITLE
Preserve invite link through the sign-in round-trip

### DIFF
--- a/frontend/src/lib/postLoginRedirect.test.ts
+++ b/frontend/src/lib/postLoginRedirect.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  POST_LOGIN_REDIRECT_KEY,
+  safeRedirectPath,
+  stashPostLoginRedirect,
+  consumePostLoginRedirect,
+} from './postLoginRedirect';
+
+describe('safeRedirectPath', () => {
+  it('accepts an in-app absolute path', () => {
+    expect(safeRedirectPath('/invite/tok-123')).toBe('/invite/tok-123');
+    expect(safeRedirectPath('/groups')).toBe('/groups');
+  });
+
+  it('decodes percent-encoded paths', () => {
+    expect(safeRedirectPath('%2Finvite%2Ftok-123')).toBe('/invite/tok-123');
+  });
+
+  it('returns null for empty / missing values', () => {
+    expect(safeRedirectPath(null)).toBeNull();
+    expect(safeRedirectPath(undefined)).toBeNull();
+    expect(safeRedirectPath('')).toBeNull();
+  });
+
+  it('rejects absolute URLs to other origins (open-redirect guard)', () => {
+    expect(safeRedirectPath('https://evil.com')).toBeNull();
+    expect(safeRedirectPath('http://evil.com/invite/x')).toBeNull();
+  });
+
+  it('rejects protocol-relative and back-slash authority tricks', () => {
+    expect(safeRedirectPath('//evil.com')).toBeNull();
+    expect(safeRedirectPath('/\\evil.com')).toBeNull();
+  });
+
+  it('rejects relative paths that do not start with a single slash', () => {
+    expect(safeRedirectPath('invite/tok-123')).toBeNull();
+  });
+
+  it('returns null on malformed percent-encoding', () => {
+    expect(safeRedirectPath('%E0%A4%A')).toBeNull();
+  });
+});
+
+describe('sessionStorage round-trip', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('stashes a safe path and consumes it once', () => {
+    stashPostLoginRedirect('/invite/tok-123');
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBe('/invite/tok-123');
+
+    expect(consumePostLoginRedirect()).toBe('/invite/tok-123');
+    // Consuming clears it so a stale redirect can't hijack a later sign-in.
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+    expect(consumePostLoginRedirect()).toBeNull();
+  });
+
+  it('does not stash an unsafe path', () => {
+    stashPostLoginRedirect('https://evil.com');
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+  });
+
+  it('does not stash a null/undefined target', () => {
+    stashPostLoginRedirect(null);
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+  });
+
+  it('swallows sessionStorage write failures (private mode, etc.)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(() => stashPostLoginRedirect('/invite/tok-123')).not.toThrow();
+  });
+
+  it('returns null when sessionStorage read throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(consumePostLoginRedirect()).toBeNull();
+  });
+});

--- a/frontend/src/lib/postLoginRedirect.ts
+++ b/frontend/src/lib/postLoginRedirect.ts
@@ -1,0 +1,59 @@
+// Post-login redirect plumbing, shared by LoginPage (writer) and AuthCallback
+// (reader). A guarded link — e.g. InvitePage's "Sign in to join" CTA — routes
+// the signed-out user to `/login?next=/invite/:token`. LoginPage stashes that
+// target in sessionStorage *before* leaving for the OAuth provider; sessionStorage
+// survives the full cross-origin OAuth round-trip (it persists for the lifetime
+// of the tab), so AuthCallback can read it back and land the now-authenticated
+// user on the page they originally wanted instead of the home page.
+
+export const POST_LOGIN_REDIRECT_KEY = 'postLoginRedirect';
+
+// Only same-origin, absolute, non-protocol-relative paths are honored. This
+// blocks open-redirect attacks where a crafted `?next=https://evil.com` (or the
+// protocol-relative `//evil.com`, or a back-slash variant some browsers
+// normalize to `//`) would otherwise bounce a freshly-authenticated user to an
+// attacker-controlled origin. Anything that isn't a clean in-app path collapses
+// to null so callers fall back to '/'.
+export function safeRedirectPath(value: string | null | undefined): string | null {
+  if (!value) return null;
+
+  let decoded = value;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    // Malformed percent-encoding — treat as untrusted and drop it.
+    return null;
+  }
+
+  // Must be an absolute in-app path ("/groups", "/invite/abc"). Reject anything
+  // that starts a new authority: "//host", "/\\host", or a full URL with scheme.
+  if (!decoded.startsWith('/')) return null;
+  if (decoded.startsWith('//') || decoded.startsWith('/\\')) return null;
+
+  return decoded;
+}
+
+// Best-effort write: a blocked sessionStorage (private mode, etc.) must never
+// stop sign-in. The value is validated first so we never persist a hostile path.
+export function stashPostLoginRedirect(value: string | null | undefined): void {
+  const safe = safeRedirectPath(value);
+  if (!safe) return;
+  try {
+    sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, safe);
+  } catch {
+    /* sessionStorage unavailable — proceed without it */
+  }
+}
+
+// Reads and clears the stashed target in one shot so a stale redirect can't
+// hijack a later, unrelated sign-in. Returns a validated path or null.
+export function consumePostLoginRedirect(): string | null {
+  let raw: string | null = null;
+  try {
+    raw = sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY);
+    sessionStorage.removeItem(POST_LOGIN_REDIRECT_KEY);
+  } catch {
+    return null;
+  }
+  return safeRedirectPath(raw);
+}

--- a/frontend/src/pages/AuthCallback.test.tsx
+++ b/frontend/src/pages/AuthCallback.test.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import AuthCallback from './AuthCallback';
+import { POST_LOGIN_REDIRECT_KEY } from '../lib/postLoginRedirect';
 
 // Mock AuthService so the test is not coupled to localStorage or the network.
 vi.mock('../lib/authService.js', () => ({
@@ -40,6 +41,7 @@ const testUser = {
 describe('AuthCallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
   });
 
   it('persists tokens, hydrates the user, and redirects home on success', async () => {
@@ -56,6 +58,44 @@ describe('AuthCallback', () => {
 
     expect(mockSetTokens).toHaveBeenCalledWith('A', 'B');
     expect(mockSetAuthUser).toHaveBeenCalledWith(testUser);
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  // The core fix: a user who started from a guarded invite link must land back
+  // on the invite (so it reappears to accept/reject) rather than the home page.
+  // LoginPage stashed the destination in sessionStorage before the OAuth hop.
+  it('returns the user to the stashed post-login redirect after a successful sign-in', async () => {
+    sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, '/invite/tok-123');
+    window.history.pushState({}, '', '/auth/callback?token=A&refresh=B');
+    mockGetCurrentUser.mockResolvedValue(testUser as any);
+
+    render(
+      <MemoryRouter>
+        <AuthCallback />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+
+    expect(mockSetAuthUser).toHaveBeenCalledWith(testUser);
+    expect(mockNavigate).toHaveBeenCalledWith('/invite/tok-123', { replace: true });
+    // The stash is consumed so a later, unrelated sign-in won't be hijacked.
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+  });
+
+  it('ignores an unsafe stashed redirect and falls back home (open-redirect guard)', async () => {
+    sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, 'https://evil.com');
+    window.history.pushState({}, '', '/auth/callback?token=A&refresh=B');
+    mockGetCurrentUser.mockResolvedValue(testUser as any);
+
+    render(
+      <MemoryRouter>
+        <AuthCallback />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
   });
 

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import AuthService from '../lib/authService.js';
 import { useAuth, type User } from '../contexts/AuthContext';
+import { consumePostLoginRedirect } from '../lib/postLoginRedirect';
 
 export default function AuthCallback() {
   const navigate = useNavigate();
@@ -40,7 +41,12 @@ export default function AuthCallback() {
           // context's User requires it. Mirror the cast already used in
           // AuthContext.tsx where getUser() is widened to User.
           setAuthUser(user as User);
-          navigate('/', { replace: true });
+          // If the user arrived via a guarded link (e.g. an invite), LoginPage
+          // stashed where they were headed before the OAuth round-trip. Return
+          // them there so the invite reappears for them to accept; otherwise
+          // fall back to the home page.
+          const redirect = consumePostLoginRedirect();
+          navigate(redirect ?? '/', { replace: true });
         } else {
           navigate('/login', {
             replace: true,

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import LoginPage from './LoginPage';
+import { POST_LOGIN_REDIRECT_KEY } from '../lib/postLoginRedirect';
 
 // Mock AuthService so the test is not coupled to the network or window.location
 // redirect. authService.js exports `default AuthService`, so the mock shape
@@ -13,17 +14,26 @@ vi.mock('../lib/authService.js', () => ({
   },
 }));
 
-// Stub useAuth so LoginPage renders without the full provider stack. Reporting
-// not-authenticated keeps the redirect-home effect inert for these assertions.
+// Stub useAuth so LoginPage renders without the full provider stack. Default to
+// not-authenticated so the redirect-home effect stays inert; individual tests
+// override mockIsAuthenticated as needed.
+let mockIsAuthenticated = false;
 vi.mock('../contexts/AuthContext', () => ({
-  useAuth: () => ({ isAuthenticated: false }),
+  useAuth: () => ({ isAuthenticated: mockIsAuthenticated }),
 }));
+
+// Stub useNavigate so the already-authenticated redirect is observable.
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 import AuthService from '../lib/authService.js';
 
-function renderLoginPage() {
+function renderLoginPage(initialEntry = '/login') {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <LoginPage />
     </MemoryRouter>
   );
@@ -32,6 +42,8 @@ function renderLoginPage() {
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsAuthenticated = false;
+    sessionStorage.clear();
   });
 
   it('renders the Google sign in button', () => {
@@ -48,6 +60,37 @@ describe('LoginPage', () => {
     renderLoginPage();
     fireEvent.click(screen.getByRole('button', { name: /Google/ }));
     expect(vi.mocked(AuthService.login)).toHaveBeenCalledTimes(1);
+  });
+
+  it('stashes the ?next destination before starting Google OAuth so the callback can return there', () => {
+    renderLoginPage(`/login?next=${encodeURIComponent('/invite/tok-123')}`);
+    fireEvent.click(screen.getByRole('button', { name: /Google/ }));
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBe('/invite/tok-123');
+    expect(vi.mocked(AuthService.login)).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the legacy ?redirect alias for the post-login destination', () => {
+    renderLoginPage(`/login?redirect=${encodeURIComponent('/groups')}`);
+    fireEvent.click(screen.getByRole('button', { name: /Google/ }));
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBe('/groups');
+  });
+
+  it('does not stash an off-site ?next (open-redirect guard)', () => {
+    renderLoginPage(`/login?next=${encodeURIComponent('https://evil.com')}`);
+    fireEvent.click(screen.getByRole('button', { name: /Google/ }));
+    expect(sessionStorage.getItem(POST_LOGIN_REDIRECT_KEY)).toBeNull();
+  });
+
+  it('redirects an already-authenticated user to ?next instead of home', () => {
+    mockIsAuthenticated = true;
+    renderLoginPage(`/login?next=${encodeURIComponent('/invite/tok-123')}`);
+    expect(mockNavigate).toHaveBeenCalledWith('/invite/tok-123', { replace: true });
+  });
+
+  it('redirects an already-authenticated user home when no destination is given', () => {
+    mockIsAuthenticated = true;
+    renderLoginPage('/login');
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
   });
 
   it('redirects to the Apple OAuth start when the Apple button is clicked', () => {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,10 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import AuthService from '../lib/authService.js';
 import AppleSignInButton from '../components/AppleSignInButton';
+import {
+  safeRedirectPath,
+  stashPostLoginRedirect,
+} from '../lib/postLoginRedirect';
 
 // Maps the `?error=` code the OAuth callback appends on failure to a friendly
 // message. Unknown codes fall back to a generic line so a new backend error
@@ -24,24 +28,28 @@ export default function LoginPage() {
     ? ERROR_MESSAGES[errorParam] ?? 'An error occurred during authentication.'
     : '';
 
-  // Already signed in? Skip the login screen.
+  // Where a guarded link wants the user to land after sign-in. Guarded CTAs use
+  // `next` (e.g. InvitePage's "Sign in to join" → /login?next=/invite/:token);
+  // `redirect` is accepted as a legacy alias. Validated to an in-app path so a
+  // crafted query can't turn this into an open redirect.
+  const redirectTarget =
+    safeRedirectPath(searchParams.get('next')) ??
+    safeRedirectPath(searchParams.get('redirect'));
+
+  // Already signed in? Skip the login screen — and honor the requested
+  // destination so an authenticated user who opens an invite link still lands
+  // on the invite rather than the home page.
   useEffect(() => {
     if (isAuthenticated) {
-      navigate('/', { replace: true });
+      navigate(redirectTarget ?? '/', { replace: true });
     }
-  }, [isAuthenticated, navigate]);
+  }, [isAuthenticated, navigate, redirectTarget]);
 
   // Stash where the user was headed (if they arrived via a guarded link) so the
   // post-OAuth callback can return them there. Best-effort: a blocked
   // sessionStorage must not stop sign-in.
   function captureRedirect() {
-    const redirect = searchParams.get('redirect');
-    if (!redirect) return;
-    try {
-      sessionStorage.setItem('postLoginRedirect', decodeURIComponent(redirect));
-    } catch {
-      /* sessionStorage unavailable (private mode, etc.) — proceed without it */
-    }
+    stashPostLoginRedirect(redirectTarget);
   }
 
   function handleGoogleSignIn() {

--- a/frontend/tests/e2e/invite-survives-login.spec.ts
+++ b/frontend/tests/e2e/invite-survives-login.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test'
+
+// Regression for the "invite lost after sign-in" bug. A signed-out user who
+// opens an invite link used to lose the invite: clicking "Sign in to join"
+// stashed nothing the callback could read, so after OAuth they were dumped on
+// the home page. This spec drives the whole journey and asserts the invite
+// reappears (ready to accept) once they are authenticated.
+//
+// The OAuth provider round-trip is simulated by fulfilling the backend
+// `/auth/google` navigation with a 302 to `/auth/callback?token=…&refresh=…`,
+// which is exactly the shape the real backend redirects with (see
+// backend/src/routes/auth.js). `/auth/me` is stubbed so AuthCallback can hydrate
+// the user. The literals '/invite', '/login' and '/auth/callback' below are also
+// what scripts/check-page-spec-coverage.mjs scans for to confirm route coverage.
+
+const TOKEN = 'tok-e2e'
+
+const INVITE = {
+  valid: true,
+  alreadyMember: false,
+  group: {
+    identifier: 'cool-group',
+    name: 'Cool Group',
+    description: 'A friendly competition',
+    memberCount: 3,
+    maxMembers: 10,
+    ownerName: 'Ada Lovelace',
+    ownerPictureUrl: '',
+  },
+  invite: {
+    token: TOKEN,
+    expiresAt: '2099-01-01T00:00:00Z',
+    maxUses: 5,
+    uses: 2,
+    remainingUses: 3,
+  },
+}
+
+const USER = {
+  id: 1,
+  email: 'invitee@example.com',
+  name: 'Grace Hopper',
+  pictureUrl: null,
+  provider: 'google',
+}
+
+async function setupMocks(page: import('@playwright/test').Page) {
+  // GET invite details (one path segment after /invites — does not match the
+  // /accept route below, since glob '*' never crosses a slash).
+  await page.route('**/api/invites/*', async (route) => {
+    await route.fulfill({ json: INVITE })
+  })
+
+  // POST accept → tells InvitePage which group to navigate to.
+  await page.route('**/api/invites/*/accept', async (route) => {
+    await route.fulfill({
+      json: { joined: true, alreadyMember: false, groupIdentifier: 'cool-group' },
+    })
+  })
+
+  // AuthCallback hydrates the signed-in user from /auth/me.
+  await page.route('**/auth/me', async (route) => {
+    await route.fulfill({ json: USER })
+  })
+
+  // The OAuth provider round-trip, collapsed into one hop: the real backend
+  // ultimately redirects to /auth/callback?token=…&refresh=… on success.
+  await page.route('**/auth/google', async (route) => {
+    await route.fulfill({
+      status: 302,
+      headers: { location: 'http://localhost:5173/auth/callback?token=A&refresh=B' },
+    })
+  })
+}
+
+test('a signed-out user keeps their invite through the sign-in round-trip', async ({ page }) => {
+  await setupMocks(page)
+
+  // 1. Signed-out visit to the invite link shows the invite with a sign-in CTA.
+  await page.goto(`/invite/${TOKEN}`)
+  await expect(page.getByRole('heading', { name: 'Join Cool Group' })).toBeVisible()
+  const signInCta = page.getByRole('button', { name: 'Sign in to join' })
+  await expect(signInCta).toBeVisible()
+
+  // 2. The CTA routes to /login carrying the invite in ?next.
+  await signInCta.click()
+  await expect(page).toHaveURL(new RegExp(`/login\\?next=${encodeURIComponent(`/invite/${TOKEN}`)}`))
+  await expect(page.getByRole('heading', { name: 'Login' })).toBeVisible()
+
+  // 3. Starting Google OAuth stashes the destination, then the simulated
+  //    provider redirect lands back on /auth/callback and onward.
+  await page.getByRole('button', { name: /Google/ }).click()
+
+  // 4. The invite reappears — now authenticated — ready to accept. THIS is the
+  //    fix: pre-fix the user would have landed on the home page instead.
+  await expect(page).toHaveURL(new RegExp(`/invite/${TOKEN}$`))
+  const acceptBtn = page.getByRole('button', { name: 'Accept Invite' })
+  await expect(acceptBtn).toBeVisible()
+
+  // 5. Accepting the now-preserved invite takes them into the group.
+  await acceptBtn.click()
+  await expect(page).toHaveURL(/\/group-details\?group=cool-group$/)
+})

--- a/frontend/tests/e2e/invite-survives-login.spec.ts
+++ b/frontend/tests/e2e/invite-survives-login.spec.ts
@@ -45,13 +45,22 @@ const USER = {
 }
 
 async function setupMocks(page: import('@playwright/test').Page) {
-  // GET invite details (one path segment after /invites — does not match the
-  // /accept route below, since glob '*' never crosses a slash).
+  // Catch-all so no request escapes to the (absent) real backend — e.g. the
+  // GroupDetailsPage we land on after accepting fires its own /api calls.
+  // Registered first; the specific routes below are registered later and so
+  // take priority (Playwright matches the most-recently-added route first).
+  await page.route('**/api/**', async (route) => {
+    await route.fulfill({ json: {} })
+  })
+
+  // GET invite details.
   await page.route('**/api/invites/*', async (route) => {
     await route.fulfill({ json: INVITE })
   })
 
-  // POST accept → tells InvitePage which group to navigate to.
+  // POST accept → tells InvitePage which group to navigate to. Registered after
+  // the GET route so it wins for the .../accept path regardless of how the glob
+  // '*' treats the slash.
   await page.route('**/api/invites/*/accept', async (route) => {
     await route.fulfill({
       json: { joined: true, alreadyMember: false, groupIdentifier: 'cool-group' },


### PR DESCRIPTION
## Problem

Users reported that clicking an invite link while signed out lets them log in, but **the invite is then lost** — they never get a chance to accept or reject it.

The redirect chain was broken in two places:

1. `InvitePage` routed signed-out users to `/login?next=/invite/:token`.
2. `LoginPage` only read a `redirect` query param (never `next`), so the token was never stashed.
3. `AuthCallback` never read the stash back — it **always** navigated to `/`.

So after OAuth the user landed on the home page and the invite vanished.

## Fix

Wire the chain end to end:

- **New `postLoginRedirect` helper** (`src/lib/postLoginRedirect.ts`): validates a redirect target as a same-origin in-app path — blocking open-redirect via absolute URLs, protocol-relative `//host`, and back-slash authority tricks — and stashes/consumes it in `sessionStorage` (which survives the cross-origin OAuth round-trip). Consuming clears it so a stale redirect can't hijack a later sign-in.
- **`LoginPage`** now captures `next` (with `redirect` kept as a legacy alias) before starting OAuth, and honors it for already-authenticated users too.
- **`AuthCallback`** consumes the stashed destination after a successful sign-in and returns the user there instead of always going home.

Net result: after signing in, the user lands back on `/invite/:token` and the invite reappears, ready to accept or reject.

## Test coverage

**Unit (vitest):**
- `postLoginRedirect.test.ts` — path validation (in-app paths, percent-decoding, open-redirect rejection, malformed encoding) and the sessionStorage stash/consume round-trip incl. private-mode write/read failures.
- `LoginPage.test.tsx` — stashes `?next`, accepts the `?redirect` alias, rejects off-site targets, and redirects an already-authenticated user to `next` (or home when absent).
- `AuthCallback.test.tsx` — returns the user to the stashed redirect on success, clears the stash, and falls back home for an unsafe stashed value.

**E2E (Playwright):** `invite-survives-login.spec.ts` drives the full journey — signed-out invite → "Sign in to join" → `/login?next=…` → simulated OAuth callback → invite reappears → accept → land in the group. The provider round-trip is simulated by fulfilling the backend `/auth/google` navigation with a 302 to `/auth/callback?token=…&refresh=…`, the same shape the real backend redirects with.

Full unit suite passes (558 passing) with coverage thresholds intact. The e2e spec typechecks; it could not be executed in this environment because the Playwright browser CDN is blocked by the network policy, so CI should be the source of truth for the e2e run.

https://claude.ai/code/session_01AzG2iEnsA8GtLZuCsAdWKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzG2iEnsA8GtLZuCsAdWKw)_