### PR TITLE
Fix prod game-save 500: winner_team_id migration + resilient stage persistence

### DIFF
--- a/backend/scripts/addWorldCupColumns.js
+++ b/backend/scripts/addWorldCupColumns.js
@@ -80,12 +80,27 @@ async function addWorldCupColumns() {
     `);
     console.log('   ✅ groups.pool_type ensured');
 
+    // 4b. games.winner_team_id — the resolved advancing-team id for soccer
+    //     knockout matches. Persisted because ESPN's competitor.winner flag (the
+    //     only signal on a PK shootout) isn't recoverable from a cached row's
+    //     scores alone. Nullable; NFL and group-stage rows leave it NULL. This
+    //     ALTER was originally only in schema.sql, so DBs that never ran a full
+    //     schema sync (e.g. production with INIT_DB unset) were missing it, which
+    //     made every Game.save() — NFL and World Cup alike — fail with
+    //     'column "winner_team_id" of relation "games" does not exist'.
+    console.log('\n4b. Adding games.winner_team_id (varchar nullable)...');
+    await pool.query(`
+      ALTER TABLE games
+      ADD COLUMN IF NOT EXISTS winner_team_id VARCHAR(50)
+    `);
+    console.log('   ✅ games.winner_team_id ensured');
+
     // 5. Verify the columns landed with the expected shape.
     console.log('\n5. Verifying added columns...');
     const verify = await pool.query(`
       SELECT table_name, column_name, data_type, is_nullable, column_default
       FROM information_schema.columns
-      WHERE (table_name = 'games' AND column_name IN ('league', 'stage'))
+      WHERE (table_name = 'games' AND column_name IN ('league', 'stage', 'winner_team_id'))
          OR (table_name = 'user_picks' AND column_name = 'picked_result')
          OR (table_name = 'groups' AND column_name = 'pool_type')
       ORDER BY table_name, column_name

--- a/backend/src/services/GameService.js
+++ b/backend/src/services/GameService.js
@@ -223,14 +223,14 @@ export class GameService {
         freshGame.winnerTeamId = GameService.resolveWinnerTeamId(freshGame, stage, winnerHomeAway);
 
         if (!cachedGame) {
-          await freshGame.save();
+          await GameService.persistOrServeLive(freshGame);
           games.push(freshGame);
           continue;
         }
 
         const winnerChanged = freshGame.winnerTeamId !== (cachedGame.winnerTeamId ?? null);
         if (forceRefresh || cachedGame.isStale() || freshGame.isDifferentFrom(cachedGame) || winnerChanged) {
-          await freshGame.save();
+          await GameService.persistOrServeLive(freshGame);
           games.push(freshGame);
         } else {
           games.push(cachedGame);
@@ -251,6 +251,21 @@ export class GameService {
     const competitors = espnEvent?.competitions?.[0]?.competitors || [];
     const flagged = competitors.find(c => c.winner === true);
     return flagged ? flagged.homeAway : null;
+  }
+
+  // Persist a freshly-fetched stage game, but never let a write failure take down
+  // a live read. The returned slate is built from these in-memory Game objects
+  // (already carrying the live ESPN scores + resolved winnerTeamId), so on a
+  // persistence error we log and serve the live data rather than throwing — a 500
+  // here would blank the stage list and the leaderboard mid-match. The canonical
+  // example is a schema drift (e.g. a missing games column): scores still surface
+  // live every refresh; they just aren't cached until the DB is repaired.
+  static async persistOrServeLive(game) {
+    try {
+      await game.save();
+    } catch (error) {
+      console.error(`[getWorldCupStage] persist failed for espnId=${game.espnId}; serving live ESPN data uncached: ${error.message}`);
+    }
   }
 
   // Resolve the winning team's id for a World Cup match, or null when there is

--- a/backend/tests/gameservice-worldcup.test.js
+++ b/backend/tests/gameservice-worldcup.test.js
@@ -66,6 +66,42 @@ describe('GameService.getWorldCupStage winner resolution', () => {
   });
 });
 
+describe('GameService.getWorldCupStage persistence resilience', () => {
+  beforeEach(() => {
+    process.env.USE_MOCK_ESPN = 'true';
+    MockESPNService.configure();
+    mock.method(Game, 'findByLeagueStage', async () => []);
+    mock.method(Game, 'findByESPNIds', async () => new Map());
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    MockESPNService.reset();
+    delete process.env.USE_MOCK_ESPN;
+  });
+
+  // Regression for the prod incident where the games table was missing the
+  // winner_team_id column: every Game.save() threw, and getWorldCupStage
+  // propagated it as a 500 that blanked the stage list and the leaderboard
+  // mid-match. A write failure must now degrade to serving the live ESPN data
+  // (in-memory, uncached) rather than failing the read.
+  test('a save failure serves live data instead of throwing', async () => {
+    mock.method(Game.prototype, 'save', async () => {
+      throw new Error('column "winner_team_id" of relation "games" does not exist');
+    });
+
+    const games = await GameService.getWorldCupStage('group');
+
+    assert.ok(Array.isArray(games), 'should resolve to a slate, not reject');
+    assert.ok(games.length > 0, 'live ESPN games should still be returned when persistence fails');
+    // The returned objects carry the live scores parsed from ESPN even though
+    // they were never persisted.
+    const draw = games.find(g => g.homeTeam.abbreviation === 'MEX' && g.awayTeam.abbreviation === 'USA');
+    assert.ok(draw, 'live slate should include the MEX vs USA fixture despite the failed save');
+    assert.strictEqual(draw.status, 'FINAL', 'live status should be parsed from ESPN');
+  });
+});
+
 describe('GameService.getWorldCupStage cache behavior', () => {
   // A persisted Game row as the finders would return it. Defaults to a fresh,
   // completed group-stage regulation result (home 2-1).


### PR DESCRIPTION
## Root cause (diagnosed via #110 smoke test + Vercel logs)

The live World Cup stage refresh 500s in production. The diagnostic workflow pulled the exact error from prod:

```
HTTP 500
.error: column "winner_team_id" of relation "games" does not exist
```

ESPN is fine (72 group events, 0 unparseable, all `slug=group-stage`). The failure is **schema drift**: the prod `games` table is missing the `winner_team_id` column. `schema.sql` declares it (idempotent ALTER, line ~329) but prod only runs schema sync when `INIT_DB=true` (it isn't), and the standalone migration `scripts/addWorldCupColumns.js` never included it. So **every `Game.save()` throws** — World Cup *and* NFL (NFL just hasn't hit it, being offseason) — and `getWorldCupStage` propagated it as a 500 that blanks the stage list and the leaderboard.

## Changes

1. **`scripts/addWorldCupColumns.js`** — add the idempotent `ALTER TABLE games ADD COLUMN IF NOT EXISTS winner_team_id VARCHAR(50)` (+ verification), so the repo's migration matches `schema.sql` and can repair existing DBs. Running this script (or the one-line ALTER) against prod is the actual fix.
2. **`GameService.getWorldCupStage`** — new `persistOrServeLive` helper wraps each save: a persistence failure is logged and the **live ESPN game is served uncached** instead of throwing. So a future schema/DB/ESPN hiccup degrades to live-but-uncached data rather than 500ing the live UI mid-match.
3. **Test** — regression test asserting a `save()` failure yields the live slate, not a rejection.

## Deploy / apply

- Merging deploys the resilience guard (the stage endpoint stops 500ing even before the column exists — it serves live data).
- **The proper fix is the migration**: run `ALTER TABLE games ADD COLUMN IF NOT EXISTS winner_team_id VARCHAR(50);` against prod (or `node backend/scripts/addWorldCupColumns.js` with the prod `DATABASE_URL`) to restore persistence/caching.

## Note on testing

The backend test suite can't be executed in the authoring sandbox (no `pg`/`express` installed there), so the new test is written to the existing mocked-DB pattern but was not run by me — please let CI / a local run confirm. All three edited files pass `node --check`.

https://claude.ai/code/session_01RC95R4aHf3fVEauZ3cFVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC95R4aHf3fVEauZ3cFVYx)_