### PR TITLE
Match timeline layout: isolate stacking context + center minute on the spine

### DIFF
--- a/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.test.tsx
+++ b/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.test.tsx
@@ -42,6 +42,14 @@ describe('MatchTimeline', () => {
     expect(awayMinute.nextElementSibling?.textContent).toContain('T. Mokoena');
   });
 
+  it('isolates its own stacking context so the minute chips never paint over page chrome', () => {
+    // The chips use z-10 to sit above the spine; `isolate` confines that z-index
+    // to this grid. Without it the chips leak into the root stacking context and
+    // render OVER the page's sticky submit bar as the row scrolls under it.
+    const { container } = render(<MatchTimeline events={EVENTS} />);
+    expect(container.firstChild).toHaveClass('isolate');
+  });
+
   it('keeps the glyph adjacent to the player name (no flex-fill gap)', () => {
     render(<MatchTimeline events={EVENTS} />);
     // The away player and its glyph live in the same flex group, so the player

--- a/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.tsx
+++ b/frontend/src/designsystem/components/MatchTimeline/MatchTimeline.tsx
@@ -55,7 +55,10 @@ export default function MatchTimeline({ events, className = '' }: MatchTimelineP
   return (
     <div
       aria-label="Match timeline"
-      className={`relative grid grid-cols-[1fr_auto_1fr] items-center gap-x-sm gap-y-xs text-xs ${className}`.trim()}
+      // `isolate` scopes the minute chips' z-10 to this grid: without it the
+      // chips leak into the root stacking context and paint OVER the page's
+      // sticky submit bar as the row scrolls under it.
+      className={`relative isolate grid grid-cols-[1fr_auto_1fr] items-center gap-x-sm gap-y-xs text-xs ${className}`.trim()}
     >
       {/* Central spine — the minute chips mask it where they sit. */}
       <span
@@ -83,8 +86,10 @@ export default function MatchTimeline({ events, className = '' }: MatchTimelineP
               <span />
             )}
 
-            {/* Minute, on the spine. */}
-            <span className="relative z-10 rounded-full bg-surface px-xs font-semibold tabular-nums text-content-muted">
+            {/* Minute, centered ON the spine so its background masks the line —
+                otherwise the spine peeks out beside the (left-aligned) number as
+                a stray grey tick. */}
+            <span className="relative z-10 justify-self-center rounded-full bg-surface px-xs text-center font-semibold tabular-nums text-content-muted">
               {ev.minute}
             </span>
 


### PR DESCRIPTION
## What

Two layout fixes for the World Cup match timeline, surfaced now that it actually renders (the events feed landed in #119). Follows #118 (renderer) and #119 (events feed + polling).

- **Spine painted over the sticky submit bar.** The minute chips use `z-10` to sit above the central spine, but the timeline root wasn't an isolated stacking context — so that `z-10` competed in the *root* context and rendered over the page's sticky submit bar as a row scrolled under it. Adding `isolate` to the grid root scopes the z-index locally; the bar now always covers the rows.
- **Stray grey tick beside each minute.** Each minute number sat left-of-center while the spine runs down the grid center, so the line poked out just to the right of the number — once per row. Centering the minute chip on the spine (`justify-self-center` + `text-center`) lets its background mask the line, and puts the numbers *on* the spine (the intended Apple-Sports look).

## Why a separate PR

These were committed to the #119 branch but pushed just after it merged, so they didn't ride along.

## Verification

Confirmed in-browser (light + dark): tick gone, numbers centered on the line. `tsc` clean; MatchTimeline tests green, including a new one asserting the root keeps its `isolate` stacking context so the z-index bug can't silently regress.
