### PR TITLE
World Cup live updates: match events feed + status-aware polling

### DIFF
--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -335,6 +335,23 @@ END $$;
 -- Serves the cache-first stage reads in GameService.getWorldCupStage.
 CREATE INDEX IF NOT EXISTS idx_games_league_stage ON games(league, stage);
 
+-- Persisted goal/card timeline. ESPN exposes a per-match `competition.details`
+-- array (each entry a goal/card with its minute, player, and side); we flatten it
+-- to { type, minute, player, side, teamAbbr } and store it so the World Cup pick
+-- card can render a match timeline from a cached read — no live ESPN call per view.
+-- NULL means "not yet parsed" (a row cached before this column existed); [] means
+-- "parsed, no events". GameService treats a started match still holding NULL as
+-- stale so the next refresh backfills it.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'games' AND column_name = 'events'
+  ) THEN
+    ALTER TABLE games ADD COLUMN events JSONB NULL;
+  END IF;
+END $$;
+
 -- Fix duplicate confidence constraint issue (remove incorrect constraint that lacks group_id)
 DO $$
 BEGIN

--- a/backend/src/mocks/espnWorldCupData.js
+++ b/backend/src/mocks/espnWorldCupData.js
@@ -79,7 +79,8 @@ export function buildMockWorldCupEvent({
   odds = null,
   probability = null,
   winner = null,
-  shootout = null
+  shootout = null,
+  events = null
 }) {
   const statusConfig = {
     scheduled: { state: 'pre', name: 'STATUS_SCHEDULED', description: 'Scheduled', detail: date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }), completed: false },
@@ -164,6 +165,34 @@ export function buildMockWorldCupEvent({
     return competitor;
   };
 
+  // ESPN exposes goals/cards under competition.details. Build that array from a
+  // compact descriptor list — { type: 'goal'|'own-goal'|'yellow-card'|'red-card',
+  // minute: "9'", player, side: 'home'|'away' } — mirroring the real payload's
+  // boolean flags (scoringPlay/ownGoal/yellowCard/redCard), clock, team ref, and
+  // athletesInvolved so Game.parseMatchEvents has realistic input to flatten.
+  const DETAIL_TYPE = {
+    goal: { id: '70', text: 'Goal' },
+    'own-goal': { id: '97', text: 'Own Goal' },
+    'yellow-card': { id: '94', text: 'Yellow Card' },
+    'red-card': { id: '93', text: 'Red Card' }
+  };
+  const matchDetails = Array.isArray(events)
+    ? events.map((e) => {
+        const team = e.side === 'home' ? homeTeam : awayTeam;
+        return {
+          type: DETAIL_TYPE[e.type] || { id: '0', text: e.type },
+          clock: { value: 0, displayValue: e.minute },
+          team: { id: team.id },
+          scoringPlay: e.type === 'goal' || e.type === 'own-goal',
+          ownGoal: e.type === 'own-goal',
+          penaltyKick: false,
+          yellowCard: e.type === 'yellow-card',
+          redCard: e.type === 'red-card',
+          athletesInvolved: [{ displayName: e.player }]
+        };
+      })
+    : [];
+
   return {
     id,
     uid: `s:600~l:606~e:${id}`,
@@ -193,6 +222,7 @@ export function buildMockWorldCupEvent({
         buildCompetitor(homeTeam, 'home', homeScore, 0),
         buildCompetitor(awayTeam, 'away', awayScore, 1)
       ],
+      details: matchDetails,
       notes: [],
       status: statusBlock,
       broadcasts: [],

--- a/backend/src/models/Game.js
+++ b/backend/src/models/Game.js
@@ -37,6 +37,12 @@ export class Game {
     // competitor.winner flag — the only signal on a PK shootout — is not
     // recoverable from a cached row's scores alone.
     this.winnerTeamId = data.winnerTeamId ?? null;
+    // Goal/card timeline (soccer). An array of { type, minute, player, side,
+    // teamAbbr } parsed from ESPN's competition.details. `null` is meaningful:
+    // it marks a row cached before the events column existed (never parsed), which
+    // GameService uses to force a one-time backfill. An ESPN-sourced Game always
+    // carries a concrete array ([] when the match has no goals/cards yet).
+    this.events = data.events ?? null;
     this.lastUpdated = data.lastUpdated;
     this.createdAt = data.createdAt;
   }
@@ -56,7 +62,9 @@ static fromESPNData(espnGame, opts = {}) {
   const homeTeam = competitors.find(c => c.homeAway === 'home');
   const awayTeam = competitors.find(c => c.homeAway === 'away');
 
-  
+  // Goal/card timeline. Always an array (possibly empty) for an ESPN-sourced game.
+  const events = Game.parseMatchEvents(competition, homeTeam, awayTeam);
+
   const weekData = competition.week || espnGame.week || {};
   let week = weekData.number || 1;
 
@@ -167,12 +175,61 @@ static fromESPNData(espnGame, opts = {}) {
     seasonType: seasonType,
     league,
     stage,
+    events,
     lastUpdated: new Date()
   });
 }
 
+// Flatten ESPN's `competition.details` into the timeline shape the World Cup pick
+// card renders: { type, minute, player, side, teamAbbr }. ESPN lists every match
+// detail — goals, cards, substitutions, VAR reviews — each tagged with the minute
+// (clock.displayValue), the involved athlete, and the team. We keep only goals and
+// bookings and resolve the team to a home/away side. A penalty goal carries
+// scoringPlay; an own goal is flagged separately so the UI can mark it. Returns []
+// when ESPN provides no details (a scheduled match, or a kickoff with nothing yet).
+static parseMatchEvents(competition, homeComp, awayComp) {
+  const details = competition && competition.details;
+  if (!Array.isArray(details) || details.length === 0) return [];
+
+  const homeId = homeComp && homeComp.id != null ? String(homeComp.id) : null;
+  const awayId = awayComp && awayComp.id != null ? String(awayComp.id) : null;
+
+  const sideFor = (teamId) => {
+    const id = teamId != null ? String(teamId) : null;
+    if (id && id === homeId) return { side: 'home', teamAbbr: homeComp.team?.abbreviation ?? null };
+    if (id && id === awayId) return { side: 'away', teamAbbr: awayComp.team?.abbreviation ?? null };
+    return null;
+  };
+
+  const classify = (d) => {
+    if (d?.ownGoal === true) return 'own-goal';
+    if (d?.scoringPlay === true || (d?.type?.text || '').toLowerCase().includes('goal')) return 'goal';
+    if (d?.redCard === true) return 'red-card';
+    if (d?.yellowCard === true) return 'yellow-card';
+    return null; // substitution, VAR, etc. — not shown on the timeline
+  };
+
+  const events = [];
+  for (const d of details) {
+    const type = classify(d);
+    if (!type) continue;
+    const where = sideFor(d?.team?.id);
+    if (!where) continue;
+    const minute = d?.clock?.displayValue ?? null;
+    const player = d?.athletesInvolved?.[0]?.displayName ?? null;
+    if (!minute || !player) continue; // a malformed detail is dropped, not rendered blank
+    events.push({ type, minute, player, side: where.side, teamAbbr: where.teamAbbr });
+  }
+  return events;
+}
+
   // Check if this game data is different from another game
   isDifferentFrom(otherGame) {
+    // Event-count fingerprint. Match feeds are append-only, so a new goal/card
+    // grows the count. `null` (never-parsed cached row) maps to -1 so a first
+    // parse — even to an empty [] — reads as a change and gets persisted, which
+    // is what backfills the events column for pre-existing rows.
+    const eventCount = (g) => (Array.isArray(g.events) ? g.events.length : -1);
     return (
       this.gameDate.getTime() !== otherGame.gameDate.getTime() ||
   this.status !== otherGame.status ||
@@ -180,7 +237,8 @@ static fromESPNData(espnGame, opts = {}) {
   this.awayScore !== otherGame.awayScore ||
   this.period !== otherGame.period ||
   this.displayClock !== otherGame.displayClock ||
-  this.statusDetail !== otherGame.statusDetail
+  this.statusDetail !== otherGame.statusDetail ||
+  eventCount(this) !== eventCount(otherGame)
     );
   }
 
@@ -198,8 +256,8 @@ async save() {
       espn_id, home_team, away_team, game_date, status,
       period, display_clock, status_detail,
       home_score, away_score, week, season, season_type, odds, probability, last_updated,
-      league, stage, winner_team_id
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+      league, stage, winner_team_id, events
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
     ON CONFLICT (espn_id)
     DO UPDATE SET
       home_team = $2,
@@ -219,7 +277,8 @@ async save() {
       last_updated = $16,
       league = $17,
       stage = $18,
-      winner_team_id = $19
+      winner_team_id = $19,
+      events = $20
     RETURNING *
   `;
 
@@ -242,7 +301,10 @@ async save() {
     this.lastUpdated,
     this.league || null,
     this.stage || null,
-    this.winnerTeamId || null
+    this.winnerTeamId || null,
+    // Persist [] (not NULL) once parsed, so a genuinely eventless match reads as
+    // "parsed, none" rather than re-triggering the backfill refresh every request.
+    JSON.stringify(this.events ?? [])
   ];
 
   const result = await pool.query(query, values);
@@ -274,6 +336,9 @@ static fromDbRow(row) {
     league: row.league,
     stage: row.stage,
     winnerTeamId: row.winner_team_id ?? null,
+    // Preserve NULL as null (never-parsed) vs [] (parsed, empty) — the distinction
+    // drives the one-time events backfill in GameService.isStageCacheFresh.
+    events: row.events == null ? null : (typeof row.events === 'string' ? JSON.parse(row.events) : row.events),
     lastUpdated: new Date(row.last_updated),
     createdAt: new Date(row.created_at)
   });
@@ -344,6 +409,8 @@ static async findByLeagueStage(league, stage) {
       league: this.league,
       stage: this.stage,
       winnerTeamId: this.winnerTeamId ?? null,
+      // The client always wants a concrete array; a never-parsed null collapses to [].
+      events: this.events ?? [],
       lastUpdated: this.lastUpdated,
       createdAt: this.createdAt
     };

--- a/backend/src/services/GameService.js
+++ b/backend/src/services/GameService.js
@@ -166,6 +166,14 @@ export class GameService {
   static isStageCacheFresh(cachedSet, now = Date.now()) {
     if (cachedSet.length === 0) return false;
 
+    // One-time events backfill: a started match (IN_PROGRESS or FINAL) whose
+    // events column is still NULL was cached before goal/card parsing existed.
+    // Force a refresh so its timeline populates. Once persisted as [] or a real
+    // array it reads as fresh, so this fires at most once per such row. Scheduled
+    // matches legitimately have no events yet, so they never trigger it.
+    const needsEventsBackfill = cachedSet.some(g => g.status !== 'SCHEDULED' && g.events == null);
+    if (needsEventsBackfill) return false;
+
     const startWindowMs = 2 * 60 * 1000;
     const needStartRefresh = cachedSet.some(g => {
       try {

--- a/backend/tests/game-soccer.test.js
+++ b/backend/tests/game-soccer.test.js
@@ -2,7 +2,11 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert';
 import { Game } from '../src/models/Game.js';
 import { generateMockWeek } from '../src/mocks/espnGameData.js';
-import { generateMockWorldCupStage } from '../src/mocks/espnWorldCupData.js';
+import {
+  generateMockWorldCupStage,
+  buildMockWorldCupEvent,
+  WORLD_CUP_2026_TEAMS,
+} from '../src/mocks/espnWorldCupData.js';
 
 // These tests focus on the pure fromESPNData / toJSON behavior — the league/stage
 // stamping and the shared competitor parsing — without touching the database. The
@@ -98,5 +102,82 @@ describe('Game.toJSON surfaces league and stage', () => {
     assert.ok('stage' in json, 'toJSON should always include the stage field');
     assert.strictEqual(json.league, 'nfl');
     assert.strictEqual(json.stage, null);
+  });
+});
+
+describe('Game.fromESPNData match events (goals/cards)', () => {
+  const { MEX, USA } = WORLD_CUP_2026_TEAMS;
+
+  function eventMatch(events, overrides = {}) {
+    return buildMockWorldCupEvent({
+      id: '900',
+      date: new Date('2026-06-11T18:00:00Z'),
+      homeTeam: MEX,
+      awayTeam: USA,
+      homeScore: 2,
+      awayScore: 1,
+      status: 'final',
+      stage: 'group',
+      events,
+      ...overrides,
+    });
+  }
+
+  test('flattens ESPN details into { type, minute, player, side, teamAbbr }', () => {
+    const game = Game.fromESPNData(
+      eventMatch([
+        { type: 'goal', minute: "9'", player: 'J. Quiñones', side: 'home' },
+        { type: 'yellow-card', minute: "17'", player: 'T. Mokoena', side: 'away' },
+        { type: 'red-card', minute: "49'", player: 'S. Sithole', side: 'away' },
+      ]),
+      { league: 'world_cup', stage: 'group' },
+    );
+
+    assert.strictEqual(game.events.length, 3);
+    assert.deepStrictEqual(game.events[0], {
+      type: 'goal',
+      minute: "9'",
+      player: 'J. Quiñones',
+      side: 'home',
+      teamAbbr: MEX.abbreviation,
+    });
+    assert.strictEqual(game.events[1].type, 'yellow-card');
+    assert.strictEqual(game.events[1].side, 'away');
+    assert.strictEqual(game.events[1].teamAbbr, USA.abbreviation);
+    assert.strictEqual(game.events[2].type, 'red-card');
+  });
+
+  test('classifies an own goal distinctly from a regular goal', () => {
+    const game = Game.fromESPNData(
+      eventMatch([{ type: 'own-goal', minute: "30'", player: 'A. Defender', side: 'home' }]),
+      { league: 'world_cup', stage: 'group' },
+    );
+    assert.strictEqual(game.events[0].type, 'own-goal');
+  });
+
+  test('returns [] for a scheduled match with no details, and toJSON exposes an array', () => {
+    const game = Game.fromESPNData(
+      buildMockWorldCupEvent({
+        id: '901',
+        date: new Date('2026-07-01T18:00:00Z'),
+        homeTeam: MEX,
+        awayTeam: USA,
+        homeScore: 0,
+        awayScore: 0,
+        status: 'scheduled',
+        stage: 'group',
+      }),
+      { league: 'world_cup', stage: 'group' },
+    );
+    assert.deepStrictEqual(game.events, []);
+    assert.ok(Array.isArray(game.toJSON().events));
+  });
+
+  test('drops a detail whose team matches neither competitor', () => {
+    const ev = eventMatch([{ type: 'goal', minute: "9'", player: 'Ghost', side: 'home' }]);
+    // Re-point the lone detail at an unknown team id; the parser can't resolve a side.
+    ev.competitions[0].details[0].team = { id: '99999' };
+    const game = Game.fromESPNData(ev, { league: 'world_cup', stage: 'group' });
+    assert.deepStrictEqual(game.events, []);
   });
 });

--- a/backend/tests/gameservice-worldcup.test.js
+++ b/backend/tests/gameservice-worldcup.test.js
@@ -119,6 +119,10 @@ describe('GameService.getWorldCupStage cache behavior', () => {
     seasonType: 1,
     league: 'world_cup',
     stage: 'group',
+    // A row written by the current code has its events parsed (empty here). NULL
+    // would mark a pre-events-column row and deliberately force a backfill refresh
+    // — that path has its own tests below.
+    events: [],
     lastUpdated: new Date(),
     ...overrides,
   });
@@ -196,6 +200,36 @@ describe('GameService.getWorldCupStage cache behavior', () => {
     await GameService.getWorldCupStage('group');
 
     assert.strictEqual(espn.mock.callCount(), 1, 'an unstarted-but-due slate must refresh');
+  });
+
+  test('a started cached game with un-parsed (NULL) events backfills from ESPN', async () => {
+    // A FINAL row cached before the events column existed. The one-time backfill
+    // must refresh it so its goal/card timeline populates, even though it is
+    // otherwise fresh by every other rule (recently updated, completed).
+    const cached = cachedGame({ events: null });
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    await GameService.getWorldCupStage('group');
+
+    assert.strictEqual(espn.mock.callCount(), 1, 'a started NULL-events row must refresh once');
+  });
+
+  test('a SCHEDULED game with NULL events does NOT force a backfill', async () => {
+    // Unstarted matches legitimately have no events yet — they must not be pulled
+    // into the backfill refresh (that is the "scheduled games keep a long TTL" rule).
+    const cached = cachedGame({
+      status: 'SCHEDULED',
+      gameDate: new Date(Date.now() + 6 * 60 * 60 * 1000), // kicks off in 6h
+      events: null,
+    });
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    const games = await GameService.getWorldCupStage('group');
+
+    assert.strictEqual(espn.mock.callCount(), 0, 'a scheduled NULL-events row stays cached');
+    assert.strictEqual(games[0], cached);
   });
 
   test('forceRefresh skips the cache entirely', async () => {

--- a/frontend/src/lib/matchPolling.test.ts
+++ b/frontend/src/lib/matchPolling.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pollIntervalFor,
+  IN_PROGRESS_POLL_MS,
+  UPCOMING_POLL_MS,
+} from './matchPolling';
+import type { WorldCupMatch } from './types';
+
+const m = (status: string): Pick<WorldCupMatch, 'status'> => ({ status });
+
+describe('pollIntervalFor', () => {
+  it('returns the fast interval when any match is in progress', () => {
+    expect(pollIntervalFor([m('FINAL'), m('IN_PROGRESS'), m('SCHEDULED')])).toBe(
+      IN_PROGRESS_POLL_MS,
+    );
+  });
+
+  it('prefers the fast interval over the slow one when both live and scheduled exist', () => {
+    // In-progress wins: a live match must refresh fast even alongside upcoming ones.
+    expect(pollIntervalFor([m('SCHEDULED'), m('IN_PROGRESS')])).toBe(IN_PROGRESS_POLL_MS);
+  });
+
+  it('returns the slow interval when matches are only scheduled (no live)', () => {
+    expect(pollIntervalFor([m('FINAL'), m('SCHEDULED')])).toBe(UPCOMING_POLL_MS);
+  });
+
+  it('stops polling (null) once every match is final', () => {
+    expect(pollIntervalFor([m('FINAL'), m('FINAL')])).toBeNull();
+  });
+
+  it('stops polling (null) for an empty slate', () => {
+    expect(pollIntervalFor([])).toBeNull();
+  });
+
+  it('keeps the slow interval slower than the fast one', () => {
+    // Guards the intent: upcoming matches must never poll faster than live ones.
+    expect(UPCOMING_POLL_MS).toBeGreaterThan(IN_PROGRESS_POLL_MS);
+  });
+});

--- a/frontend/src/lib/matchPolling.ts
+++ b/frontend/src/lib/matchPolling.ts
@@ -1,0 +1,27 @@
+import type { WorldCupMatch } from './types';
+
+/** Live matches refresh fast so goals/cards land within ~30s of happening. */
+export const IN_PROGRESS_POLL_MS = 30_000;
+/**
+ * Matches that haven't kicked off yet poll slowly — purely to notice the
+ * SCHEDULED → IN_PROGRESS transition, after which the fast cadence takes over.
+ * A long interval here keeps idle pages (and ESPN) from being hammered while
+ * still catching kickoff without a manual refresh.
+ */
+export const UPCOMING_POLL_MS = 5 * 60_000;
+
+/**
+ * Status-aware poll cadence for a World Cup match slate, in milliseconds, or
+ * `null` to stop polling entirely.
+ *
+ * - Any match in progress → fast (live scores/events).
+ * - Otherwise any match still scheduled → slow (watch for kickoff).
+ * - Everything final → `null`; the slate can't change, so don't poll.
+ *
+ * Only the `status` field is read, so callers can pass the raw API matches.
+ */
+export function pollIntervalFor(matches: Pick<WorldCupMatch, 'status'>[]): number | null {
+  if (matches.some((m) => m.status === 'IN_PROGRESS')) return IN_PROGRESS_POLL_MS;
+  if (matches.some((m) => m.status === 'SCHEDULED')) return UPCOMING_POLL_MS;
+  return null;
+}

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -19,6 +19,7 @@ import {
   submitUserWorldCupPicks,
 } from '../../lib/worldCupService.js';
 import { getMyGroups } from '../../lib/groupsService.js';
+import { pollIntervalFor } from '../../lib/matchPolling';
 import SaveTargetsDropdown, { type SaveTarget } from '../../components/SaveTargetsDropdown';
 import PickPersonSelector, { type PickPersonOption } from '../../components/PickPersonSelector';
 
@@ -167,6 +168,39 @@ export default function WorldCupPicksTab({
   }, [reloadKey]);
 
   const fetchMatches = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  // Live updates: re-pull every stage in the background and swap in the fresh
+  // matches WITHOUT toggling the loading flag (which would blank the list) and
+  // WITHOUT touching the draft. A transient failure is swallowed so the last-good
+  // slate stays on screen. This is what feeds new scores, statuses, and goal/card
+  // events into the rows (and their timelines) while a match is live.
+  const refreshMatchesSilently = useCallback(async () => {
+    try {
+      const responses = await Promise.all(WORLD_CUP_STAGES.map((stage) => getStageMatches(stage)));
+      const matches = responses.flatMap((r) => (Array.isArray(r?.games) ? r.games : []));
+      setFetchState((s) => ({ ...s, matches }));
+    } catch {
+      // Keep the existing slate; the next tick retries.
+    }
+  }, []);
+
+  // Status-aware cadence: fast while any match is live, slow while matches are
+  // only upcoming (to catch kickoff), and stopped once everything is final. The
+  // effect keys off the interval NUMBER, so it only re-subscribes when the tier
+  // actually changes — a same-tier data refresh doesn't reset the timer.
+  const pollInterval = useMemo(
+    () => pollIntervalFor(fetchState.matches),
+    [fetchState.matches],
+  );
+  useEffect(() => {
+    if (pollInterval == null) return;
+    const id = setInterval(() => {
+      // Don't poll a backgrounded tab — resume on the next tick once it's visible.
+      if (typeof document !== 'undefined' && document.hidden) return;
+      refreshMatchesSilently();
+    }, pollInterval);
+    return () => clearInterval(id);
+  }, [pollInterval, refreshMatchesSilently]);
 
   // Clear the draft SYNCHRONOUSLY the instant the selected person changes, so
   // one member's in-progress picks can never linger on screen — and be


### PR DESCRIPTION
## What

Makes the World Cup match timeline actually populate, and keeps it live during a match.

[#118](https://github.com/dokun1/confidence-picks/pull/118) shipped the timeline **renderer**, but nothing ever produced the events it renders — so `match.events` was always empty and the timeline never appeared, **including on the already-completed match**. This PR is the missing data half.

## Backend — events feed

- **`Game.parseMatchEvents`** flattens ESPN's `competition.details` (which the scoreboard already carries — verified live: the completed Mexico match returns 8 entries) into the timeline shape `{ type, minute, player, side, teamAbbr }`. Goals and yellow/red cards only; own-goals are classified distinctly; substitutions/VAR are dropped; a detail whose team matches neither side is dropped rather than rendered blank.
- **New `events` JSONB column** (idempotent migration, mirrors the `winner_team_id` block). `NULL` means *"never parsed"* (a row cached before the column existed); `[]` means *"parsed, no events"* — the distinction drives a self-healing backfill.
- **`isStageCacheFresh`** forces a one-time refresh for a *started* match still holding `NULL` events, so the existing completed match backfills its timeline on the next load. Scheduled matches keep their long TTL and never trigger it. `isDifferentFrom` gained an event-count fingerprint so a card with no score change still persists.

## Frontend — live polling

- **`pollIntervalFor`**: status-aware cadence — **30s** while any match is in progress, **5 min** while matches are only upcoming (to catch kickoff), **stop** once all are final.
- **`WorldCupPicksTab`** polls silently: no loading flash, the draft is never touched, failures keep the last-good slate, and a backgrounded tab pauses. New scores, statuses, and goal/card events flow into the rows (and their timelines) without a manual refresh.

## Why the completed game was blank

Nothing was broken in #118 — the renderer is gated on `locked && match.events?.length > 0`, and the backend never emitted `events`. After this ships, the cached completed match is detected as needing a backfill, re-fetched once, its 8 events parsed + persisted, and the timeline renders.

## Verification

- Backend: event parsing, own-goal, unknown-team-drop, and NULL-events-backfill-vs-scheduled-stays-cached tests all green (the only failures in the suite are `ECONNREFUSED :5432` — no local Postgres).
- Frontend: `tsc` clean, **607 tests pass**, prod build OK (~89 kB gzip). New `pollIntervalFor` cadence tests included.
