### PR TITLE
Mobile-responsive group picks (card layout below md)

### DIFF
--- a/frontend/src/designsystem/components/GroupPicks/GroupPicks.test.tsx
+++ b/frontend/src/designsystem/components/GroupPicks/GroupPicks.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { GroupPicks } from './';
 import type { GameData, GroupMember, MemberPicks, PickData, TeamData } from '../../../lib/types';
 
@@ -286,6 +286,48 @@ describe('GroupPicks', () => {
       // With only SCHEDULED + IN_PROGRESS games, the column disappears entirely.
       rerender(<GroupPicks games={[SCHEDULED_GAME, IN_PROGRESS_GAME]} picks={PICKS} members={MEMBERS} />);
       expect(screen.queryByRole('columnheader', { name: 'Correct' })).not.toBeInTheDocument();
+    });
+  });
+
+  // Below the `md` breakpoint, useMediaQuery('(max-width: 767px)') matches and
+  // GroupPicks renders a card-per-game layout instead of the wide table.
+  describe('mobile layout (below md)', () => {
+    function mockViewport(matches: boolean) {
+      window.matchMedia = ((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      })) as unknown as typeof window.matchMedia;
+    }
+
+    beforeEach(() => mockViewport(true)); // simulate a small viewport
+    afterEach(() => mockViewport(false)); // restore the desktop default
+
+    it('renders cards instead of the table', () => {
+      render(<GroupPicks games={GAMES} picks={PICKS} members={MEMBERS} />);
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+      // One matchup heading per game (unique), and every member is listed in
+      // each game's card.
+      expect(screen.getByText('KC @ BUF')).toBeInTheDocument();
+      expect(screen.getByText('SF @ BAL')).toBeInTheDocument();
+      expect(screen.getAllByText('Alice Johnson')).toHaveLength(GAMES.length);
+    });
+
+    it('withholds picks until kickoff in the card layout', () => {
+      render(<GroupPicks games={[SCHEDULED_GAME]} picks={PICKS} members={MEMBERS} />);
+      // One "Hidden" placeholder per member for the still-scheduled game.
+      expect(screen.getAllByText('Hidden')).toHaveLength(MEMBERS.length);
+    });
+
+    it('shows graded results and the per-game correct/graded aggregate', () => {
+      render(<GroupPicks games={[FINAL_GAME]} picks={PICKS} members={MEMBERS} />);
+      // Alice + Carol correct, Bob wrong → 2/3.
+      expect(screen.getByText('2/3 correct')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/designsystem/components/GroupPicks/GroupPicks.tsx
+++ b/frontend/src/designsystem/components/GroupPicks/GroupPicks.tsx
@@ -1,5 +1,7 @@
 import Avatar from '../Avatar';
 import Button from '../Button';
+import Card from '../Card';
+import { useMediaQuery } from '../../../hooks/useMediaQuery';
 import type { GameData, GroupMember, MemberPicks, PickData } from '../../../lib/types';
 
 export interface GroupPicksProps {
@@ -78,6 +80,13 @@ function rowCorrectness(game: GameData, picksByMember: Map<string, Map<number, P
   return { correct, graded };
 }
 
+/** Human-readable status line for a game, shared by the table and mobile cards. */
+function statusLabel(game: GameData): string {
+  if (game.status === 'FINAL') return `Final ${game.awayScore}-${game.homeScore}`;
+  if (game.status === 'IN_PROGRESS') return game.statusDetail || 'In progress';
+  return 'Scheduled';
+}
+
 const HEADER_CELL = 'px-sm py-xs text-left text-xs font-semibold uppercase tracking-wide text-secondary-500 dark:text-secondary-400';
 const BODY_CELL = 'px-sm py-xs align-top text-sm text-secondary-900 dark:text-neutral-0 border-t border-secondary-200 dark:border-secondary-700';
 const PLACEHOLDER = 'text-secondary-400 dark:text-secondary-500 italic';
@@ -105,6 +114,10 @@ export default function GroupPicks({ games, picks, members, onRefresh }: GroupPi
 
   const hasFinal = games.some(game => game.status === 'FINAL');
 
+  // Below `md`, the member-per-column table can't fit — render a card per game
+  // instead (one layout mounts at a time so screen readers don't read both).
+  const isMobile = useMediaQuery('(max-width: 767px)');
+
   return (
     <div className="space-y-md">
       {/* Header */}
@@ -123,6 +136,56 @@ export default function GroupPicks({ games, picks, members, onRefresh }: GroupPi
         <p className="text-sm text-secondary-500 dark:text-secondary-400 py-lg text-center">
           {games.length === 0 ? 'No games available for this week.' : 'No members to display.'}
         </p>
+      ) : isMobile ? (
+        /* Mobile: one card per game, members listed inside. */
+        <div className="space-y-sm">
+          {games.map(game => {
+            const { correct, graded } = rowCorrectness(game, picksByMember, members);
+            return (
+              <Card key={game.id} padding="md" className="space-y-sm">
+                <div className="flex items-start justify-between gap-sm">
+                  <div className="min-w-0">
+                    <div className="font-heading font-semibold text-secondary-900 dark:text-neutral-0">
+                      {game.awayTeam.abbreviation} @ {game.homeTeam.abbreviation}
+                    </div>
+                    <div className="text-xs text-secondary-500 dark:text-secondary-400">
+                      {statusLabel(game)}
+                    </div>
+                  </div>
+                  {hasFinal && game.status === 'FINAL' && (
+                    <span className="shrink-0 rounded-full bg-secondary-100 dark:bg-secondary-800 px-xs py-xxxs text-xs font-medium text-secondary-700 dark:text-secondary-300">
+                      {correct}/{graded} correct
+                    </span>
+                  )}
+                </div>
+                <ul className="divide-y divide-secondary-200 dark:divide-secondary-700">
+                  {members.map(member => {
+                    const pick = picksByMember.get(member.id)?.get(game.id);
+                    const state = cellState(game, pick);
+                    return (
+                      <li key={member.id} className="flex items-center justify-between gap-sm py-xs">
+                        <div className="flex min-w-0 items-center gap-xs">
+                          <Avatar
+                            name={member.name}
+                            email={member.email}
+                            pictureUrl={member.pictureUrl}
+                            variant="sm"
+                          />
+                          <span className="truncate text-sm font-medium text-secondary-700 dark:text-secondary-300">
+                            {member.name || member.email}
+                          </span>
+                        </div>
+                        <div className="shrink-0 text-right text-sm text-secondary-900 dark:text-neutral-0">
+                          {renderCell(game, pick, state)}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </Card>
+            );
+          })}
+        </div>
       ) : (
         <div className="overflow-x-auto rounded-lg border border-secondary-200 dark:border-secondary-700">
           <table className="min-w-full border-collapse bg-neutral-0 dark:bg-secondary-900">
@@ -163,11 +226,7 @@ export default function GroupPicks({ games, picks, members, onRefresh }: GroupPi
                         {game.awayTeam.abbreviation} @ {game.homeTeam.abbreviation}
                       </span>
                       <span className="block text-xs font-normal text-secondary-500 dark:text-secondary-400">
-                        {game.status === 'FINAL'
-                          ? `Final ${game.awayScore}-${game.homeScore}`
-                          : game.status === 'IN_PROGRESS'
-                            ? game.statusDetail || 'In progress'
-                            : 'Scheduled'}
+                        {statusLabel(game)}
                       </span>
                     </th>
 

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Subscribe to a CSS media query and return whether it currently matches.
+ *
+ * Used to mount responsive variants conditionally (one layout at a time) rather
+ * than rendering both and toggling with CSS `hidden` — which would duplicate
+ * content for screen readers and break single-element test queries.
+ *
+ * Safe when `matchMedia` is unavailable (returns `false`); tests mock
+ * `window.matchMedia` in test-setup.ts.
+ */
+export function useMediaQuery(query: string): boolean {
+  const getMatches = () =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(query).matches
+      : false;
+
+  const [matches, setMatches] = useState<boolean>(getMatches);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener?.('change', onChange);
+    return () => mql.removeEventListener?.('change', onChange);
+  }, [query]);
+
+  return matches;
+}
+
+export default useMediaQuery;

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom'
+
+// jsdom has no matchMedia. Default every query to "not matching" so responsive
+// components (useMediaQuery) render their desktop/base layout in tests unless a
+// test explicitly overrides window.matchMedia to simulate a smaller viewport.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string): MediaQueryList =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}


### PR DESCRIPTION
## Summary
The group **Picks** matrix (`GroupPicks`) is a games × members `<table>` that scrolls sideways on a phone once a group has more than ~2 members. Below the `md` breakpoint it now renders **one card per game** — matchup + status, with each member's pick listed inside — so there's **no horizontal scroll at any group size**. Desktop (≥768px) renders the original table, unchanged.

## How
- New **`useMediaQuery` hook** mounts a *single* layout at a time (not a CSS `hidden`/dual-render), so screen readers don't read both copies and tests stay deterministic.
- Shared the cell-visibility / lock / status logic between the table and the cards, so the two layouts can never disagree (picks stay "Hidden" until kickoff in both).
- `test-setup.ts` gets a default `matchMedia` mock (desktop) so all existing table tests are unaffected; the new mobile-layout tests flip it to assert the cards.

## Scope / safety
- **NFL group picks only.** World Cup picks render entirely separate components (`MatchPickRow`, `TournamentLeaderboard`) — untouched. No shared code path.
- 4 files changed, **+157 / −6**.

## Verification
- ✅ unit **593 passing** (Node 20), incl. 3 new mobile-layout tests
- ✅ e2e **33 passing** (incl. the World Cup picks e2e — proves the WC path is unaffected)
- ✅ `tsc --noEmit` clean

| | |
|---|---|
| Mobile (≤767px) | one card per game, members inside, no horizontal scroll |
| Desktop (≥768px) | original member-per-column table, unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)