### PR TITLE
SEV: fix World Cup scores/picks gone + slow loads (un-migrated events column)

### DIFF
--- a/backend/src/models/Game.js
+++ b/backend/src/models/Game.js
@@ -249,48 +249,62 @@ static parseMatchEvents(competition, homeComp, awayComp) {
     return new Date(this.lastUpdated) < twentyFourHoursAgo;
   }
 
-// Save to database
-async save() {
-  const query = `
-    INSERT INTO games (
-      espn_id, home_team, away_team, game_date, status,
-      period, display_clock, status_detail,
-      home_score, away_score, week, season, season_type, odds, probability, last_updated,
-      league, stage, winner_team_id, events
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
-    ON CONFLICT (espn_id)
-    DO UPDATE SET
-      home_team = $2,
-      away_team = $3,
-      game_date = $4,
-  status = $5,
-      period = $6,
-      display_clock = $7,
-      status_detail = $8,
-      home_score = $9,
-      away_score = $10,
-      week = $11,
-      season = $12,
-      season_type = $13,
-      odds = $14,
-      probability = $15,
-      last_updated = $16,
-      league = $17,
-      stage = $18,
-      winner_team_id = $19,
-      events = $20
-    RETURNING *
-  `;
+// Whether the live database has the games.events column. It ships with the
+// match-timeline feature and is added by the INIT_DB schema sync — which on
+// production runs only when explicitly enabled, so a deploy can be live for a
+// while before the column exists. A save() that blindly writes a missing column
+// throws, returns no row, and leaves the Game without an id; an id-less Game then
+// silently breaks the pick↔game join the leaderboard and picks page rely on
+// (every pick referencing that game scores nothing and renders unselected). So we
+// detect the column's absence once and stop emitting it until the process
+// restarts against a migrated schema. See [[worldcup-backend-gaps]].
+static eventsColumnAvailable = true;
 
+// Postgres "undefined_column" (42703), scoped to the events column so a genuinely
+// malformed query still surfaces instead of being silently swallowed + retried.
+static isMissingEventsColumnError(err) {
+  return !!err && err.code === '42703' && /\bevents\b/i.test(err.message || '');
+}
+
+// Save to database. Resilient to an un-migrated schema: if the events column is
+// absent we persist every other field anyway (the id, scores, status, and winner
+// MUST land) and drop only the timeline.
+async save() {
+  try {
+    return await this.upsert(Game.eventsColumnAvailable);
+  } catch (err) {
+    if (Game.eventsColumnAvailable && Game.isMissingEventsColumnError(err)) {
+      Game.eventsColumnAvailable = false;
+      console.warn(
+        '[Game.save] games.events column is missing — persisting without it. ' +
+        'Run the INIT_DB schema sync to enable the match timeline.'
+      );
+      return await this.upsert(false);
+    }
+    throw err;
+  }
+}
+
+// Build and run the upsert. `includeEvents` toggles the one column that may not
+// exist yet; every other column is always written. ON CONFLICT updates every
+// column except the espn_id conflict key (EXCLUDED.* = the values we just tried
+// to insert), so adding/removing the trailing events column needs no re-numbering.
+async upsert(includeEvents) {
+  const columns = [
+    'espn_id', 'home_team', 'away_team', 'game_date', 'status',
+    'period', 'display_clock', 'status_detail',
+    'home_score', 'away_score', 'week', 'season', 'season_type',
+    'odds', 'probability', 'last_updated', 'league', 'stage', 'winner_team_id',
+  ];
   const values = [
     this.espnId,
     JSON.stringify(this.homeTeam),
     JSON.stringify(this.awayTeam),
     this.gameDate,
-  this.status, // normalized (SCHEDULED | IN_PROGRESS | FINAL)
-  this.period,
-  this.displayClock,
-  this.statusDetail,
+    this.status, // normalized (SCHEDULED | IN_PROGRESS | FINAL)
+    this.period,
+    this.displayClock,
+    this.statusDetail,
     this.homeScore,
     this.awayScore,
     this.week,
@@ -302,10 +316,22 @@ async save() {
     this.league || null,
     this.stage || null,
     this.winnerTeamId || null,
+  ];
+  if (includeEvents) {
+    columns.push('events');
     // Persist [] (not NULL) once parsed, so a genuinely eventless match reads as
     // "parsed, none" rather than re-triggering the backfill refresh every request.
-    JSON.stringify(this.events ?? [])
-  ];
+    values.push(JSON.stringify(this.events ?? []));
+  }
+
+  const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
+  const updates = columns.slice(1).map((c) => `${c} = EXCLUDED.${c}`).join(', ');
+  const query = `
+    INSERT INTO games (${columns.join(', ')})
+    VALUES (${placeholders})
+    ON CONFLICT (espn_id) DO UPDATE SET ${updates}
+    RETURNING *
+  `;
 
   const result = await pool.query(query, values);
   this.id = result.rows[0].id;

--- a/backend/src/services/GameService.js
+++ b/backend/src/services/GameService.js
@@ -171,7 +171,14 @@ export class GameService {
     // Force a refresh so its timeline populates. Once persisted as [] or a real
     // array it reads as fresh, so this fires at most once per such row. Scheduled
     // matches legitimately have no events yet, so they never trigger it.
-    const needsEventsBackfill = cachedSet.some(g => g.status !== 'SCHEDULED' && g.events == null);
+    //
+    // Gated on the column actually existing: if the events column is missing the
+    // refresh can never persist events, so the NULL never clears and this would
+    // re-fetch every stage from ESPN on every request — turning the leaderboard
+    // and picks page slow. When the column is absent we leave the cached slate
+    // fresh and skip the backfill entirely.
+    const needsEventsBackfill =
+      Game.eventsColumnAvailable && cachedSet.some(g => g.status !== 'SCHEDULED' && g.events == null);
     if (needsEventsBackfill) return false;
 
     const startWindowMs = 2 * 60 * 1000;
@@ -238,7 +245,12 @@ export class GameService {
 
         const winnerChanged = freshGame.winnerTeamId !== (cachedGame.winnerTeamId ?? null);
         if (forceRefresh || cachedGame.isStale() || freshGame.isDifferentFrom(cachedGame) || winnerChanged) {
-          await GameService.persistOrServeLive(freshGame);
+          const persisted = await GameService.persistOrServeLive(freshGame);
+          // If the row couldn't be persisted (e.g. an un-migrated schema), the
+          // fresh Game has no id. Borrow the cached row's id so the live data is
+          // still joinable — an id-less game silently drops every pick that
+          // references it from the leaderboard and the picks page.
+          if (!persisted && freshGame.id == null) freshGame.id = cachedGame.id;
           games.push(freshGame);
         } else {
           games.push(cachedGame);
@@ -268,11 +280,17 @@ export class GameService {
   // here would blank the stage list and the leaderboard mid-match. The canonical
   // example is a schema drift (e.g. a missing games column): scores still surface
   // live every refresh; they just aren't cached until the DB is repaired.
+  //
+  // Returns true when the row was persisted (so it carries a real id), false when
+  // it was served live-but-uncached — the caller uses that to keep the slate
+  // joinable by falling back to a cached id.
   static async persistOrServeLive(game) {
     try {
       await game.save();
+      return true;
     } catch (error) {
       console.error(`[getWorldCupStage] persist failed for espnId=${game.espnId}; serving live ESPN data uncached: ${error.message}`);
+      return false;
     }
   }
 

--- a/backend/tests/game-soccer.test.js
+++ b/backend/tests/game-soccer.test.js
@@ -1,5 +1,6 @@
-import { test, describe } from 'node:test';
+import { test, describe, afterEach, mock } from 'node:test';
 import assert from 'node:assert';
+import pool from '../src/config/database.js';
 import { Game } from '../src/models/Game.js';
 import { generateMockWeek } from '../src/mocks/espnGameData.js';
 import {
@@ -179,5 +180,85 @@ describe('Game.fromESPNData match events (goals/cards)', () => {
     ev.competitions[0].details[0].team = { id: '99999' };
     const game = Game.fromESPNData(ev, { league: 'world_cup', stage: 'group' });
     assert.deepStrictEqual(game.events, []);
+  });
+});
+
+// Regression for the events-column sev: on an un-migrated production schema the
+// games.events column is absent. save() MUST still persist the row (and set the
+// id) — a failed save returns no id, and an id-less Game breaks the pick↔game
+// join the leaderboard + picks page depend on. The pg pool is mocked so this
+// runs without a live Postgres.
+describe('Game.save events-column resilience', () => {
+  const { MEX, USA } = WORLD_CUP_2026_TEAMS;
+  const finalMatch = () =>
+    Game.fromESPNData(
+      buildMockWorldCupEvent({
+        id: '900',
+        date: new Date('2026-06-11T18:00:00Z'),
+        homeTeam: MEX,
+        awayTeam: USA,
+        homeScore: 2,
+        awayScore: 1,
+        status: 'final',
+        stage: 'group',
+        events: [{ type: 'goal', minute: "9'", player: 'J. Q', side: 'home' }],
+      }),
+      { league: 'world_cup', stage: 'group' },
+    );
+
+  afterEach(() => {
+    mock.restoreAll();
+    Game.eventsColumnAvailable = true; // never leak the flag between tests
+  });
+
+  test('writes the events column in a single upsert when it is available', async () => {
+    Game.eventsColumnAvailable = true;
+    const queries = [];
+    mock.method(pool, 'query', async (text) => {
+      queries.push(text);
+      return { rows: [{ id: 5 }] };
+    });
+
+    const g = finalMatch();
+    await g.save();
+
+    assert.strictEqual(queries.length, 1, 'single upsert, no retry');
+    assert.match(queries[0], /events/, 'the upsert includes the events column');
+    assert.strictEqual(g.id, 5);
+  });
+
+  test('retries without events — still setting the id — when the column is missing', async () => {
+    Game.eventsColumnAvailable = true;
+    const queries = [];
+    mock.method(pool, 'query', async (text) => {
+      queries.push(text);
+      if (queries.length === 1) {
+        const err = new Error('column "events" of relation "games" does not exist');
+        err.code = '42703';
+        throw err;
+      }
+      return { rows: [{ id: 77 }] };
+    });
+
+    const g = finalMatch();
+    await g.save();
+
+    assert.strictEqual(g.id, 77, 'id is still set from the retry — the row persists');
+    assert.strictEqual(Game.eventsColumnAvailable, false, 'the flag flips so later saves skip events upfront');
+    assert.strictEqual(queries.length, 2, 'first attempt + one retry');
+    assert.match(queries[0], /events/, 'first attempt included events');
+    assert.doesNotMatch(queries[1], /events/, 'retry omitted events');
+  });
+
+  test('does not swallow an unrelated column error', async () => {
+    Game.eventsColumnAvailable = true;
+    mock.method(pool, 'query', async () => {
+      const err = new Error('null value in column "status" violates not-null constraint');
+      err.code = '23502';
+      throw err;
+    });
+
+    await assert.rejects(() => finalMatch().save(), /status/);
+    assert.strictEqual(Game.eventsColumnAvailable, true, 'an unrelated failure must not disable events');
   });
 });

--- a/backend/tests/gameservice-worldcup.test.js
+++ b/backend/tests/gameservice-worldcup.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { GameService } from '../src/services/GameService.js';
 import { Game } from '../src/models/Game.js';
 import { MockESPNService } from '../src/mocks/MockESPNService.js';
-import { WORLD_CUP_2026_TEAMS } from '../src/mocks/espnWorldCupData.js';
+import { WORLD_CUP_2026_TEAMS, buildMockWorldCupEvent } from '../src/mocks/espnWorldCupData.js';
 
 // These tests exercise GameService.getWorldCupStage and resolveWinnerTeamId
 // against the MockESPNService + generateMockWorldCupStage fixtures. The DB layer
@@ -256,6 +256,108 @@ describe('GameService.getWorldCupStage cache behavior', () => {
     // Fixture: MEX 1-1 USA decided on penalties — the winner must already be on
     // the Game at save time, otherwise a cached read can never score the match.
     assert.strictEqual(savedWinners.get('MEX-USA'), WORLD_CUP_2026_TEAMS.USA.id);
+  });
+});
+
+// Regression for the events-column sev: a deploy can be live before the
+// games.events column is migrated in. The stage read must degrade gracefully —
+// never re-fetch every request, and never return an id-less game (an id-less
+// game silently drops every pick that references it from the leaderboard and the
+// picks page, which read as "scores gone" / "picks gone").
+describe('GameService.getWorldCupStage events-column resilience', () => {
+  // A persisted, completed group game with a real id, as findByLeagueStage
+  // returns it. events: null mimics a row from before the events column existed.
+  const cachedGame = (overrides = {}) => new Game({
+    id: 1,
+    espnId: '760601',
+    homeTeam: { id: WORLD_CUP_2026_TEAMS.MEX.id, abbreviation: 'MEX' },
+    awayTeam: { id: WORLD_CUP_2026_TEAMS.USA.id, abbreviation: 'USA' },
+    gameDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    status: 'FINAL',
+    homeScore: 2,
+    awayScore: 1,
+    week: 1,
+    season: 2026,
+    seasonType: 1,
+    league: 'world_cup',
+    stage: 'group',
+    events: null,
+    lastUpdated: new Date(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    process.env.USE_MOCK_ESPN = 'true';
+    MockESPNService.configure();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    MockESPNService.reset();
+    delete process.env.USE_MOCK_ESPN;
+    Game.eventsColumnAvailable = true; // never leak the flag between tests
+  });
+
+  test('skips the events backfill when the column is unavailable (no ESPN re-fetch loop)', () => {
+    Game.eventsColumnAvailable = false;
+    assert.strictEqual(
+      GameService.isStageCacheFresh([cachedGame()]),
+      true,
+      'a started NULL-events row stays fresh when there is no column to backfill into'
+    );
+    Game.eventsColumnAvailable = true;
+    assert.strictEqual(
+      GameService.isStageCacheFresh([cachedGame()]),
+      false,
+      'with the column present the one-time backfill still fires'
+    );
+  });
+
+  test('serves cached group games WITH their ids when the column is missing', async () => {
+    Game.eventsColumnAvailable = false;
+    const cached = cachedGame();
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek');
+
+    const games = await GameService.getWorldCupStage('group');
+
+    assert.strictEqual(espn.mock.callCount(), 0, 'must not re-fetch from ESPN every request');
+    assert.strictEqual(games.length, 1);
+    assert.strictEqual(games[0].id, 1, 'the served game keeps its id so the pick join resolves');
+  });
+
+  test('a refresh whose persist fails still returns a game carrying the cached id', async () => {
+    // Force the live refresh path (in-progress > 60s) and make every save throw,
+    // simulating a persistence failure mid-match. The live score must still
+    // surface, but the game MUST carry the cached id so picks remain joined.
+    const cached = cachedGame({
+      status: 'IN_PROGRESS',
+      lastUpdated: new Date(Date.now() - 2 * 60 * 1000),
+      events: [],
+    });
+    const espnEvent = buildMockWorldCupEvent({
+      id: '760601',
+      date: new Date(cached.gameDate),
+      homeTeam: WORLD_CUP_2026_TEAMS.MEX,
+      awayTeam: WORLD_CUP_2026_TEAMS.USA,
+      homeScore: 1,
+      awayScore: 0,
+      status: 'inProgress',
+      stage: 'group',
+    });
+    mock.method(Game, 'findByLeagueStage', async () => [cached]);
+    mock.method(Game, 'findByESPNIds', async () => new Map([['760601', cached]]));
+    mock.method(MockESPNService, 'fetchSoccerWeek', async () => [espnEvent]);
+    mock.method(Game.prototype, 'save', async () => {
+      throw new Error('persist boom');
+    });
+
+    const games = await GameService.getWorldCupStage('group');
+
+    assert.strictEqual(games.length, 1);
+    assert.ok(games[0].id != null, 'never return an id-less game when a cached id exists');
+    assert.strictEqual(games[0].id, 1);
+    assert.strictEqual(games[0].homeScore, 1, 'and it carries the live score, not the stale cached one');
   });
 });
 


### PR DESCRIPTION
## SEV: World Cup scores gone, picks not visible, leaderboard + picks page slow

### Root cause (proven)

[#119](https://github.com/dokun1/confidence-picks/pull/119) added a `games.events` column and made `Game.save()` write it (`$20`). But **production schema sync only runs when `INIT_DB=true`** ([`app.js`](backend/src/app.js) lines 70–75), and [`deploy-backend.yml`](.github/workflows/deploy-backend.yml) never sets it. So after #119 deployed, the `events` column was **never created** in the prod database.

The failure chain:

1. Every World Cup `save()` throws `column "events" does not exist`.
2. `getWorldCupStage` → `persistOrServeLive` **swallows** the error and returns the **unsaved** `Game`. Only `save()` sets `this.id` (from `RETURNING`), so that game has **no id**.
3. The leaderboard keys games by id — [`worldCupPicks.js:199`](backend/src/routes/worldCupPicks.js) `new Map(games.map(g => [g.id, g]))` — and joins picks via `gameById.get(pr.game_id)` ([:226](backend/src/routes/worldCupPicks.js)). Id-less group games ⇒ **every group pick drops out of the join ⇒ "scores gone."**
4. The picks page renders rows keyed by `match.id`; id-less matches ⇒ `draft[match.id]` never resolves ⇒ **"picks not visible."**
5. The write never sticks, so the events-backfill rule (`status !== 'SCHEDULED' && events == null`) re-fetches **all seven stages from ESPN on every request** ⇒ **slow leaderboard + picks**.

Only the **group** stage hits this (its games are started → forced through the refresh); knockout games stay SCHEDULED and keep their cached ids — matching "scores gone *in the group*."

### Fix — resilient whether or not the column exists

- **`Game.save()`** detects a missing events column (Postgres `42703`) once, flips `Game.eventsColumnAvailable = false`, and persists every other field anyway — **id, scores, status, winner always land**. Unrelated errors still surface (not swallowed).
- **`isStageCacheFresh`** only forces the events backfill when the column exists — kills the per-request ESPN re-fetch loop on an un-migrated schema.
- **`getWorldCupStage`** borrows the cached row's id if a refresh can't persist, so a live game is **never returned id-less** (defense-in-depth for any save failure).

This restores scores/picks and fast loads **on deploy, with no migration**. Running the `INIT_DB` schema sync additionally creates the column and re-enables the match timeline.

### Tests (6 new)

- `save()`: single upsert with events when available; retry-without-events (id still set, flag flips) on `42703`; unrelated column error **not** swallowed.
- `getWorldCupStage`: column-missing serves cached **id-bearing** games with **zero** ESPN calls; backfill gated on column availability; a failed persist still returns a game carrying the cached id + the live score.

Backend suite: 201 pass; the only 4 failures are `ECONNREFUSED :5432` (no local Postgres), unrelated.

### Follow-up

Run the `INIT_DB=true` schema sync against prod to add the `events` column and turn the timeline back on. The app no longer depends on it to function.
