### PR TITLE
World Cup match timeline (goal/card events in the pick card)

### DIFF
--- a/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
+++ b/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import MatchPickRow from './MatchPickRow';
-import type { TeamData, WorldCupMatch } from '../../../lib/types';
+import type { MatchEvent, TeamData, WorldCupMatch } from '../../../lib/types';
 
 const mexico: TeamData = { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: '' };
 const usa: TeamData = { id: '2', name: 'United States', abbreviation: 'USA', logo: '' };
@@ -164,5 +164,34 @@ describe('MatchPickRow', () => {
     expect(screen.getByRole('button', { name: 'Pick United States to win' })).toBeDisabled();
     fireEvent.click(screen.getByRole('button', { name: 'Pick Mexico to win' }));
     expect(props.onPick).not.toHaveBeenCalled();
+  });
+
+  describe('match timeline', () => {
+    const EVENTS: MatchEvent[] = [
+      { type: 'goal', minute: "9'", player: 'J. Quiñones', side: 'home', teamAbbr: 'MEX' },
+      { type: 'red-card', minute: "49'", player: 'S. Sithole', side: 'away', teamAbbr: 'USA' },
+    ];
+
+    it('renders the goal/card timeline once a started match has events', () => {
+      const match = groupMatch({ status: 'FINAL', events: EVENTS });
+      render(<MatchPickRow {...baseProps()} match={match} />);
+      expect(screen.getByText("9'")).toBeInTheDocument();
+      expect(screen.getByText('J. Quiñones')).toBeInTheDocument();
+      expect(screen.getByText('S. Sithole')).toBeInTheDocument();
+    });
+
+    it('hides the timeline before kickoff even when events are present', () => {
+      // Default groupMatch is SCHEDULED with a future kickoff → not locked.
+      const match = groupMatch({ events: EVENTS });
+      render(<MatchPickRow {...baseProps()} match={match} />);
+      expect(screen.queryByText("9'")).not.toBeInTheDocument();
+      expect(screen.queryByText('J. Quiñones')).not.toBeInTheDocument();
+    });
+
+    it('renders no timeline when a started match has no events', () => {
+      const match = groupMatch({ status: 'FINAL' });
+      render(<MatchPickRow {...baseProps()} match={match} />);
+      expect(screen.queryByText('J. Quiñones')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.tsx
+++ b/frontend/src/designsystem/components/MatchPickRow/MatchPickRow.tsx
@@ -1,4 +1,5 @@
 import Button from '../Button';
+import MatchTimeline from '../MatchTimeline';
 import { hasBothTeamsAssigned } from '../../../lib/teamUtils';
 import type { MatchPickResult, TeamData, WorldCupMatch } from '../../../lib/types';
 
@@ -132,6 +133,12 @@ export default function MatchPickRow({
         <span className="text-xs font-semibold uppercase text-content-muted">vs</span>
         <TeamLabel team={match.awayTeam} score={match.awayScore} showScore={locked} align="right" />
       </div>
+
+      {locked && match.events && match.events.length > 0 && (
+        <div className="border-t border-border pt-xs">
+          <MatchTimeline events={match.events} />
+        </div>
+      )}
 
       <div className="flex items-stretch gap-xs" role="group" aria-label="Select match result">
         {pickButton('home', homeLabel, `Pick ${match.homeTeam.name} to win`)}

--- a/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.test.tsx
+++ b/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import MatchTimeline from './MatchTimeline';
+import type { MatchEvent } from '../../../lib/types';
+
+const EVENTS: MatchEvent[] = [
+  { type: 'goal', minute: "9'", player: 'J. Quiñones', side: 'home', teamAbbr: 'MEX' },
+  { type: 'yellow-card', minute: "17'", player: 'T. Mokoena', side: 'away', teamAbbr: 'RSA' },
+  { type: 'red-card', minute: "49'", player: 'S. Sithole', side: 'away', teamAbbr: 'RSA' },
+];
+
+describe('MatchTimeline', () => {
+  it('renders nothing when there are no events', () => {
+    const { container } = render(<MatchTimeline events={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the minute and player for every event', () => {
+    render(<MatchTimeline events={EVENTS} />);
+    for (const ev of EVENTS) {
+      expect(screen.getByText(ev.minute)).toBeInTheDocument();
+      expect(screen.getByText(ev.player)).toBeInTheDocument();
+    }
+  });
+
+  it('renders a labelled glyph matching each event type', () => {
+    render(<MatchTimeline events={EVENTS} />);
+    expect(screen.getByTitle('Goal')).toBeInTheDocument();
+    expect(screen.getByTitle('Yellow card')).toBeInTheDocument();
+    expect(screen.getByTitle('Red card')).toBeInTheDocument();
+  });
+
+  it('places home events left of the minute and away events right of it', () => {
+    render(<MatchTimeline events={EVENTS} />);
+    // Each event contributes three grid cells: [home] [minute] [away]. A home
+    // event fills the left cell (previous sibling of the minute); an away event
+    // fills the right cell (next sibling).
+    const homeMinute = screen.getByText("9'");
+    expect(homeMinute.previousElementSibling?.textContent).toContain('J. Quiñones');
+
+    const awayMinute = screen.getByText("17'");
+    expect(awayMinute.nextElementSibling?.textContent).toContain('T. Mokoena');
+  });
+
+  it('keeps the glyph adjacent to the player name (no flex-fill gap)', () => {
+    render(<MatchTimeline events={EVENTS} />);
+    // The away player and its glyph live in the same flex group, so the player
+    // span's immediate sibling is the glyph wrapper (titled) — not a spacer.
+    const player = screen.getByText('T. Mokoena');
+    expect(player.parentElement?.querySelector('[title="Yellow card"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.tsx
+++ b/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.tsx
@@ -1,0 +1,105 @@
+import { Fragment } from 'react';
+import type { MatchEvent, MatchEventType } from '../../../lib/types';
+
+export interface MatchTimelineProps {
+  /** Chronological goal/card events for a match (already ordered by the source). */
+  events: MatchEvent[];
+  className?: string;
+}
+
+/** Stylized soccer-ball glyph; inherits its color from the surrounding text. */
+function GoalGlyph({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={`h-icon-sm w-icon-sm ${className}`.trim()}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7.4l4.1 3-1.6 4.9H9.5L7.9 10.4 12 7.4z" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+/** A booking card — a small rounded rectangle in the yellow/red token color. */
+function CardGlyph({ tone }: { tone: 'yellow' | 'red' }) {
+  const color = tone === 'yellow' ? 'bg-warning-400' : 'bg-error-500';
+  return <span className={`inline-block h-icon-sm w-[0.65em] rounded-sm ${color}`} aria-hidden="true" />;
+}
+
+const GLYPH: Record<MatchEventType, React.ReactNode> = {
+  goal: <GoalGlyph className="text-content" />,
+  'own-goal': <GoalGlyph className="text-error-500" />,
+  'yellow-card': <CardGlyph tone="yellow" />,
+  'red-card': <CardGlyph tone="red" />,
+};
+
+const LABEL: Record<MatchEventType, string> = {
+  goal: 'Goal',
+  'own-goal': 'Own goal',
+  'yellow-card': 'Yellow card',
+  'red-card': 'Red card',
+};
+
+/**
+ * Two-sided match timeline (Apple Sports style): the minute runs down a central
+ * spine, with each event's glyph + player branching to the left (home) or right
+ * (away). Purely presentational and fully token-driven — the parent supplies the
+ * `events`; nothing here is hard-coded.
+ */
+export default function MatchTimeline({ events, className = '' }: MatchTimelineProps) {
+  if (events.length === 0) return null;
+  return (
+    <div
+      aria-label="Match timeline"
+      className={`relative grid grid-cols-[1fr_auto_1fr] items-center gap-x-sm gap-y-xs text-xs ${className}`.trim()}
+    >
+      {/* Central spine — the minute chips mask it where they sit. */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border"
+      />
+
+      {events.map((ev, i) => {
+        const home = ev.side === 'home';
+        const glyph = (
+          <span className="flex shrink-0 justify-center" title={LABEL[ev.type]}>
+            {GLYPH[ev.type]}
+          </span>
+        );
+        const player = <span className="min-w-0 truncate text-content">{ev.player}</span>;
+        return (
+          <Fragment key={i}>
+            {/* Home side (left): glyph · name grouped, hugging the spine. */}
+            {home ? (
+              <div className="flex min-w-0 items-center justify-end gap-xs">
+                {glyph}
+                {player}
+              </div>
+            ) : (
+              <span />
+            )}
+
+            {/* Minute, on the spine. */}
+            <span className="relative z-10 rounded-full bg-surface px-xs font-semibold tabular-nums text-content-muted">
+              {ev.minute}
+            </span>
+
+            {/* Away side (right): name · glyph grouped, hugging the spine. */}
+            {home ? (
+              <span />
+            ) : (
+              <div className="flex min-w-0 items-center justify-start gap-xs">
+                {player}
+                {glyph}
+              </div>
+            )}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/designsystem/components/MatchTimeline/index.ts
+++ b/frontend/src/designsystem/components/MatchTimeline/index.ts
@@ -1,0 +1,2 @@
+export { default, default as MatchTimeline } from './MatchTimeline';
+export type { MatchTimelineProps } from './MatchTimeline';

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -128,6 +128,23 @@ export const WORLD_CUP_STAGES: readonly WorldCupStage[] = [
   'final',
 ] as const;
 
+// Normalized in-match event (goal or card), derived from ESPN's
+// `competitions[0].details`. Presentational only — minute is ESPN's display
+// clock string ("9'", "90'+2'") so the UI never re-formats stoppage time.
+export type MatchEventType = 'goal' | 'own-goal' | 'yellow-card' | 'red-card';
+
+export interface MatchEvent {
+  type: MatchEventType;
+  /** ESPN display clock, e.g. "9'" or "90'+2'". */
+  minute: string;
+  /** Player short name, e.g. "J. Quiñones". */
+  player: string;
+  /** Which side the event is credited to. */
+  side: 'home' | 'away';
+  /** Team abbreviation for display, e.g. "MEX". */
+  teamAbbr: string;
+}
+
 // Shaped like the backend world_cup Game JSON. `isKnockout` is a derived flag
 // (stage !== 'group') the route emits so the UI can disable draw picks without
 // re-deriving stage membership.
@@ -142,6 +159,8 @@ export interface WorldCupMatch {
   isKnockout: boolean;
   gameDate?: string;
   winnerTeamId?: string | null;
+  /** Goal/card timeline once the match has started. Absent before kickoff. */
+  events?: MatchEvent[];
 }
 
 // Mirrors the backend pick route body, which keys off `pickedResult`.


### PR DESCRIPTION
## What

Adds a two-sided **match timeline** to the World Cup pick card, showing goals and yellow/red cards with the minute and player, once a match has kicked off.

The layout follows the Apple Sports pattern: the minute runs down a central spine, with each event's glyph + player name branching left (home) or right (away). The glyph hugs the name (no flex-fill gap) so it stays legible.

## Scope

**Presentation layer only.** This PR consumes a `MatchEvent[]` already attached to `WorldCupMatch.events` and renders it. The backend events feed + live in-progress updates land in the **follow-up PR** (status-aware TTL + polling, "Timeline PR first, live next").

## Details

- New `MatchTimeline` design-system component — fully token-driven (no hard-coded colors/spacing); goal glyph is a stylized soccer ball inheriting `currentColor`, cards are `bg-warning-400` / `bg-error-500` chips.
- `MatchPickRow` renders the timeline below the score, **only once the match is locked** (kickoff passed) and events exist — never before kickoff.
- New `MatchEvent` / `MatchEventType` types on `lib/types`.
- Tests: 5 for `MatchTimeline` (empty, minute/player render, glyph-by-title, home/away placement, glyph adjacency); 3 for `MatchPickRow` timeline gating (shows after kickoff with events, hidden before kickoff, none when no events).

## Verification

- `tsc` clean
- Unit suite green (601 passing)
- Production build OK (~89 kB gzip)
