### PR TITLE
Restore old groups' picks and scores after the season rollover

### DIFF
--- a/backend/src/models/UserPick.js
+++ b/backend/src/models/UserPick.js
@@ -78,6 +78,21 @@ export class UserPick {
     return rows.map(r => new UserPick(r));
   }
 
+  static async findForGroupWeek({ groupId, season, seasonType, week }) {
+    const q = `SELECT * FROM user_picks WHERE group_id=$1 AND season=$2 AND season_type=$3 AND week=$4`;
+    const { rows } = await pool.query(q, [groupId, season, seasonType, week]);
+    return rows.map(r => new UserPick(r));
+  }
+
+  // Seasons that have any stored pick data for a group, newest first. Lets the
+  // frontend default its season selector to the latest season with history so
+  // old groups stay readable after the calendar rolls into a new season.
+  static async findSeasonsForGroup(groupId) {
+    const q = `SELECT DISTINCT season FROM user_picks WHERE group_id=$1 ORDER BY season DESC`;
+    const { rows } = await pool.query(q, [groupId]);
+    return rows.map(r => r.season);
+  }
+
   static async bulkUpsert({ userId, groupId, season, seasonType, week, picks }) {
     if (!picks || picks.length === 0) return [];
   console.log('[user_picks] bulkUpsert incoming', { userId, groupId, season, seasonType, week, picks });

--- a/backend/src/routes/picks.js
+++ b/backend/src/routes/picks.js
@@ -31,11 +31,13 @@ async function computeClosestWeek(seasonYear, seasonType) {
   return rows[rows.length - 1].week; // all final -> last week (could be 0)
 }
 
+// Pre-game statuses: games in these states are editable and other members'
+// picks on them stay hidden (legacy/alternate spellings included, e.g. NOT_STARTED).
+const PRE_STATUSES = new Set(['SCHEDULED','NOT_STARTED','PRE','PREGAME']);
+
 function deriveGamePickMeta(gameJson, pick) {
   const status = gameJson.status;
-  // Treat legacy/alternate pre-game statuses as editable (e.g., NOT_STARTED)
-  const preStatuses = new Set(['SCHEDULED','NOT_STARTED','PRE','PREGAME']);
-  const lock = !preStatuses.has(status);
+  const lock = !PRE_STATUSES.has(status);
   const inProgress = status === 'IN_PROGRESS';
   return {
     locked: lock,
@@ -43,6 +45,25 @@ function deriveGamePickMeta(gameJson, pick) {
     inProgress,
     final: status === 'FINAL'
   };
+}
+
+// Grade a pick in memory against a FINAL game when no points are stored yet.
+// Mirrors the persisted on-demand scoring above but never writes — used for the
+// group-wide picks payload where another member's pick may predate grading.
+function gradeAgainstFinal(gameJson, pick) {
+  if (pick.points != null || gameJson.status !== 'FINAL' || pick.confidence == null || !pick.pickedTeamId) return pick;
+  let winnerTeamId = null;
+  if (gameJson.homeScore > gameJson.awayScore) winnerTeamId = gameJson.homeTeam.id;
+  else if (gameJson.awayScore > gameJson.homeScore) winnerTeamId = gameJson.awayTeam.id;
+  if (winnerTeamId == null) {
+    pick.points = 0;
+    pick.won = null;
+  } else {
+    const won = String(winnerTeamId) === String(pick.pickedTeamId);
+    pick.won = won;
+    pick.points = won ? pick.confidence : -pick.confidence;
+  }
+  return pick;
 }
 
 /**
@@ -228,8 +249,37 @@ router.get('/:identifier/picks', authenticateToken, async (req, res) => {
     const availableConfidences = Array.from({ length: totalGames }, (_, i) => i + 1).filter(n => !usedConfidences.includes(n));
     const weekPoints = picks.reduce((sum, p) => sum + (p.points || 0), 0);
 
+    // Group-wide picks for the member matrix, keyed by member id. A member's
+    // pick on a game that hasn't kicked off is withheld from everyone but its
+    // owner server-side so picks can't be read off the wire before lockout.
+    // Queried after the persist block above so freshly graded points are read
+    // back; anything still ungraded (e.g. old seasons graded for other members
+    // only) is graded in memory against the FINAL game.
+    const groupPicks = await UserPick.findForGroupWeek({ groupId: group.id, season, seasonType: fetchSeasonType, week: fetchWeek });
+    const gameJsonById = new Map(games.map(g => [g.id, normalizeGame(g)]));
+    const memberPicksMap = new Map();
+    for (const p of groupPicks) {
+      const gameJson = gameJsonById.get(p.gameId);
+      if (!gameJson) continue;
+      if (p.userId !== req.user.id && PRE_STATUSES.has(gameJson.status)) continue;
+      gradeAgainstFinal(gameJson, p);
+      if (!memberPicksMap.has(p.userId)) memberPicksMap.set(p.userId, []);
+      memberPicksMap.get(p.userId).push({
+        gameId: p.gameId,
+        pickedTeamId: p.pickedTeamId,
+        confidence: p.confidence,
+        won: p.won,
+        points: p.points
+      });
+    }
+    const memberPicks = [...memberPicksMap.entries()].map(([memberId, memberPickList]) => ({
+      memberId: String(memberId),
+      picks: memberPickList
+    }));
+
     res.json({
       games: payloadGames,
+      picks: memberPicks,
       availableConfidences,
       totalGames,
       pickedCount: usedConfidences.length,
@@ -256,6 +306,24 @@ router.get('/:identifier/picks/closest', authenticateToken, async (req, res) => 
     if (e.message === 'GROUP_NOT_FOUND') return res.status(404).json({ error: 'Group not found' });
     if (e.message === 'NOT_MEMBER') return res.status(403).json({ error: 'Not a group member' });
     res.status(500).json({ error: 'Failed to compute closest week' });
+  }
+});
+
+// Seasons with stored pick data for this group, newest first. The group page
+// defaults its season selector to the latest entry so groups from prior
+// seasons keep their picks and scores reachable after the calendar rolls into
+// a new (still empty) season.
+router.get('/:identifier/picks/seasons', authenticateToken, async (req, res) => {
+  try {
+    const { identifier } = req.params;
+    const group = await ensureMembership(identifier, req.user.id);
+    const seasons = await UserPick.findSeasonsForGroup(group.id);
+    res.json({ seasons });
+  } catch (e) {
+    if (e.message === 'GROUP_NOT_FOUND') return res.status(404).json({ error: 'Group not found' });
+    if (e.message === 'NOT_MEMBER') return res.status(403).json({ error: 'Not a group member' });
+    console.error('GET picks seasons error', e);
+    res.status(500).json({ error: 'Failed to load seasons' });
   }
 });
 

--- a/backend/tests/picks-seasons-route.test.js
+++ b/backend/tests/picks-seasons-route.test.js
@@ -1,0 +1,192 @@
+import { test, describe, before, after, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import picksRouter from '../src/routes/picks.js';
+import { AuthService } from '../src/services/AuthService.js';
+import { User } from '../src/models/User.js';
+import { Group } from '../src/models/Group.js';
+import { GameService } from '../src/services/GameService.js';
+import { UserPick } from '../src/models/UserPick.js';
+
+// Mounts the NFL picks router on a throwaway app at /api/groups and stubs every
+// collaborator (auth, group lookup, GameService, UserPick) so the route logic is
+// exercised without a live Postgres or ESPN feed — same pattern as
+// worldcup-picks-route.test.js. Covers the two endpoints that restore old
+// groups' history: GET /:identifier/picks/seasons (season discovery for the
+// frontend's default-season logic) and the group-wide `picks` payload on
+// GET /:identifier/picks (the member matrix).
+
+const AUTH_HEADER = { Authorization: 'Bearer test-token' };
+
+const memberGroup = { id: 7, identifier: 'sunday-squad', userRole: 'member' };
+
+function finalGame() {
+  return {
+    id: 101,
+    espnId: 'e101',
+    homeTeam: { id: '1', name: 'Patriots', abbreviation: 'NE' },
+    awayTeam: { id: '2', name: 'Bills', abbreviation: 'BUF' },
+    homeScore: 20,
+    awayScore: 24,
+    status: 'FINAL',
+    gameDate: '2025-09-14T17:00:00.000Z',
+    week: 2,
+    season: 2025,
+    seasonType: 2,
+  };
+}
+
+function scheduledGame() {
+  return {
+    id: 102,
+    espnId: 'e102',
+    homeTeam: { id: '2', name: 'Bills', abbreviation: 'BUF' },
+    awayTeam: { id: '1', name: 'Patriots', abbreviation: 'NE' },
+    homeScore: 0,
+    awayScore: 0,
+    status: 'SCHEDULED',
+    gameDate: '2025-09-21T17:00:00.000Z',
+    week: 2,
+    season: 2025,
+    seasonType: 2,
+  };
+}
+
+describe('NFL picks router — old-season history endpoints', () => {
+  let server;
+  let baseURL;
+
+  before(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/groups', picksRouter);
+    await new Promise((resolve) => {
+      server = app.listen(0, () => {
+        baseURL = `http://localhost:${server.address().port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    mock.method(AuthService, 'verifyAccessToken', () => ({ userId: 1 }));
+    mock.method(User, 'findById', async () => ({ id: 1, name: 'Tester', email: 't@x.io' }));
+    mock.method(UserPick, 'ensureConfidenceIndex', async () => {});
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  describe('GET /:identifier/picks/seasons', () => {
+    test('rejects an unauthenticated request', async () => {
+      const res = await fetch(`${baseURL}/api/groups/sunday-squad/picks/seasons`);
+      assert.strictEqual(res.status, 401);
+    });
+
+    test('rejects a non-member with 403', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ ...memberGroup, userRole: null }));
+      const res = await fetch(`${baseURL}/api/groups/sunday-squad/picks/seasons`, { headers: AUTH_HEADER });
+      assert.strictEqual(res.status, 403);
+    });
+
+    test('404s for an unknown group', async () => {
+      mock.method(Group, 'findByIdentifier', async () => null);
+      const res = await fetch(`${baseURL}/api/groups/nope/picks/seasons`, { headers: AUTH_HEADER });
+      assert.strictEqual(res.status, 404);
+    });
+
+    test('returns the seasons with pick data, newest first', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ ...memberGroup }));
+      mock.method(UserPick, 'findSeasonsForGroup', async (groupId) => {
+        assert.strictEqual(groupId, memberGroup.id);
+        return [2025, 2024];
+      });
+      const res = await fetch(`${baseURL}/api/groups/sunday-squad/picks/seasons`, { headers: AUTH_HEADER });
+      assert.strictEqual(res.status, 200);
+      const body = await res.json();
+      assert.deepStrictEqual(body, { seasons: [2025, 2024] });
+    });
+
+    test('returns an empty list for a group with no picks yet', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ ...memberGroup }));
+      mock.method(UserPick, 'findSeasonsForGroup', async () => []);
+      const res = await fetch(`${baseURL}/api/groups/sunday-squad/picks/seasons`, { headers: AUTH_HEADER });
+      assert.strictEqual(res.status, 200);
+      const body = await res.json();
+      assert.deepStrictEqual(body, { seasons: [] });
+    });
+  });
+
+  describe('GET /:identifier/picks — group-wide member picks payload', () => {
+    test('includes every member\'s picks, withholding unstarted games from non-owners', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ ...memberGroup }));
+      mock.method(GameService, 'getGamesForWeek', async () => [finalGame(), scheduledGame()]);
+      // Requester (user 1) picks: already graded on the FINAL game, plus one on
+      // the SCHEDULED game that must stay visible to its owner.
+      mock.method(UserPick, 'findForUserWeek', async () => [
+        { gameId: 101, pickedTeamId: '2', confidence: 5, won: true, points: 5 },
+        { gameId: 102, pickedTeamId: '1', confidence: 3, won: null, points: null },
+      ]);
+      // Group-wide rows: user 2's FINAL-game pick is ungraded (points null) to
+      // exercise the in-memory grading; their SCHEDULED-game pick must be
+      // withheld from the requesting user.
+      mock.method(UserPick, 'findForGroupWeek', async () => [
+        { userId: 1, gameId: 101, pickedTeamId: '2', confidence: 5, won: true, points: 5 },
+        { userId: 1, gameId: 102, pickedTeamId: '1', confidence: 3, won: null, points: null },
+        { userId: 2, gameId: 101, pickedTeamId: '1', confidence: 7, won: null, points: null },
+        { userId: 2, gameId: 102, pickedTeamId: '2', confidence: 1, won: null, points: null },
+      ]);
+
+      const res = await fetch(
+        `${baseURL}/api/groups/sunday-squad/picks?season=2025&seasonType=2&week=2`,
+        { headers: AUTH_HEADER },
+      );
+      assert.strictEqual(res.status, 200);
+      const body = await res.json();
+
+      assert.ok(Array.isArray(body.picks), 'response carries a member-keyed picks array');
+      const byMember = new Map(body.picks.map((entry) => [entry.memberId, entry.picks]));
+
+      // Requester sees both of their own picks, including the unstarted game.
+      const mine = byMember.get('1');
+      assert.strictEqual(mine.length, 2);
+
+      // The other member's SCHEDULED pick is withheld; only the FINAL game shows.
+      const theirs = byMember.get('2');
+      assert.strictEqual(theirs.length, 1);
+      assert.strictEqual(theirs[0].gameId, 101);
+
+      // Their ungraded FINAL pick was graded in memory: BUF (team 2) won 24-20,
+      // they picked NE (team 1) at confidence 7 -> lost 7 points.
+      assert.strictEqual(theirs[0].won, false);
+      assert.strictEqual(theirs[0].points, -7);
+    });
+
+    test('serves an old season when requested explicitly', async () => {
+      const captured = {};
+      mock.method(Group, 'findByIdentifier', async () => ({ ...memberGroup }));
+      mock.method(GameService, 'getGamesForWeek', async (season, seasonType, week) => {
+        Object.assign(captured, { season, seasonType, week });
+        return [finalGame()];
+      });
+      mock.method(UserPick, 'findForUserWeek', async () => []);
+      mock.method(UserPick, 'findForGroupWeek', async () => []);
+
+      const res = await fetch(
+        `${baseURL}/api/groups/sunday-squad/picks?season=2024&seasonType=2&week=18`,
+        { headers: AUTH_HEADER },
+      );
+      assert.strictEqual(res.status, 200);
+      // The query's season/week flow straight through — nothing pins the fetch
+      // to the current calendar season.
+      assert.deepStrictEqual(captured, { season: 2024, seasonType: 2, week: 18 });
+      const body = await res.json();
+      assert.deepStrictEqual(body.picks, []);
+    });
+  });
+});

--- a/frontend/src/lib/picksService.d.ts
+++ b/frontend/src/lib/picksService.d.ts
@@ -95,3 +95,44 @@ export function savePicks(
   groupIdentifier: string,
   body: SavePicksBody,
 ): Promise<GetPicksResponse>;
+
+/** Response shape of GET /:identifier/picks/seasons — seasons with pick data, newest first. */
+export interface PickSeasonsResponse {
+  seasons: number[];
+}
+
+/**
+ * Fetch the seasons that have stored pick data for the group. The group tabs
+ * default their season selector to the latest entry so old groups keep their
+ * history visible during the offseason.
+ */
+export function getPickSeasons(groupIdentifier: string): Promise<PickSeasonsResponse>;
+
+/** One member's points for a single week in the scoreboard payload. */
+export interface ScoreboardWeekly {
+  week: number;
+  points: number;
+}
+
+/** One member's scoreboard row: weekly points plus the season total. */
+export interface ScoreboardUser {
+  userId: number;
+  name: string;
+  pictureUrl: string | null;
+  weekly: ScoreboardWeekly[];
+  totalPoints: number;
+}
+
+/** Response shape of GET /:identifier/scoreboard. */
+export interface ScoreboardResponse {
+  season: number;
+  seasonType: number;
+  weeks: number[];
+  users: ScoreboardUser[];
+}
+
+/** Fetch the per-member weekly/total points for a season. */
+export function getScoreboard(
+  groupIdentifier: string,
+  query: { season: number; seasonType: number },
+): Promise<ScoreboardResponse>;

--- a/frontend/src/lib/picksService.js
+++ b/frontend/src/lib/picksService.js
@@ -32,6 +32,20 @@ export async function getClosestWeek(groupIdentifier, season, seasonType) {
   return res.json();
 }
 
+/**
+ * Seasons with stored pick data for the group, newest first. The group page
+ * defaults its season selector to the latest entry so an old group's picks and
+ * scores stay reachable once the calendar rolls into a new season.
+ */
+export async function getPickSeasons(groupIdentifier) {
+  const res = await authFetch(`${apiBase()}/${groupIdentifier}/picks/seasons`);
+  if (!res.ok) {
+    const data = await res.json().catch(()=>({}));
+    throw new Error(data.error || 'Failed to load seasons');
+  }
+  return res.json();
+}
+
 export async function getPicks(groupIdentifier, { season, seasonType, week }) {
   const params = new URLSearchParams({ season, seasonType, week });
   const res = await authFetch(`${apiBase()}/${groupIdentifier}/picks?${params}`);

--- a/frontend/src/pages/GroupDetails/LeaderboardTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/LeaderboardTab.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LeaderboardTab from './LeaderboardTab';
+import type { ScoreboardResponse } from '../../lib/picksService';
+
+// The "current" season is 2026 (offseason) while the group's pick data lives in
+// 2025 — the regression scenario: the leaderboard must default to the season
+// with data so old groups keep their scores visible.
+vi.mock('../../lib/nflSeasonUtils.js', () => ({ getCurrentNFLSeason: vi.fn(() => 2026) }));
+vi.mock('../../lib/picksService.js', () => ({
+  getPickSeasons: vi.fn(),
+  getScoreboard: vi.fn(),
+}));
+
+import { getPickSeasons, getScoreboard } from '../../lib/picksService.js';
+const mockGetPickSeasons = vi.mocked(getPickSeasons);
+const mockGetScoreboard = vi.mocked(getScoreboard);
+
+const identifier = 'sunday-squad';
+
+function scoreboard(): ScoreboardResponse {
+  return {
+    season: 2025,
+    seasonType: 2,
+    weeks: [1, 2],
+    users: [
+      // Out of order on purpose: the tab sorts by totalPoints descending.
+      { userId: 2, name: 'Bob', pictureUrl: null, weekly: [{ week: 1, points: 3 }, { week: 2, points: 4 }], totalPoints: 7 },
+      { userId: 1, name: 'Alice', pictureUrl: null, weekly: [{ week: 1, points: 10 }, { week: 2, points: 5 }], totalPoints: 15 },
+    ],
+  };
+}
+
+describe('LeaderboardTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPickSeasons.mockResolvedValue({ seasons: [2025] });
+    mockGetScoreboard.mockResolvedValue(scoreboard());
+  });
+
+  it('shows a loading state before the fetch resolves', async () => {
+    render(<LeaderboardTab identifier={identifier} />);
+    expect(screen.getByText('Loading leaderboard…')).toBeInTheDocument();
+    await screen.findAllByText('Alice');
+  });
+
+  it('defaults to the latest season with pick data and fetches its scoreboard', async () => {
+    render(<LeaderboardTab identifier={identifier} />);
+    await screen.findAllByText('Alice');
+    expect(mockGetScoreboard).toHaveBeenCalledWith(identifier, { season: 2025, seasonType: 2 });
+    const seasonSelect = screen.getByLabelText('Select season') as HTMLSelectElement;
+    expect(seasonSelect.value).toBe('2025');
+    expect(Array.from(seasonSelect.options).map((o) => o.value)).toEqual(['2026', '2025']);
+  });
+
+  it('renders standings sorted by total points with a weekly breakdown', async () => {
+    render(<LeaderboardTab identifier={identifier} />);
+    await screen.findAllByText('Alice');
+
+    // Ranked list: Alice (15) above Bob (7). Names render in both the list and
+    // the weekly table, so compare positions within the list only.
+    const list = screen.getByRole('list');
+    const items = Array.from(list.querySelectorAll('li')).map((li) => li.textContent ?? '');
+    expect(items[0]).toContain('Alice');
+    expect(items[0]).toContain('15');
+    expect(items[1]).toContain('Bob');
+    expect(items[1]).toContain('7');
+
+    // Weekly breakdown table: one column per week with data plus the total.
+    expect(screen.getByRole('columnheader', { name: 'W1' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'W2' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Total' })).toBeInTheDocument();
+  });
+
+  it('refetches the scoreboard when the season selector changes', async () => {
+    render(<LeaderboardTab identifier={identifier} />);
+    await screen.findAllByText('Alice');
+    expect(mockGetScoreboard).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText('Select season'), { target: { value: '2026' } });
+    await waitFor(() =>
+      expect(mockGetScoreboard).toHaveBeenCalledWith(identifier, { season: 2026, seasonType: 2 }),
+    );
+  });
+
+  it('refetches when Refresh is clicked', async () => {
+    render(<LeaderboardTab identifier={identifier} />);
+    await screen.findAllByText('Alice');
+    expect(mockGetScoreboard).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(mockGetScoreboard).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an empty state when the season has no scored weeks', async () => {
+    mockGetPickSeasons.mockResolvedValue({ seasons: [] });
+    mockGetScoreboard.mockResolvedValue({ season: 2026, seasonType: 2, weeks: [], users: [] });
+    render(<LeaderboardTab identifier={identifier} />);
+    expect(await screen.findByText(/No points yet for the 2026 season/i)).toBeInTheDocument();
+  });
+
+  it('shows the error message when the scoreboard fetch fails', async () => {
+    mockGetScoreboard.mockRejectedValue(new Error('Failed to load scoreboard'));
+    render(<LeaderboardTab identifier={identifier} />);
+    expect(await screen.findByText('Failed to load scoreboard')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/GroupDetails/LeaderboardTab.tsx
+++ b/frontend/src/pages/GroupDetails/LeaderboardTab.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useState } from 'react';
+import Avatar from '../../designsystem/components/Avatar';
+import Button from '../../designsystem/components/Button';
+import { getScoreboard } from '../../lib/picksService.js';
+import type { ScoreboardUser } from '../../lib/picksService';
+import { useSeasonOptions } from './useSeasonOptions';
+
+// Regular season; mirrors PicksTab's constant.
+const SEASON_TYPE = 2;
+
+export interface LeaderboardTabProps {
+  /** Group identifier, used to fetch the scoreboard for the selected season. */
+  identifier: string;
+}
+
+/**
+ * NFL leaderboard tab, ported from the Svelte GroupDetailsPage leaderboard card
+ * (commit 98a5782^). Owns its own fetch like WorldCupLeaderboardTab: resolves
+ * the group's seasons (defaulting to the newest one with pick data so old
+ * groups keep their scores visible during the offseason), fetches the
+ * scoreboard for the selected season, and renders the ranked standings plus a
+ * per-week points breakdown.
+ */
+export default function LeaderboardTab({ identifier }: LeaderboardTabProps) {
+  const { options, season, setSeason, resolved } = useSeasonOptions(identifier);
+  const [users, setUsers] = useState<ScoreboardUser[]>([]);
+  const [weeks, setWeeks] = useState<number[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (season == null) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getScoreboard(identifier, { season, seasonType: SEASON_TYPE });
+      const sorted = (Array.isArray(data?.users) ? data.users : [])
+        .slice()
+        .sort((a, b) => b.totalPoints - a.totalPoints);
+      setUsers(sorted);
+      setWeeks(Array.isArray(data?.weeks) ? data.weeks : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load leaderboard');
+    } finally {
+      setLoading(false);
+    }
+  }, [identifier, season]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (!resolved || (loading && users.length === 0 && !error)) {
+    return <p className="text-[var(--color-text-secondary)]">Loading leaderboard…</p>;
+  }
+
+  return (
+    <div className="space-y-md">
+      {/* Season selector + refresh */}
+      <div className="flex flex-wrap items-center gap-sm">
+        <select
+          aria-label="Select season"
+          value={season ?? ''}
+          onChange={(e) => setSeason(Number(e.target.value))}
+          className="px-sm py-xs border border-secondary-200 dark:border-secondary-700 rounded bg-neutral-0 dark:bg-secondary-800 text-[var(--color-text-primary)]"
+        >
+          {options.map((s) => (
+            <option key={s} value={s}>
+              {s} Season
+            </option>
+          ))}
+        </select>
+        <Button variant="tertiary" size="sm" onClick={load} disabled={loading}>
+          {loading ? 'Loading…' : 'Refresh'}
+        </Button>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-error-600 dark:text-error-400">{error}</p>
+      ) : users.length === 0 || weeks.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-secondary)]">
+          No points yet for the {season} season.
+        </p>
+      ) : (
+        <>
+          {/* Ranked standings, mirroring the Svelte leaderboard card. */}
+          <ul className="divide-y divide-secondary-200 dark:divide-secondary-700 rounded-lg border border-secondary-200 dark:border-secondary-700 bg-neutral-0 dark:bg-secondary-800">
+            {users.map((u, i) => (
+              <li key={u.userId} className="flex items-center gap-sm px-md py-sm">
+                <div className="w-6 text-right pr-1 text-sm font-medium tabular-nums text-[var(--color-text-primary)]">
+                  {i + 1}
+                </div>
+                <Avatar name={u.name} pictureUrl={u.pictureUrl ?? ''} variant="md" />
+                <div className="flex-1 truncate text-sm text-[var(--color-text-primary)]">{u.name}</div>
+                <div className="text-sm font-semibold tabular-nums text-[var(--color-text-primary)]">
+                  {u.totalPoints}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          {/* Weekly breakdown, ported from the Svelte PicksPanel scoreboard table. */}
+          <div className="overflow-x-auto rounded-lg border border-secondary-200 dark:border-secondary-700">
+            <table className="min-w-full text-sm bg-neutral-0 dark:bg-secondary-900">
+              <thead>
+                <tr className="text-left bg-secondary-50 dark:bg-secondary-800">
+                  <th scope="col" className="px-sm py-xs font-semibold text-secondary-500 dark:text-secondary-400">
+                    Member
+                  </th>
+                  {weeks.map((w) => (
+                    <th
+                      key={w}
+                      scope="col"
+                      className="px-sm py-xs text-center font-semibold text-secondary-500 dark:text-secondary-400"
+                    >
+                      W{w}
+                    </th>
+                  ))}
+                  <th scope="col" className="px-sm py-xs text-center font-semibold text-secondary-500 dark:text-secondary-400">
+                    Total
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr key={u.userId} className="border-t border-secondary-200 dark:border-secondary-700">
+                    <th scope="row" className="px-sm py-xs text-left font-medium whitespace-nowrap text-[var(--color-text-primary)]">
+                      {u.name}
+                    </th>
+                    {weeks.map((w) => (
+                      <td key={w} className="px-sm py-xs text-center tabular-nums text-[var(--color-text-primary)]">
+                        {u.weekly.find((x) => x.week === w)?.points ?? 0}
+                      </td>
+                    ))}
+                    <td className="px-sm py-xs text-center font-semibold tabular-nums text-[var(--color-text-primary)]">
+                      {u.totalPoints}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/GroupDetails/PicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/PicksTab.test.tsx
@@ -6,15 +6,19 @@ import type { GetPicksResponse } from '../../lib/picksService';
 
 // Mock the season helper so the derived season is deterministic, and the picks
 // service so the test fully controls the fetched shape without touching network.
-vi.mock('../../lib/nflSeasonUtils.js', () => ({ getCurrentNFLSeason: vi.fn(() => 2025) }));
+// The "current" season is 2026 (offseason) while the group's pick data lives in
+// 2025 — the regression scenario: the tab must default to the season with data.
+vi.mock('../../lib/nflSeasonUtils.js', () => ({ getCurrentNFLSeason: vi.fn(() => 2026) }));
 vi.mock('../../lib/picksService.js', () => ({
   getClosestWeek: vi.fn(),
   getPicks: vi.fn(),
+  getPickSeasons: vi.fn(),
 }));
 
-import { getClosestWeek, getPicks } from '../../lib/picksService.js';
+import { getClosestWeek, getPicks, getPickSeasons } from '../../lib/picksService.js';
 const mockGetClosestWeek = vi.mocked(getClosestWeek);
 const mockGetPicks = vi.mocked(getPicks);
+const mockGetPickSeasons = vi.mocked(getPickSeasons);
 
 const identifier = 'sunday-squad';
 
@@ -51,6 +55,7 @@ function arrayResponse(): GetPicksResponse {
 describe('PicksTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetPickSeasons.mockResolvedValue({ seasons: [2025] });
     mockGetClosestWeek.mockResolvedValue({ season: 2025, seasonType: 2, week: 2 });
     mockGetPicks.mockResolvedValue(arrayResponse());
   });
@@ -62,11 +67,45 @@ describe('PicksTab', () => {
     await screen.findByText('BUF @ NE');
   });
 
-  it('derives the season, resolves the closest week, then fetches picks for it', async () => {
+  it('defaults to the latest season with pick data, not the empty current season', async () => {
     render(<PicksTab identifier={identifier} members={members} />);
     await screen.findByText('BUF @ NE');
+    // Current NFL season is 2026 (offseason) but the group's data is in 2025:
+    // the closest-week resolution and picks fetch must both target 2025.
     expect(mockGetClosestWeek).toHaveBeenCalledWith(identifier, 2025, 2);
     expect(mockGetPicks).toHaveBeenCalledWith(identifier, { season: 2025, seasonType: 2, week: 2 });
+    // The season selector defaults to 2025 while still offering the current season.
+    const seasonSelect = screen.getByLabelText('Select season') as HTMLSelectElement;
+    expect(seasonSelect.value).toBe('2025');
+    expect(Array.from(seasonSelect.options).map((o) => o.value)).toEqual(['2026', '2025']);
+  });
+
+  it('falls back to the current season when the group has no pick data', async () => {
+    mockGetPickSeasons.mockResolvedValue({ seasons: [] });
+    render(<PicksTab identifier={identifier} members={members} />);
+    await screen.findByText('BUF @ NE');
+    expect(mockGetClosestWeek).toHaveBeenCalledWith(identifier, 2026, 2);
+    expect(mockGetPicks).toHaveBeenCalledWith(identifier, { season: 2026, seasonType: 2, week: 2 });
+  });
+
+  it('refetches picks when the week selector changes', async () => {
+    render(<PicksTab identifier={identifier} members={members} />);
+    await screen.findByText('BUF @ NE');
+    expect(mockGetPicks).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText('Select week'), { target: { value: '5' } });
+    await waitFor(() =>
+      expect(mockGetPicks).toHaveBeenCalledWith(identifier, { season: 2025, seasonType: 2, week: 5 }),
+    );
+  });
+
+  it('re-resolves the closest week when the season selector changes', async () => {
+    render(<PicksTab identifier={identifier} members={members} />);
+    await screen.findByText('BUF @ NE');
+    expect(mockGetClosestWeek).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText('Select season'), { target: { value: '2026' } });
+    await waitFor(() => expect(mockGetClosestWeek).toHaveBeenCalledWith(identifier, 2026, 2));
   });
 
   it('renders the GroupPicks matrix with member columns and adapted picks', async () => {

--- a/frontend/src/pages/GroupDetails/PicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/PicksTab.tsx
@@ -1,14 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import GroupPicks from '../../designsystem/components/GroupPicks';
 import type { GroupMember } from '../../lib/groupsService';
-import { getCurrentNFLSeason } from '../../lib/nflSeasonUtils.js';
 import { getClosestWeek, getPicks } from '../../lib/picksService.js';
 import type { GetPicksResponse } from '../../lib/picksService';
 import type { GameData, GroupMember as PicksMember, MemberPicks, PickData } from '../../lib/types';
+import { useSeasonOptions } from './useSeasonOptions';
 
 // Regular-season picks. seasonType 2 is the ESPN regular season (1 = preseason,
 // 3 = postseason); GroupPicks only renders the regular-season matrix here.
 const SEASON_TYPE = 2;
+
+// Regular season weeks offered by the week selector, mirroring the Svelte
+// PicksPanel's TOTAL_WEEKS.
+const TOTAL_WEEKS = 18;
 
 export interface PicksTabProps {
   /** Group identifier, used to fetch games + picks for the active week. */
@@ -79,11 +83,16 @@ function adaptPicks(response: GetPicksResponse): MemberPicks[] {
 
 /**
  * PicksTab owns its own data fetch (the page mount only loads group/members/
- * messages). On mount and on refresh it resolves the closest week, fetches the
- * week's games + picks, adapts them into GroupPicks' props, and renders the
- * read-only matrix. GroupPicks never fetches — PicksTab supplies the data.
+ * messages). It resolves the group's seasons (defaulting to the newest one with
+ * pick data so old groups keep their picks visible during the offseason), the
+ * closest week within the selected season, then fetches that week's games +
+ * picks and renders the read-only matrix. Season and week selectors let members
+ * navigate back through history; GroupPicks never fetches — PicksTab supplies
+ * the data.
  */
 export default function PicksTab({ identifier, members }: PicksTabProps) {
+  const { options: seasonOptions, season, setSeason } = useSeasonOptions(identifier);
+  const [week, setWeek] = useState<number | null>(null);
   const [games, setGames] = useState<GameData[]>([]);
   const [picks, setPicks] = useState<MemberPicks[]>([]);
   const [loading, setLoading] = useState(true);
@@ -92,14 +101,38 @@ export default function PicksTab({ identifier, members }: PicksTabProps) {
   // this is what onRefresh triggers.
   const [reloadKey, setReloadKey] = useState(0);
 
+  // Resolve the closest week whenever the season (or group) changes. Week is
+  // nulled first so the picks fetch below waits for the new season's week.
   useEffect(() => {
+    if (season == null) return;
+    let cancelled = false;
+    setWeek(null);
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const { week: closest } = await getClosestWeek(identifier, season, SEASON_TYPE);
+        if (!cancelled) setWeek(typeof closest === 'number' ? closest : 1);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load picks');
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [identifier, season]);
+
+  // Fetch the week's games + picks once season and week are both resolved.
+  useEffect(() => {
+    if (season == null || week == null) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
     (async () => {
       try {
-        const season = getCurrentNFLSeason();
-        const { week } = await getClosestWeek(identifier, season, SEASON_TYPE);
         const response = await getPicks(identifier, { season, seasonType: SEASON_TYPE, week });
         if (cancelled) return;
         setGames(adaptGames(response));
@@ -114,19 +147,31 @@ export default function PicksTab({ identifier, members }: PicksTabProps) {
     return () => {
       cancelled = true;
     };
-  }, [identifier, reloadKey]);
+  }, [identifier, season, week, reloadKey]);
 
   const onRefresh = useCallback(() => setReloadKey((k) => k + 1), []);
 
   // GroupPicks' members prop wants types.GroupMember (pictureUrl: string); the
   // page supplies groupsService.GroupMember (pictureUrl: string | null). Coerce
   // the nullable field — Avatar already treats '' as "no picture" (initials).
+  // The id is coerced to string to match the backend's stringified memberId
+  // keys (the matrix looks picks up by member id).
   const groupMembers = useMemo<PicksMember[]>(
-    () => members.map((m) => ({ ...m, pictureUrl: m.pictureUrl ?? '' })),
+    () => members.map((m) => ({ ...m, id: String(m.id), pictureUrl: m.pictureUrl ?? '' })),
     [members],
   );
 
-  if (loading) {
+  // Weeks 1..18; week 0 (preseason finale slot) is only offered when the
+  // backend's closest-week resolution landed there.
+  const weekOptions = useMemo(() => {
+    const base = Array.from({ length: TOTAL_WEEKS }, (_, i) => i + 1);
+    return week === 0 ? [0, ...base] : base;
+  }, [week]);
+
+  // Until the seasons fetch resolves there is no selector state to render at
+  // all; afterwards the selectors stay mounted through week/season changes and
+  // only the matrix area swaps to its loading text.
+  if (season == null) {
     return (
       <div className='rounded-md border border-border bg-surface p-lg'>
         <p className='text-secondary'>Loading picks…</p>
@@ -134,17 +179,49 @@ export default function PicksTab({ identifier, members }: PicksTabProps) {
     );
   }
 
-  if (error) {
-    return (
-      <div className='rounded-md border border-border bg-surface p-lg'>
-        <p className='text-sm text-error-600 dark:text-error-400'>{error}</p>
-      </div>
-    );
-  }
-
   return (
-    <div className='rounded-md border border-border bg-surface p-lg'>
-      <GroupPicks games={games} picks={picks} members={groupMembers} onRefresh={onRefresh} />
+    <div className='rounded-md border border-border bg-surface p-lg space-y-md'>
+      {/* Season + week navigation. Defaults to the latest season with data and
+          its closest week, so old groups land on their most recent picks. */}
+      <div className='flex flex-wrap items-center gap-sm'>
+        <select
+          aria-label='Select season'
+          value={season ?? ''}
+          onChange={(e) => setSeason(Number(e.target.value))}
+          className='px-sm py-xs border border-secondary-200 dark:border-secondary-700 rounded bg-neutral-0 dark:bg-secondary-800 text-[var(--color-text-primary)]'
+        >
+          {seasonOptions.map((s) => (
+            <option key={s} value={s}>
+              {s} Season
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label='Select week'
+          value={week ?? ''}
+          onChange={(e) => setWeek(Number(e.target.value))}
+          disabled={week == null}
+          className='px-sm py-xs border border-secondary-200 dark:border-secondary-700 rounded bg-neutral-0 dark:bg-secondary-800 text-[var(--color-text-primary)]'
+        >
+          {week == null ? (
+            <option value=''>Loading…</option>
+          ) : (
+            weekOptions.map((w) => (
+              <option key={w} value={w}>
+                Week {w}
+              </option>
+            ))
+          )}
+        </select>
+      </div>
+
+      {loading ? (
+        <p className='text-secondary'>Loading picks…</p>
+      ) : error ? (
+        <p className='text-sm text-error-600 dark:text-error-400'>{error}</p>
+      ) : (
+        <GroupPicks games={games} picks={picks} members={groupMembers} onRefresh={onRefresh} />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/GroupDetails/useSeasonOptions.ts
+++ b/frontend/src/pages/GroupDetails/useSeasonOptions.ts
@@ -1,0 +1,58 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getCurrentNFLSeason } from '../../lib/nflSeasonUtils.js';
+import { getPickSeasons } from '../../lib/picksService.js';
+
+export interface SeasonOptions {
+  /** Selectable seasons, newest first. Always contains the current NFL season. */
+  options: number[];
+  /** Selected season; null until the default resolves. */
+  season: number | null;
+  setSeason: (season: number) => void;
+  /** True once the seasons fetch settled and a default season was chosen. */
+  resolved: boolean;
+}
+
+/**
+ * Resolve the group's selectable seasons and the default selection for the
+ * Leaderboard and Picks tabs.
+ *
+ * The default is the newest season that actually has pick data — NOT the
+ * current NFL season. During the offseason getCurrentNFLSeason() already
+ * points at the upcoming (empty) season, which is exactly how old groups lost
+ * their picks and scores; defaulting to the latest season with data keeps the
+ * history visible while still offering the current season in the dropdown.
+ * The seasons fetch is best-effort: on failure we fall back to the current
+ * season so the tab still renders.
+ */
+export function useSeasonOptions(identifier: string): SeasonOptions {
+  const currentSeason = useMemo(() => getCurrentNFLSeason(), []);
+  const [options, setOptions] = useState<number[]>([currentSeason]);
+  const [season, setSeason] = useState<number | null>(null);
+  const [resolved, setResolved] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setResolved(false);
+    setSeason(null);
+    setOptions([currentSeason]);
+    (async () => {
+      let withData: number[] = [];
+      try {
+        const resp = await getPickSeasons(identifier);
+        withData = Array.isArray(resp?.seasons) ? resp.seasons : [];
+      } catch {
+        // Best-effort: an error here must not blank the tab.
+      }
+      if (cancelled) return;
+      const merged = [...new Set([currentSeason, ...withData])].sort((a, b) => b - a);
+      setOptions(merged);
+      setSeason(withData.length > 0 ? Math.max(...withData) : currentSeason);
+      setResolved(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [identifier, currentSeason]);
+
+  return { options, season, setSeason, resolved };
+}

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -18,13 +18,16 @@ vi.mock('../lib/groupsService.js', () => ({
   getMyGroups: vi.fn(),
 }));
 
-// PicksTab owns its own fetch (season -> closest week -> picks). Mock those so the
-// picks tab renders deterministically; getClosestWeek is left pending in the tab-
-// switching test so the tab sits in its loading state.
+// PicksTab and LeaderboardTab own their own fetches (seasons -> closest week ->
+// picks / scoreboard). Mock those so the tabs render deterministically;
+// getClosestWeek is left pending in the tab-switching test so the picks tab
+// sits in its loading state.
 vi.mock('../lib/nflSeasonUtils.js', () => ({ getCurrentNFLSeason: vi.fn(() => 2025) }));
 vi.mock('../lib/picksService.js', () => ({
   getClosestWeek: vi.fn(),
   getPicks: vi.fn(),
+  getPickSeasons: vi.fn(),
+  getScoreboard: vi.fn(),
 }));
 
 // World Cup pools fetch a tournament-shaped leaderboard, and their Picks tab
@@ -60,7 +63,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 });
 
 import { getGroup, getMembers, getMessages, getMyGroups } from '../lib/groupsService.js';
-import { getClosestWeek } from '../lib/picksService.js';
+import { getClosestWeek, getPickSeasons, getScoreboard } from '../lib/picksService.js';
 import {
   getWorldCupLeaderboard,
   getStageMatches,
@@ -71,6 +74,8 @@ const mockGetMembers = vi.mocked(getMembers);
 const mockGetMessages = vi.mocked(getMessages);
 const mockGetMyGroups = vi.mocked(getMyGroups);
 const mockGetClosestWeek = vi.mocked(getClosestWeek);
+const mockGetPickSeasons = vi.mocked(getPickSeasons);
+const mockGetScoreboard = vi.mocked(getScoreboard);
 const mockGetWorldCupLeaderboard = vi.mocked(getWorldCupLeaderboard);
 const mockGetStageMatches = vi.mocked(getStageMatches);
 const mockGetMyWorldCupPicks = vi.mocked(getMyWorldCupPicks);
@@ -131,6 +136,10 @@ describe('GroupDetailsPage', () => {
     // Hold the picks fetch open so the picks tab stays in its loading state for
     // the tab-switching assertions (this suite covers navigation, not picks data).
     mockGetClosestWeek.mockReturnValue(new Promise(() => {}));
+    // The NFL leaderboard/picks tabs resolve the group's seasons on mount; an
+    // empty list defaults them to the (mocked) current season.
+    mockGetPickSeasons.mockResolvedValue({ seasons: [] });
+    mockGetScoreboard.mockResolvedValue({ season: 2025, seasonType: 2, weeks: [], users: [] });
   });
 
   it('renders the group name as the heading once the parallel fetch resolves', async () => {
@@ -158,8 +167,9 @@ describe('GroupDetailsPage', () => {
     await screen.findByRole('heading', { name: ownerGroup.name });
 
     expect(screen.getByText('Owner')).toBeInTheDocument();
-    // Default tab is leaderboard.
-    expect(screen.getByText(/Leaderboard coming soon/i)).toBeInTheDocument();
+    // Default tab is leaderboard: the NFL LeaderboardTab fetches the scoreboard
+    // (empty here) and renders its empty state.
+    expect(await screen.findByText(/No points yet/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('tab', { name: /picks/i }));
     // PicksTab owns its fetch; with getClosestWeek pending it shows the loader.
@@ -172,6 +182,39 @@ describe('GroupDetailsPage', () => {
     fireEvent.click(screen.getByRole('tab', { name: /settings/i }));
     // SettingsTab leads with the Members roster section.
     expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument();
+  });
+
+  it('renders the NFL leaderboard for the season that has pick data (old group)', async () => {
+    mockGetGroup.mockResolvedValue(memberGroup);
+    mockGetMembers.mockResolvedValue(members);
+    mockGetMessages.mockResolvedValue(messages);
+    // Old group: pick data only exists for 2024 while the (mocked) current
+    // season is 2025. The leaderboard must request the season that actually
+    // has data, not the empty current one — this is the regression that hid
+    // old groups' scores after the season rolled over.
+    mockGetPickSeasons.mockResolvedValue({ seasons: [2024] });
+    mockGetScoreboard.mockResolvedValue({
+      season: 2024,
+      seasonType: 2,
+      weeks: [1, 2],
+      users: [
+        { userId: 1, name: 'Alice', pictureUrl: null, weekly: [{ week: 1, points: 10 }, { week: 2, points: 5 }], totalPoints: 15 },
+        { userId: 2, name: 'Bob', pictureUrl: null, weekly: [{ week: 1, points: 3 }, { week: 2, points: 4 }], totalPoints: 7 },
+      ],
+    });
+
+    renderPage();
+    await screen.findByRole('heading', { name: memberGroup.name });
+
+    // Standings render with season totals (Alice leads).
+    expect(await screen.findAllByText('15')).not.toHaveLength(0);
+    expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
+    // Weekly breakdown columns for the weeks with data.
+    expect(screen.getByRole('columnheader', { name: 'W1' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'W2' })).toBeInTheDocument();
+    // The scoreboard was fetched for the old season with data, not the current one.
+    expect(mockGetScoreboard).toHaveBeenCalledWith('sunday-squad', { season: 2024, seasonType: 2 });
   });
 
   it('hides the Owner badge for a non-admin member', async () => {

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { getGroup, getMembers, getMessages } from '../lib/groupsService.js';
 import type { GroupDetail, GroupMember, GroupMessage } from '../lib/groupsService';
 import Button from '../designsystem/components/Button';
+import LeaderboardTab from './GroupDetails/LeaderboardTab';
 import PicksTab from './GroupDetails/PicksTab';
 import ChatTab from './GroupDetails/ChatTab';
 import SettingsTab from './GroupDetails/SettingsTab';
@@ -12,9 +13,8 @@ import WorldCupPicksTab from './GroupDetails/WorldCupPicksTab';
 
 // Ported from GroupDetailsPage.svelte (commit d6b2566^). This is the page shell:
 // it resolves the group identifier, runs the parallel mount fetch, and owns the
-// header + tab navigation. The tab bodies (picks/chat/settings) are delegated to
-// child components; the leaderboard tab is a deferred placeholder (no
-// getScoreboard wiring per the task scope).
+// header + tab navigation. The tab bodies (leaderboard/picks/chat/settings) are
+// delegated to child components.
 //
 // World Cup pools (poolType === 'world_cup_2026') render the tournament-shaped
 // variant of the same two tabs: the Leaderboard tab swaps the placeholder for
@@ -221,9 +221,7 @@ export default function GroupDetailsPage() {
           (isWorldCup ? (
             <WorldCupLeaderboardTab identifier={identifier} />
           ) : (
-            // Bare placeholder — the active tab already names the section, so no
-            // card wrapper or duplicate "Leaderboard" heading.
-            <p className="text-[var(--color-text-secondary)]">Leaderboard coming soon</p>
+            <LeaderboardTab identifier={identifier} />
           ))}
         {activeTab === 'picks' &&
           (isWorldCup ? (

--- a/frontend/tests/e2e/group-nfl-leaderboard-old-season.spec.ts
+++ b/frontend/tests/e2e/group-nfl-leaderboard-old-season.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test'
+
+// Regression guard for old groups losing their scores after the NFL season
+// rolls over. An NFL (non-World-Cup) group's Leaderboard tab — the page's
+// default tab — must render real standings from GET .../scoreboard for the
+// newest season that has pick data (2025 here), not an empty "current season"
+// view or the old "Leaderboard coming soon" placeholder. All API calls are
+// stubbed so the flow never reaches a real backend and never depends on the
+// machine's calendar date.
+test('old NFL group leaderboard renders past-season standings', async ({ page }) => {
+  // Visit the app first so localStorage is writable for this origin.
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Catch-all safety net first (lowest precedence): any unstubbed API call
+  // resolves to an empty object so the test can never reach a real backend.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  // Capture the scoreboard request so the asserted season is the one the
+  // frontend actually asked for.
+  let scoreboardQuery: URLSearchParams | null = null
+
+  await page.route('**/api/groups/**', async (route) => {
+    const url = new URL(route.request().url())
+    const path = url.pathname
+
+    if (path.endsWith('/members') || path.endsWith('/messages')) {
+      await route.fulfill({ json: [] })
+      return
+    }
+    if (path.endsWith('/picks/seasons')) {
+      // The group's only pick data is in 2025 — the leaderboard must default
+      // its season selector here instead of the empty current season.
+      await route.fulfill({ json: { seasons: [2025] } })
+      return
+    }
+    if (path.endsWith('/scoreboard')) {
+      scoreboardQuery = url.searchParams
+      await route.fulfill({
+        json: {
+          season: 2025,
+          seasonType: 2,
+          weeks: [1, 2],
+          users: [
+            {
+              userId: 1,
+              name: 'Ada Lovelace',
+              pictureUrl: null,
+              weekly: [
+                { week: 1, points: 10 },
+                { week: 2, points: 5 },
+              ],
+              totalPoints: 15,
+            },
+            {
+              userId: 2,
+              name: 'Grace Hopper',
+              pictureUrl: null,
+              weekly: [
+                { week: 1, points: 3 },
+                { week: 2, points: 4 },
+              ],
+              totalPoints: 7,
+            },
+          ],
+        },
+      })
+      return
+    }
+    // Group detail mount fetch: a plain NFL pool (no pool_type).
+    await route.fulfill({
+      json: {
+        id: '1',
+        name: 'Sunday Squad',
+        identifier: 'sunday-squad',
+        description: 'Old NFL group',
+        memberCount: 2,
+        userRole: 'member',
+      },
+    })
+  })
+
+  await page.goto('/group-details?group=sunday-squad')
+  await expect(page.getByRole('heading', { name: 'Sunday Squad' })).toBeVisible()
+
+  // The leaderboard is the default tab: the old placeholder is gone and the
+  // standings render for the 2025 season, ranked by total points.
+  await expect(page.getByText('Leaderboard coming soon')).toHaveCount(0)
+  await expect(page.getByLabel('Select season')).toHaveValue('2025')
+
+  const standings = page.getByRole('list')
+  await expect(standings.getByText('Ada Lovelace')).toBeVisible()
+  await expect(standings.getByText('15')).toBeVisible()
+  await expect(standings.getByText('Grace Hopper')).toBeVisible()
+  await expect(standings.getByText('7')).toBeVisible()
+
+  // Weekly breakdown table shows each scored week plus the total column.
+  await expect(page.getByRole('columnheader', { name: 'W1' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'W2' })).toBeVisible()
+  await expect(page.getByRole('columnheader', { name: 'Total' })).toBeVisible()
+
+  // And the request that produced it targeted the old season with data.
+  expect(scoreboardQuery).not.toBeNull()
+  expect(scoreboardQuery!.get('season')).toBe('2025')
+})

--- a/frontend/tests/e2e/group-picks-old-season-renders.spec.ts
+++ b/frontend/tests/e2e/group-picks-old-season-renders.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test'
+
+// Regression guard for old groups losing their pick history after the NFL
+// season rolls over. An NFL group whose pick data lives in a past season (2025
+// here) must still land on that season's picks: the Picks tab resolves the
+// group's seasons (GET .../picks/seasons), defaults to the newest one WITH
+// data — not the empty current calendar season — resolves that season's
+// closest week, and renders the member-picks matrix for it. All API calls are
+// stubbed so the flow never reaches a real backend and never depends on the
+// machine's calendar date.
+test('old NFL group picks tab renders the past season picks matrix', async ({ page }) => {
+  // Visit the app first so localStorage is writable for this origin.
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Catch-all safety net first (lowest precedence): any unstubbed API call
+  // resolves to an empty object so the test can never reach a real backend.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  // Capture the picks request so the asserted season/week are the ones the
+  // frontend actually asked for.
+  let picksQuery: URLSearchParams | null = null
+
+  await page.route('**/api/groups/**', async (route) => {
+    const url = new URL(route.request().url())
+    const path = url.pathname
+
+    if (path.endsWith('/members')) {
+      await route.fulfill({
+        json: [
+          { id: 1, name: 'Ada Lovelace', email: 'ada@example.com', role: 'admin', joined_at: '2025-08-01', picture_url: null },
+          { id: 2, name: 'Grace Hopper', email: 'grace@example.com', role: 'member', joined_at: '2025-08-02', picture_url: null },
+        ],
+      })
+      return
+    }
+    if (path.endsWith('/messages')) {
+      await route.fulfill({ json: [] })
+      return
+    }
+    if (path.endsWith('/picks/seasons')) {
+      // The group's only pick data is in 2025 — an "old" season by the time
+      // this runs (the current calendar season is whatever today says).
+      await route.fulfill({ json: { seasons: [2025] } })
+      return
+    }
+    if (path.endsWith('/picks/closest')) {
+      await route.fulfill({ json: { season: 2025, seasonType: 2, week: 18 } })
+      return
+    }
+    if (path.endsWith('/picks')) {
+      picksQuery = url.searchParams
+      await route.fulfill({
+        json: {
+          games: [
+            {
+              id: 101,
+              espnId: 'e101',
+              homeTeam: { id: '1', name: 'Patriots', abbreviation: 'NE', logo: '' },
+              awayTeam: { id: '2', name: 'Bills', abbreviation: 'BUF', logo: '' },
+              homeScore: 20,
+              awayScore: 24,
+              status: 'FINAL',
+              gameDate: '2026-01-04T18:00:00.000Z',
+              week: 18,
+              season: 2025,
+              seasonType: 2,
+            },
+          ],
+          picks: [
+            { memberId: '1', picks: [{ gameId: 101, pickedTeamId: '2', confidence: 5, won: true, points: 5 }] },
+            { memberId: '2', picks: [{ gameId: 101, pickedTeamId: '1', confidence: 7, won: false, points: -7 }] },
+          ],
+          availableConfidences: [],
+          totalGames: 1,
+          pickedCount: 1,
+          weekPoints: 5,
+        },
+      })
+      return
+    }
+    // Group detail mount fetch: a plain NFL pool (no pool_type).
+    await route.fulfill({
+      json: {
+        id: '1',
+        name: 'Sunday Squad',
+        identifier: 'sunday-squad',
+        description: 'Old NFL group',
+        memberCount: 2,
+        userRole: 'member',
+      },
+    })
+  })
+
+  await page.goto('/group-details?group=sunday-squad')
+  await expect(page.getByRole('heading', { name: 'Sunday Squad' })).toBeVisible()
+
+  await page.getByRole('tab', { name: 'Picks' }).click()
+
+  // Season selector defaulted to the old season with data; week resolved to
+  // that season's closest (final) week.
+  await expect(page.getByLabel('Select season')).toHaveValue('2025')
+  await expect(page.getByLabel('Select week')).toHaveValue('18')
+
+  // The matrix renders the 2025 finale with both members' graded picks: Ada's
+  // winning BUF pick (+5) and Grace's losing NE pick (-7).
+  await expect(page.getByText('BUF @ NE')).toBeVisible()
+  await expect(page.getByText('Final 24-20')).toBeVisible()
+  await expect(page.getByTitle('Won 5')).toBeVisible()
+  await expect(page.getByTitle('Lost -7')).toBeVisible()
+
+  // And the request that produced it targeted the old season, not the current one.
+  expect(picksQuery).not.toBeNull()
+  expect(picksQuery!.get('season')).toBe('2025')
+  expect(picksQuery!.get('week')).toBe('18')
+})


### PR DESCRIPTION
People in groups from past NFL seasons could no longer see their old
picks or scores. The data was intact in the database; the React group
page just couldn't reach it:

- The NFL Leaderboard tab was never ported from Svelte — it rendered a
  "Leaderboard coming soon" placeholder, so old scores were invisible.
- PicksTab pinned its fetch to getCurrentNFLSeason() (the upcoming,
  empty season once the calendar passes February) with no season or
  week navigation, so past-season picks were unreachable.
- PicksTab's member matrix read response.picks, a field the backend's
  GET /:identifier/picks never returned, so even in-season the matrix
  showed no one's picks.

Backend:
- New GET /:identifier/picks/seasons returns the seasons that have pick
  data for the group (newest first).
- GET /:identifier/picks now includes a member-keyed `picks` array for
  the whole group, withholding picks on unstarted games from everyone
  but their owner, and grading ungraded picks against FINAL games in
  memory.
- New UserPick.findForGroupWeek / findSeasonsForGroup helpers.

Frontend:
- New LeaderboardTab (ported from the Svelte leaderboard + scoreboard
  table) renders ranked standings and a weekly points breakdown.
- Shared useSeasonOptions hook defaults both tabs to the newest season
  that actually has data — not the empty current season — while still
  offering the current season in the selector.
- PicksTab gains season and week selectors and now defaults to the
  closest week of the season with data.

Tests:
- backend/tests/picks-seasons-route.test.js covers the seasons endpoint
  and the group-wide picks payload (withholding + in-memory grading).
- Unit tests for LeaderboardTab, the new PicksTab season/week behavior,
  and the page-level NFL leaderboard rendering.
- Two e2e specs covering an old group's leaderboard and picks matrix
  rendering past-season data.

https://claude.ai/code/session_01HYDMDkHt1K6Nxb2tfWktc7