### PR TITLE
Lock World Cup picks at kickoff time, enforced server-side

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,10 @@
       "Bash(brain:*)",
       "Bash(find /Users/davidokun/Developer/brain/brain-sdk/src -name \"*.ts\" -exec wc -l {})",
       "Bash(for module:*)",
-      "Bash(do echo:*)"
+      "Bash(do echo:*)",
+      "mcp__868e3bd8-5c02-43d5-acb0-b5367605b1b3__get_runtime_logs",
+      "mcp__868e3bd8-5c02-43d5-acb0-b5367605b1b3__list_deployments",
+      "mcp__868e3bd8-5c02-43d5-acb0-b5367605b1b3__deploy_to_vercel"
     ],
     "deny": [],
     "ask": []

--- a/backend/src/routes/worldCupPicks.js
+++ b/backend/src/routes/worldCupPicks.js
@@ -63,7 +63,7 @@ router.post('/group/:groupId/world-cup', authenticateToken, async (req, res) => 
     // slot columns (season/season_type/week) the upsert requires.
     const gameIds = picks.map(p => p.gameId);
     const { rows: gameRows } = await pool.query(
-      `SELECT id, season, season_type, week FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
+      `SELECT id, season, season_type, week, game_date FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
       [gameIds]
     );
     const gameById = new Map(gameRows.map(g => [g.id, g]));
@@ -74,10 +74,33 @@ router.post('/group/:groupId/world-cup', authenticateToken, async (req, res) => 
       }
     }
 
+    // Lock picks at kickoff. game_date (the scheduled start) is the authoritative,
+    // stable boundary — we never trust the client and we never key off the live
+    // status, because ESPN can briefly flap an in-progress match back to
+    // SCHEDULED. Any pick whose kickoff has passed is dropped (its previously
+    // saved value is preserved untouched); the rest of the submission still
+    // saves. The client submits the whole slate each time, so rejecting the
+    // entire batch would make every pick unsavable once the first match starts —
+    // hence skip-and-save-rest, with the locked ids reported back.
+    const now = Date.now();
+    const lockedGameIds = [];
+    const openPicks = picks.filter(p => {
+      const g = gameById.get(p.gameId);
+      if (g && new Date(g.game_date).getTime() <= now) {
+        lockedGameIds.push(p.gameId);
+        return false;
+      }
+      return true;
+    });
+
+    if (openPicks.length === 0) {
+      return res.json({ picks: [], lockedGameIds });
+    }
+
     // Group picks by their game's (season, season_type, week) slot — one upsert call
     // per slot keeps the parameter columns consistent across mixed-stage submissions.
     const bySlot = new Map();
-    for (const p of picks) {
+    for (const p of openPicks) {
       const g = gameById.get(p.gameId);
       const key = `${g.season}|${g.season_type}|${g.week}`;
       if (!bySlot.has(key)) {
@@ -101,6 +124,7 @@ router.post('/group/:groupId/world-cup', authenticateToken, async (req, res) => 
 
     res.json({
       picks: saved.map(p => ({ gameId: p.gameId, pickedResult: p.pickedResult })),
+      lockedGameIds,
     });
   } catch (e) {
     if (e.message === 'GROUP_NOT_FOUND') return res.status(404).json({ error: 'Group not found' });
@@ -352,7 +376,7 @@ router.post('/group/:groupId/world-cup/user/:userId', authenticateToken, async (
     // are upserted under targetUserId rather than the caller.
     const gameIds = picks.map((p) => p.gameId);
     const { rows: gameRows } = await pool.query(
-      `SELECT id, season, season_type, week FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
+      `SELECT id, season, season_type, week, game_date FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
       [gameIds]
     );
     const gameById = new Map(gameRows.map((g) => [g.id, g]));
@@ -362,8 +386,26 @@ router.post('/group/:groupId/world-cup/user/:userId', authenticateToken, async (
       }
     }
 
+    // Kickoff lock applies to admin overrides too: a started match's pick is
+    // frozen for everyone, so even an admin cannot change a member's pick after
+    // the result is in motion. Same stable game_date boundary as the self route.
+    const now = Date.now();
+    const lockedGameIds = [];
+    const openPicks = picks.filter((p) => {
+      const g = gameById.get(p.gameId);
+      if (g && new Date(g.game_date).getTime() <= now) {
+        lockedGameIds.push(p.gameId);
+        return false;
+      }
+      return true;
+    });
+
+    if (openPicks.length === 0) {
+      return res.json({ picks: [], targetUserId, isAdminOverride: true, lockedGameIds });
+    }
+
     const bySlot = new Map();
-    for (const p of picks) {
+    for (const p of openPicks) {
       const g = gameById.get(p.gameId);
       const key = `${g.season}|${g.season_type}|${g.week}`;
       if (!bySlot.has(key)) {
@@ -389,6 +431,7 @@ router.post('/group/:groupId/world-cup/user/:userId', authenticateToken, async (
       picks: saved.map((p) => ({ gameId: p.gameId, pickedResult: p.pickedResult })),
       targetUserId,
       isAdminOverride: true,
+      lockedGameIds,
     });
   } catch (e) {
     if (e.message === 'GROUP_NOT_FOUND') return res.status(404).json({ error: 'Group not found' });

--- a/backend/tests/worldcup-picks-route.test.js
+++ b/backend/tests/worldcup-picks-route.test.js
@@ -118,10 +118,10 @@ describe('World Cup picks router', () => {
       mock.method(pool, 'query', async (sql) => {
         if (/FROM games/.test(sql)) {
           return { rows: [
-            // Kickoff long past -> locked, must never reach the upsert.
-            { id: 101, season: 2026, season_type: 1, week: 1, game_date: '2000-01-01T00:00:00.000Z' },
-            // Kickoff far future -> still open.
-            { id: 102, season: 2026, season_type: 1, week: 1, game_date: '2099-01-01T00:00:00.000Z' },
+            // Kickoff an hour ago -> locked, must never reach the upsert.
+            { id: 101, season: 2026, season_type: 1, week: 1, game_date: new Date(Date.now() - 60 * 60 * 1000).toISOString() },
+            // Kickoff tomorrow -> still open.
+            { id: 102, season: 2026, season_type: 1, week: 1, game_date: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() },
           ] };
         }
         throw new Error(`unexpected query: ${sql}`);

--- a/backend/tests/worldcup-picks-route.test.js
+++ b/backend/tests/worldcup-picks-route.test.js
@@ -113,6 +113,41 @@ describe('World Cup picks router', () => {
       ]);
     });
 
+    test('locks picks for matches past kickoff, persisting only the open ones', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member' }));
+      mock.method(pool, 'query', async (sql) => {
+        if (/FROM games/.test(sql)) {
+          return { rows: [
+            // Kickoff long past -> locked, must never reach the upsert.
+            { id: 101, season: 2026, season_type: 1, week: 1, game_date: '2000-01-01T00:00:00.000Z' },
+            // Kickoff far future -> still open.
+            { id: 102, season: 2026, season_type: 1, week: 1, game_date: '2099-01-01T00:00:00.000Z' },
+          ] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      });
+      const upsert = mock.method(UserPick, 'bulkUpsertWorldCupPicks', async ({ picks }) =>
+        picks.map((p) => ({ gameId: p.gameId, pickedResult: p.pickedResult }))
+      );
+
+      const res = await fetch(`${baseURL}/api/picks/group/wc-pool/world-cup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+        body: JSON.stringify({ picks: [
+          { gameId: 101, pickedResult: 'home' }, // started -> dropped
+          { gameId: 102, pickedResult: 'draw' }, // open -> saved
+        ] }),
+      });
+
+      assert.strictEqual(res.status, 200);
+      const data = await res.json();
+      assert.deepStrictEqual(data.lockedGameIds, [101], 'the started match is reported as locked');
+      assert.deepStrictEqual(data.picks, [{ gameId: 102, pickedResult: 'draw' }], 'only the open pick saves');
+      // The locked game id must never be handed to the persistence layer.
+      const upsertedIds = upsert.mock.calls[0].arguments[0].picks.map((p) => p.gameId);
+      assert.deepStrictEqual(upsertedIds, [102], 'upsert receives only the open game');
+    });
+
     test('rejects a gameId that is not a World Cup game', async () => {
       mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member' }));
       mock.method(pool, 'query', async () => ({ rows: [] })); // no matching WC games

--- a/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
+++ b/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
@@ -16,9 +16,9 @@ function groupMatch(overrides: Partial<WorldCupMatch> = {}): WorldCupMatch {
     awayScore: 0,
     status: 'SCHEDULED',
     isKnockout: false,
-    // Far future so "scheduled, not yet kicked off" stays editable whenever the
+    // Tomorrow so "scheduled, not yet kicked off" stays editable whenever the
     // suite runs. Past-kickoff locking is covered by its own test below.
-    gameDate: '2099-06-11T20:00:00.000Z',
+    gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     ...overrides,
   };
 }
@@ -156,7 +156,7 @@ describe('MatchPickRow', () => {
   it('locks a SCHEDULED match whose kickoff time has already passed', () => {
     const props = {
       ...baseProps(),
-      match: groupMatch({ status: 'SCHEDULED', gameDate: '2000-01-01T00:00:00.000Z' }),
+      match: groupMatch({ status: 'SCHEDULED', gameDate: new Date(Date.now() - 60 * 60 * 1000).toISOString() }),
     };
     render(<MatchPickRow {...props} />);
     expect(screen.getByRole('button', { name: 'Pick Mexico to win' })).toBeDisabled();

--- a/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
+++ b/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
@@ -16,7 +16,9 @@ function groupMatch(overrides: Partial<WorldCupMatch> = {}): WorldCupMatch {
     awayScore: 0,
     status: 'SCHEDULED',
     isKnockout: false,
-    gameDate: '2026-06-11T20:00:00.000Z',
+    // Far future so "scheduled, not yet kicked off" stays editable whenever the
+    // suite runs. Past-kickoff locking is covered by its own test below.
+    gameDate: '2099-06-11T20:00:00.000Z',
     ...overrides,
   };
 }
@@ -144,6 +146,22 @@ describe('MatchPickRow', () => {
     };
     render(<MatchPickRow {...props} />);
     expect(screen.getByRole('button', { name: 'Pick Mexico to win' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Pick Mexico to win' }));
+    expect(props.onPick).not.toHaveBeenCalled();
+  });
+
+  // Regression: ESPN can briefly flap an in-progress match's status back to
+  // SCHEDULED mid-game. Locking must key off the kickoff time, not just status,
+  // so a started match stays locked even when status reads 'SCHEDULED'.
+  it('locks a SCHEDULED match whose kickoff time has already passed', () => {
+    const props = {
+      ...baseProps(),
+      match: groupMatch({ status: 'SCHEDULED', gameDate: '2000-01-01T00:00:00.000Z' }),
+    };
+    render(<MatchPickRow {...props} />);
+    expect(screen.getByRole('button', { name: 'Pick Mexico to win' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Pick a draw' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Pick United States to win' })).toBeDisabled();
     fireEvent.click(screen.getByRole('button', { name: 'Pick Mexico to win' }));
     expect(props.onPick).not.toHaveBeenCalled();
   });

--- a/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.tsx
+++ b/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.tsx
@@ -70,8 +70,15 @@ export default function MatchPickRow({
   disabled = false,
 }: MatchPickRowProps) {
   const status = deriveStatus(match.status);
-  // Once a match leaves the scheduled state it can no longer be picked.
-  const locked = status !== 'not started';
+  // A pick locks at kickoff and STAYS locked. We key off the scheduled kickoff
+  // time (match.gameDate), not just match.status: ESPN occasionally serves a
+  // stale pre-kickoff snapshot mid-match that flaps status back to SCHEDULED,
+  // and a status-only lock would briefly re-open an in-progress match's pick.
+  // The kickoff timestamp is stable, so once it passes the row stays locked no
+  // matter how status flaps. The backend enforces the same kickoff rule.
+  const kickoffPassed =
+    match.gameDate != null && new Date(match.gameDate).getTime() <= Date.now();
+  const locked = status !== 'not started' || kickoffPassed;
   // Knockout fixtures appear in the schedule before their participants are
   // decided; until both slots hold real teams there is nothing to pick.
   const teamsAssigned = hasBothTeamsAssigned(match);

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -44,7 +44,10 @@ function match(overrides: Partial<WorldCupMatch>): WorldCupMatch {
     awayScore: 0,
     status: 'SCHEDULED',
     isKnockout: false,
-    gameDate: '2026-06-11T20:00:00.000Z',
+    // Relative to now (tomorrow) so an upcoming match is always pre-kickoff and
+    // pickable whenever the suite runs — kickoff-time locking is exercised
+    // directly in MatchPickRow's own test.
+    gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     ...overrides,
   };
 }

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -240,7 +240,8 @@ describe('GroupDetailsPage', () => {
       awayScore: 0,
       status: 'SCHEDULED',
       isKnockout: false,
-      gameDate: '2026-06-11T20:00:00.000Z',
+      // Tomorrow, so the match stays pre-kickoff and pickable whenever CI runs.
+      gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     };
     const stageResponder = (stage: WorldCupStage) => {
       const games = stage === 'group' ? [wcMatch] : [];

--- a/frontend/src/pages/WorldCupPicksPage.test.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.test.tsx
@@ -36,7 +36,8 @@ const groupMatch: WorldCupMatch = {
   awayScore: 0,
   status: 'SCHEDULED',
   isKnockout: false,
-  gameDate: '2026-06-11T20:00:00.000Z',
+  // Tomorrow, so the match stays pre-kickoff and pickable whenever CI runs.
+  gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
 };
 
 function renderPage(route = '/world-cup?group=la-crew') {

--- a/frontend/tests/e2e/world-cup-picks-person-selector.spec.ts
+++ b/frontend/tests/e2e/world-cup-picks-person-selector.spec.ts
@@ -79,7 +79,7 @@ async function stubStages(page: Page) {
             status: 'SCHEDULED',
             homeScore: 0,
             awayScore: 0,
-            gameDate: '2026-06-11T19:00:00.000Z',
+            gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
             winnerTeamId: null,
             homeTeam: { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: 'https://example.test/mex.png' },
             awayTeam: { id: '2', name: 'Canada', abbreviation: 'CAN', logo: 'https://example.test/can.png' },

--- a/frontend/tests/e2e/world-cup-picks-renders.spec.ts
+++ b/frontend/tests/e2e/world-cup-picks-renders.spec.ts
@@ -53,7 +53,7 @@ test('world cup picks page renders the stage match list with pick buttons', asyn
           status: 'SCHEDULED',
           homeScore: 0,
           awayScore: 0,
-          gameDate: '2026-06-11T19:00:00.000Z',
+          gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
           winnerTeamId: null,
           homeTeam: {
             id: '1',
@@ -78,7 +78,7 @@ test('world cup picks page renders the stage match list with pick buttons', asyn
           status: 'SCHEDULED',
           homeScore: 0,
           awayScore: 0,
-          gameDate: '2026-06-29T19:00:00.000Z',
+          gameDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
           winnerTeamId: null,
           homeTeam: {
             id: '3',
@@ -206,7 +206,7 @@ test('makes world cup picks inline on the group detail Picks tab', async ({ page
             status: 'SCHEDULED',
             homeScore: 0,
             awayScore: 0,
-            gameDate: '2026-06-11T19:00:00.000Z',
+            gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
             winnerTeamId: null,
             homeTeam: {
               id: '1',


### PR DESCRIPTION
## Problem (caught live during the Jun 11 opener)

During MEX vs RSA, a stale ESPN read flapped the live match's status back to `SCHEDULED`, and the pick UI **re-opened the pick** — you could change a pick after seeing the score. Two bugs:

1. **Frontend (cosmetic):** `MatchPickRow` derived `locked` from `match.status` alone (`MatchPickRow.tsx:74`), so a flap back to `SCHEDULED` re-enabled the buttons.
2. **Backend (the real integrity hole):** both World Cup submit routes (`worldCupPicks.js`) validated pick shape, membership, and that the game is a WC game — but **never checked kickoff or status**. A late pick was accepted and overwrote the previous one. The UI lock was just UX.

## Fix — lock on kickoff *time*, enforced server-side

`game_date` (scheduled kickoff) is stable, so it's immune to the ESPN status flap.

- **`MatchPickRow.tsx`** — `locked = status !== 'not started' || kickoffPassed`, where `kickoffPassed = new Date(match.gameDate) <= now`. Stays locked through status flaps.
- **`worldCupPicks.js` (self + admin routes)** — select `game_date`; drop any pick whose kickoff has passed, **preserving the already-saved value**, and return `lockedGameIds`. Skip-and-save-rest (not reject-the-batch) because the client submits the whole 72-match slate every time, so a hard reject would make all picks unsavable once the first match starts. The lock applies to admin overrides too — a started match is frozen for everyone.
- Tests: component locks a `SCHEDULED` match with a past kickoff; route drops the started pick, saves the rest, and never hands the locked id to the upsert.

## Testing note

The frontend (vitest) and backend (express/pg) suites can't run in the authoring sandbox (no installed deps there), so the new tests are written but unrun by me — please let CI / a local run confirm. All edited JS passes `node --check`; the backend change is backward-compatible with the existing route tests (rows without `game_date` → `NaN` comparison → treated as open).

## Deploy note

This is a mid-tournament correctness fix. Merging deploys the backend (the authoritative lock) and frontend via the existing Vercel workflows. Recommend merging promptly since the hole is actively exploitable, but it's your call given a match is live.

https://claude.ai/code/session_01RC95R4aHf3fVEauZ3cFVYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC95R4aHf3fVEauZ3cFVYx)_