### PR TITLE
WC browse P3: match detail panel + /event summary endpoint (on-demand, no-schema)

### DIFF
--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import pool from '../config/database.js';
 import { GameService } from '../services/GameService.js';
+import { ESPNService } from '../services/ESPNService.js';
+import { SoccerSummaryService } from '../services/SoccerSummaryService.js';
 import { authenticateToken, optionalAuth } from '../middleware/auth.js';
 
 const router = express.Router();
@@ -50,6 +52,23 @@ router.get('/games/world-cup-2026/stage/:stage', async (req, res) => {
     });
   } catch (error) {
     res.status(500).json({ error: error.message });
+  }
+});
+
+// On-demand, resilient, no-schema per-match detail for the World Cup detail panel.
+// Registered before /games/:year/:seasonType/:week for the same reason as the stage
+// route: world-cup-2026/event/:espnId is a literal-prefixed 4-segment path the NFL
+// param route would otherwise claim. Fetches ESPN /summary live and returns parsed
+// JSON — NO database, NO persistence. NEVER 500: on any failure we return HTTP 200
+// with a sparse-but-valid body so a broken /summary only blanks the panel.
+router.get('/games/world-cup-2026/event/:espnId', async (req, res) => {
+  const { espnId } = req.params;
+  try {
+    const summary = await ESPNService.fetchSoccerSummary(espnId);
+    res.json(SoccerSummaryService.parseSummary(summary));
+  } catch (error) {
+    console.error(`[event-detail] failed for espnId=${espnId}: ${error.message}`);
+    res.json({ venue: null, stats: [], lineups: null }); // never 500 — blank detail, not an error
   }
 });
 

--- a/backend/src/services/ESPNService.js
+++ b/backend/src/services/ESPNService.js
@@ -159,6 +159,24 @@ export class ESPNService {
     return qs ? `${base}?${qs}` : base;
   }
 
+  /**
+   * Fetch ESPN's per-event `/summary` for a single FIFA World Cup 2026 match.
+   *
+   * Mirrors fetchSoccerWeek's fetch/throw contract: builds the summary URL,
+   * throws on a non-OK response so the caller (the resilient /event route) can
+   * catch and return a sparse body. The route — not this method — guarantees the
+   * never-500 behaviour; this stays a thin throwing fetch like its siblings.
+   *
+   * @param {(string|number)} eventId - ESPN event id
+   * @returns {Promise<Object>} Raw ESPN summary JSON
+   */
+  static async fetchSoccerSummary(eventId) {
+    const url = `${this.SOCCER_BASE_URL}/fifa.world/summary?event=${encodeURIComponent(eventId)}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`ESPN summary ${res.status} for event ${eventId}`);
+    return res.json();
+  }
+
   static async fetchGameById(gameId) {
     // ESPN doesn't have a direct game-by-id endpoint for scoreboard
     // You'd need to implement this based on their API structure

--- a/backend/src/services/SoccerSummaryService.js
+++ b/backend/src/services/SoccerSummaryService.js
@@ -139,10 +139,10 @@ export class SoccerSummaryService {
   static _deriveLine(abbr) {
     if (!abbr) return 'MID';
     const a = String(abbr).toUpperCase();
-    if (a === 'G' || a === 'GK') return 'GK';
-    if (a.startsWith('D') || a === 'LB' || a === 'RB' || a === 'CD') return 'DEF';
-    if (a.startsWith('M') || a === 'CM' || a === 'DM' || a === 'AM' || a === 'LM' || a === 'RM') return 'MID';
-    if (a === 'F' || a === 'CF' || a === 'ST' || a === 'LW' || a === 'RW') return 'FWD';
+    if (a.startsWith('G')) return 'GK';
+    if (a.startsWith('DM') || a.startsWith('CM') || a.startsWith('AM') || a.startsWith('LM') || a.startsWith('RM') || a.startsWith('M')) return 'MID';
+    if (a.startsWith('CD') || a.startsWith('CB') || a.startsWith('LWB') || a.startsWith('RWB') || a.startsWith('LB') || a.startsWith('RB') || a.startsWith('SW') || a.startsWith('D')) return 'DEF';
+    if (a.startsWith('CF') || a.startsWith('ST') || a.startsWith('LW') || a.startsWith('RW') || a.startsWith('F') || a.startsWith('W')) return 'FWD';
     return 'MID';
   }
 

--- a/backend/src/services/SoccerSummaryService.js
+++ b/backend/src/services/SoccerSummaryService.js
@@ -1,0 +1,192 @@
+/**
+ * SoccerSummaryService — a pure parser for ESPN's per-event `/summary` payload.
+ *
+ * Isolated from the stage/list/picks flow on purpose: it does NO fetching, NO
+ * persistence, and touches NO database. It takes a raw ESPN summary object and
+ * returns the curated `{ venue, stats, lineups }` shape the World Cup detail
+ * panel renders. The calling route fetches live and guarantees the never-500
+ * contract; this parser only has to be defensive — never throw on a missing key.
+ *
+ * Scope (v1): venue + match stats + lineups. Head-to-head and standings are
+ * deliberately deferred. The frontend renders only the sections present.
+ */
+
+// Curated, ordered stat set. Each entry: [ESPN statistic `name`, display label].
+// Looked up by `name` in each team's boxscore `.statistics[]`; missing → ''.
+const STAT_SPEC = [
+  ['possessionPct', 'Possession'],
+  ['totalShots', 'Shots'],
+  ['shotsOnTarget', 'Shots on target'],
+  ['wonCorners', 'Corners'],
+  ['foulsCommitted', 'Fouls'],
+  ['yellowCards', 'Yellow cards'],
+  ['redCards', 'Red cards'],
+];
+
+export class SoccerSummaryService {
+  /**
+   * Parse a raw ESPN `/summary` object into the detail-panel shape.
+   * Always returns a valid object; never throws.
+   *
+   * @param {Object} summary - raw ESPN summary JSON (may be sparse/empty)
+   * @returns {{ venue: (string|null), stats: Array, lineups: (Object|null) }}
+   */
+  static parseSummary(summary) {
+    const safe = summary && typeof summary === 'object' ? summary : {};
+
+    // Identify home/away once; every other section maps off this.
+    const competitors = safe?.header?.competitions?.[0]?.competitors || [];
+    const home = competitors.find((c) => c && c.homeAway === 'home') || null;
+    const away = competitors.find((c) => c && c.homeAway === 'away') || null;
+    const homeId = home?.team?.id ?? null;
+    const awayId = away?.team?.id ?? null;
+
+    return {
+      venue: this._parseVenue(safe),
+      stats: this._parseStats(safe, homeId, awayId),
+      lineups: this._parseLineups(safe, home, away),
+    };
+  }
+
+  /** "<fullName> · <address.city>" from gameInfo.venue, or null if absent. */
+  static _parseVenue(summary) {
+    const v = summary?.gameInfo?.venue;
+    if (!v || !v.fullName) return null;
+    const city = v?.address?.city;
+    return city ? `${v.fullName} · ${city}` : v.fullName;
+  }
+
+  /**
+   * Ordered [{ label, home, away }] for the curated STAT_SPEC. Maps each team's
+   * boxscore entry to home/away by team.id. Returns [] if boxscore/teams absent.
+   */
+  static _parseStats(summary, homeId, awayId) {
+    const teams = summary?.boxscore?.teams;
+    if (!Array.isArray(teams) || teams.length === 0) return [];
+
+    const byId = (id) => teams.find((t) => t && t?.team?.id === id) || null;
+    const homeTeam = byId(homeId);
+    const awayTeam = byId(awayId);
+
+    const lookup = (team, name) => {
+      const list = team?.statistics;
+      if (!Array.isArray(list)) return '';
+      const found = list.find((s) => s && s.name === name);
+      return found && found.displayValue != null ? found.displayValue : '';
+    };
+
+    return STAT_SPEC.map(([name, label]) => ({
+      label,
+      home: lookup(homeTeam, name),
+      away: lookup(awayTeam, name),
+    }));
+  }
+
+  /**
+   * { home: TeamLineup, away: TeamLineup } from summary.rosters[], or null if
+   * rosters absent/empty. keyEvents marks are attached best-effort by name.
+   */
+  static _parseLineups(summary, home, away) {
+    const rosters = summary?.rosters;
+    if (!Array.isArray(rosters) || rosters.length === 0) return null;
+
+    const marksByName = this._buildMarks(summary?.keyEvents);
+
+    const homeRoster = rosters.find((r) => r && r.homeAway === 'home') || null;
+    const awayRoster = rosters.find((r) => r && r.homeAway === 'away') || null;
+
+    return {
+      home: this._teamLineup(homeRoster, home, marksByName),
+      away: this._teamLineup(awayRoster, away, marksByName),
+    };
+  }
+
+  /**
+   * Build a TeamLineup from a roster + its matching competitor. Returns a valid
+   * (possibly empty) lineup even when the roster is missing, so the panel can
+   * still render the team header.
+   */
+  static _teamLineup(roster, competitor, marksByName) {
+    const abbr = competitor?.team?.abbreviation ?? '';
+    const name = competitor?.team?.displayName ?? '';
+    const formation = roster?.formation ?? '';
+    const entries = Array.isArray(roster?.roster) ? roster.roster : [];
+
+    const starters = entries
+      .filter((e) => e && e.starter === true)
+      .map((e) => ({
+        num: e?.jersey ?? '',
+        name: e?.athlete?.displayName ?? '',
+        line: this._deriveLine(e?.position?.abbreviation),
+        marks: marksByName.get(e?.athlete?.displayName) || [],
+      }));
+
+    const subs = entries
+      .filter((e) => e && e.subbedIn === true)
+      .map((e) => ({
+        num: e?.jersey ?? '',
+        name: e?.athlete?.displayName ?? '',
+        marks: marksByName.get(e?.athlete?.displayName) || [],
+      }));
+
+    return { abbr, name, formation, starters, subs };
+  }
+
+  /**
+   * Map an ESPN position abbreviation to a coarse line: GK/DEF/MID/FWD.
+   * Unknown/absent → 'MID' (a safe centre default for the pitch layout).
+   */
+  static _deriveLine(abbr) {
+    if (!abbr) return 'MID';
+    const a = String(abbr).toUpperCase();
+    if (a === 'G' || a === 'GK') return 'GK';
+    if (a.startsWith('D') || a === 'LB' || a === 'RB' || a === 'CD') return 'DEF';
+    if (a.startsWith('M') || a === 'CM' || a === 'DM' || a === 'AM' || a === 'LM' || a === 'RM') return 'MID';
+    if (a === 'F' || a === 'CF' || a === 'ST' || a === 'LW' || a === 'RW') return 'FWD';
+    return 'MID';
+  }
+
+  /**
+   * Build a Map<displayName, mark[]> from summary.keyEvents. Each mark is
+   * { kind, min }. Be defensive — keyEvents may be absent; never throw.
+   *
+   *   Goal (type.text contains 'Goal', not 'Own') → scorer participants[0]: {kind:'goal'}
+   *   Own goal (type.text contains 'Own')         → participants[0]: {kind:'own-goal'}
+   *   Yellow Card                                  → participants[0]: {kind:'yellow'}
+   *   Red Card                                     → participants[0]: {kind:'red'}
+   *   Substitution → participants[0] ON {kind:'on'}, participants[1] OFF {kind:'off'}
+   */
+  static _buildMarks(keyEvents) {
+    const map = new Map();
+    if (!Array.isArray(keyEvents)) return map;
+
+    const add = (displayName, mark) => {
+      if (!displayName) return;
+      if (!map.has(displayName)) map.set(displayName, []);
+      map.get(displayName).push(mark);
+    };
+
+    for (const ev of keyEvents) {
+      if (!ev) continue;
+      const text = ev?.type?.text || '';
+      const min = ev?.clock?.displayValue ?? '';
+      const parts = Array.isArray(ev.participants) ? ev.participants : [];
+      const nameOf = (i) => parts[i]?.athlete?.displayName;
+
+      if (text === 'Substitution') {
+        add(nameOf(0), { kind: 'on', min });
+        add(nameOf(1), { kind: 'off', min });
+      } else if (/Own/i.test(text)) {
+        add(nameOf(0), { kind: 'own-goal', min });
+      } else if (/Goal/i.test(text)) {
+        add(nameOf(0), { kind: 'goal', min });
+      } else if (/Yellow Card/i.test(text)) {
+        add(nameOf(0), { kind: 'yellow', min });
+      } else if (/Red Card/i.test(text)) {
+        add(nameOf(0), { kind: 'red', min });
+      }
+    }
+
+    return map;
+  }
+}

--- a/backend/tests/api-worldcup-route.test.js
+++ b/backend/tests/api-worldcup-route.test.js
@@ -5,6 +5,7 @@ import apiRouter from '../src/routes/api.js';
 import { Game } from '../src/models/Game.js';
 import { MockESPNService } from '../src/mocks/MockESPNService.js';
 import { WORLD_CUP_2026_TEAMS } from '../src/mocks/espnWorldCupData.js';
+import { ESPNService } from '../src/services/ESPNService.js';
 
 // Exercises GET /api/games/world-cup-2026/stage/:stage in isolation: the router is
 // mounted on a throwaway Express app, ESPN is the mock service, and the DB layer is
@@ -89,5 +90,60 @@ describe('GET /api/games/world-cup-2026/stage/:stage', () => {
     );
     assert.ok(reg, 'knockout slate should include ENG vs GER');
     assert.strictEqual(reg.winnerTeamId, WORLD_CUP_2026_TEAMS.ENG.id, 'advancing team surfaces in JSON');
+  });
+});
+
+describe('GET /api/games/world-cup-2026/event/:espnId', () => {
+  let server;
+  let baseURL;
+
+  before(async () => {
+    const app = express();
+    app.use('/api', apiRouter);
+    await new Promise((resolve) => {
+      server = app.listen(0, () => {
+        baseURL = `http://localhost:${server.address().port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  test('never-500 on fetch failure — returns 200 with sparse body', async () => {
+    mock.method(ESPNService, 'fetchSoccerSummary', async () => { throw new Error('boom'); });
+
+    const res = await fetch(`${baseURL}/api/games/world-cup-2026/event/760415`);
+    assert.strictEqual(res.status, 200, 'should never 500 on upstream failure');
+    const body = await res.json();
+    assert.deepStrictEqual(body, { venue: null, stats: [], lineups: null });
+  });
+
+  test('happy path — returns 200 with parsed venue', async () => {
+    const fixture = {
+      header: {
+        competitions: [{
+          competitors: [
+            { homeAway: 'home', team: { id: '1', abbreviation: 'USA', displayName: 'United States' } },
+            { homeAway: 'away', team: { id: '2', abbreviation: 'MEX', displayName: 'Mexico' } },
+          ],
+        }],
+      },
+      gameInfo: {
+        venue: { fullName: 'SoFi Stadium', address: { city: 'Inglewood' } },
+      },
+    };
+    mock.method(ESPNService, 'fetchSoccerSummary', async () => fixture);
+
+    const res = await fetch(`${baseURL}/api/games/world-cup-2026/event/760415`);
+    assert.strictEqual(res.status, 200, 'should return 200 on success');
+    const body = await res.json();
+    assert.strictEqual(body.venue, 'SoFi Stadium · Inglewood', 'venue should be formatted');
   });
 });

--- a/backend/tests/soccer-summary.test.js
+++ b/backend/tests/soccer-summary.test.js
@@ -1,0 +1,191 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { SoccerSummaryService } from '../src/services/SoccerSummaryService.js';
+
+// Minimal hand-built fixtures. parseSummary is a pure function, so no live fetch
+// is needed — we assert the curated shape directly. Home = 'H', Away = 'A'.
+const header = {
+  competitions: [{
+    competitors: [
+      { homeAway: 'home', team: { id: 'H', abbreviation: 'HOM', displayName: 'Home United' } },
+      { homeAway: 'away', team: { id: 'A', abbreviation: 'AWY', displayName: 'Away City' } },
+    ],
+  }],
+};
+
+describe('SoccerSummaryService.parseSummary — venue', () => {
+  test('formats "<fullName> · <city>" from gameInfo.venue', () => {
+    const out = SoccerSummaryService.parseSummary({
+      header,
+      gameInfo: { venue: { fullName: 'Estadio Banorte', address: { city: 'Mexico City' } } },
+    });
+    assert.strictEqual(out.venue, 'Estadio Banorte · Mexico City');
+  });
+
+  test('venue is null when gameInfo.venue is absent', () => {
+    const out = SoccerSummaryService.parseSummary({ header });
+    assert.strictEqual(out.venue, null);
+  });
+});
+
+describe('SoccerSummaryService.parseSummary — stats', () => {
+  test('maps curated stats by team id, in order, with missing → ""', () => {
+    const out = SoccerSummaryService.parseSummary({
+      header,
+      boxscore: {
+        teams: [
+          {
+            team: { id: 'H' },
+            statistics: [
+              { name: 'possessionPct', displayValue: '55.2' },
+              { name: 'totalShots', displayValue: '14' },
+              // shotsOnTarget intentionally omitted → ''
+              { name: 'wonCorners', displayValue: '6' },
+              { name: 'foulsCommitted', displayValue: '12' },
+              { name: 'yellowCards', displayValue: '1' },
+              { name: 'redCards', displayValue: '0' },
+            ],
+          },
+          {
+            team: { id: 'A' },
+            statistics: [
+              { name: 'possessionPct', displayValue: '44.8' },
+              { name: 'totalShots', displayValue: '9' },
+              { name: 'shotsOnTarget', displayValue: '3' },
+              { name: 'wonCorners', displayValue: '2' },
+              { name: 'foulsCommitted', displayValue: '11' },
+              { name: 'yellowCards', displayValue: '2' },
+              { name: 'redCards', displayValue: '1' },
+            ],
+          },
+        ],
+      },
+    });
+
+    assert.deepStrictEqual(out.stats, [
+      { label: 'Possession', home: '55.2', away: '44.8' },
+      { label: 'Shots', home: '14', away: '9' },
+      { label: 'Shots on target', home: '', away: '3' },
+      { label: 'Corners', home: '6', away: '2' },
+      { label: 'Fouls', home: '12', away: '11' },
+      { label: 'Yellow cards', home: '1', away: '2' },
+      { label: 'Red cards', home: '0', away: '1' },
+    ]);
+  });
+
+  test('stats is [] when boxscore/teams absent', () => {
+    const out = SoccerSummaryService.parseSummary({ header });
+    assert.deepStrictEqual(out.stats, []);
+  });
+});
+
+describe('SoccerSummaryService.parseSummary — lineups', () => {
+  test('splits starters/subs, derives line, attaches goal/on/off marks by name', () => {
+    const out = SoccerSummaryService.parseSummary({
+      header,
+      rosters: [
+        {
+          homeAway: 'home',
+          formation: '4-3-3',
+          roster: [
+            {
+              starter: true,
+              jersey: '1',
+              athlete: { displayName: 'Keeper One' },
+              position: { abbreviation: 'G' },
+            },
+            {
+              starter: true,
+              jersey: '9',
+              athlete: { displayName: 'Striker Nine' },
+              position: { abbreviation: 'F' },
+            },
+            {
+              subbedIn: true,
+              jersey: '17',
+              athlete: { displayName: 'Sub Seventeen' },
+              position: { abbreviation: 'SUB' },
+            },
+          ],
+        },
+        {
+          homeAway: 'away',
+          formation: '4-4-2',
+          roster: [
+            {
+              starter: true,
+              jersey: '4',
+              athlete: { displayName: 'Defender Four' },
+              position: { abbreviation: 'D' },
+            },
+            {
+              subbedIn: true,
+              jersey: '20',
+              athlete: { displayName: 'Sub Twenty' },
+              position: { abbreviation: 'SUB' },
+            },
+          ],
+        },
+      ],
+      keyEvents: [
+        // Striker Nine scored at 9'
+        { type: { text: 'Goal' }, clock: { displayValue: "9'" }, participants: [{ athlete: { displayName: 'Striker Nine' } }] },
+        // Substitution at 56': Sub Seventeen ON, Striker Nine OFF
+        {
+          type: { text: 'Substitution' },
+          clock: { displayValue: "56'" },
+          participants: [
+            { athlete: { displayName: 'Sub Seventeen' } },
+            { athlete: { displayName: 'Striker Nine' } },
+          ],
+        },
+      ],
+    });
+
+    const { home, away } = out.lineups;
+
+    // Home team header from competitor
+    assert.strictEqual(home.abbr, 'HOM');
+    assert.strictEqual(home.name, 'Home United');
+    assert.strictEqual(home.formation, '4-3-3');
+
+    // starters split + line derivation
+    assert.strictEqual(home.starters.length, 2);
+    const keeper = home.starters.find((p) => p.name === 'Keeper One');
+    const striker = home.starters.find((p) => p.name === 'Striker Nine');
+    assert.strictEqual(keeper.line, 'GK');
+    assert.strictEqual(keeper.num, '1');
+    assert.strictEqual(striker.line, 'FWD');
+
+    // subs split
+    assert.strictEqual(home.subs.length, 1);
+    assert.strictEqual(home.subs[0].name, 'Sub Seventeen');
+    assert.strictEqual(home.subs[0].num, '17');
+
+    // goal mark on the scorer
+    assert.deepStrictEqual(
+      striker.marks.filter((m) => m.kind === 'goal'),
+      [{ kind: 'goal', min: "9'" }],
+    );
+    // OFF mark on the player who came off (a starter)
+    assert.ok(striker.marks.some((m) => m.kind === 'off' && m.min === "56'"));
+    // ON mark on the sub who came on
+    assert.ok(home.subs[0].marks.some((m) => m.kind === 'on' && m.min === "56'"));
+
+    // away line derivation: 'D' → DEF
+    assert.strictEqual(away.starters[0].line, 'DEF');
+    assert.strictEqual(away.subs.length, 1);
+  });
+});
+
+describe('SoccerSummaryService.parseSummary — resilience', () => {
+  test('parseSummary({}) returns a sparse-but-valid body without throwing', () => {
+    const out = SoccerSummaryService.parseSummary({});
+    assert.deepStrictEqual(out, { venue: null, stats: [], lineups: null });
+  });
+
+  test('parseSummary(null) does not throw', () => {
+    const out = SoccerSummaryService.parseSummary(null);
+    assert.deepStrictEqual(out, { venue: null, stats: [], lineups: null });
+  });
+});

--- a/backend/tests/soccer-summary.test.js
+++ b/backend/tests/soccer-summary.test.js
@@ -178,6 +178,20 @@ describe('SoccerSummaryService.parseSummary — lineups', () => {
   });
 });
 
+describe('SoccerSummaryService._deriveLine — position bucketing', () => {
+  const dl = (abbr) => SoccerSummaryService._deriveLine(abbr);
+
+  test("'G' → 'GK'", () => assert.strictEqual(dl('G'), 'GK'));
+  test("'CD-L' → 'DEF'", () => assert.strictEqual(dl('CD-L'), 'DEF'));
+  test("'LB' → 'DEF'", () => assert.strictEqual(dl('LB'), 'DEF'));
+  test("'DM' → 'MID'", () => assert.strictEqual(dl('DM'), 'MID'));
+  test("'CM-R' → 'MID'", () => assert.strictEqual(dl('CM-R'), 'MID'));
+  test("'LM' → 'MID'", () => assert.strictEqual(dl('LM'), 'MID'));
+  test("'F' → 'FWD'", () => assert.strictEqual(dl('F'), 'FWD'));
+  test("'RW' → 'FWD'", () => assert.strictEqual(dl('RW'), 'FWD'));
+  test("unknown 'XYZ' → 'MID'", () => assert.strictEqual(dl('XYZ'), 'MID'));
+});
+
 describe('SoccerSummaryService.parseSummary — resilience', () => {
   test('parseSummary({}) returns a sparse-but-valid body without throwing', () => {
     const out = SoccerSummaryService.parseSummary({});

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import MatchDetailPanel from './MatchDetailPanel';
+import type { BrowseGame } from '../../../lib/wcGamesView';
+import type { EventDetail } from '../../../lib/wcMatchDetail';
+
+const baseGame = (over: Partial<BrowseGame> = {}): BrowseGame => ({
+  id: 1,
+  espnId: 'espn-1',
+  stage: 'group',
+  stageLabel: 'Group Stage',
+  kickoff: '2026-06-12T17:00:00Z',
+  home: { abbr: 'MEX', name: 'Mexico', logo: 'mex.png' },
+  away: { abbr: 'RSA', name: 'South Africa', logo: 'rsa.png' },
+  status: 'SCHEDULED',
+  isKnockout: false,
+  ...over,
+});
+
+const now = new Date('2026-06-11T00:00:00Z'); // before kickoff → scheduled
+
+describe('MatchDetailPanel', () => {
+  it('shows the matchup and a lineups-loading note for a scheduled game with no detail yet', () => {
+    render(
+      <MatchDetailPanel
+        game={baseGame()}
+        detail={null}
+        loading={true}
+        now={now}
+        onPick={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText('Mexico')).toBeInTheDocument();
+    expect(screen.getByText('South Africa')).toBeInTheDocument();
+    expect(screen.getByText('Loading lineups…')).toBeInTheDocument();
+  });
+
+  it('renders venue, a match stat, and a starter name for a final game with detail', () => {
+    const game = baseGame({
+      status: 'FINAL',
+      kickoff: '2026-06-01T17:00:00Z', // in the past → locked
+      homeScore: 2,
+      awayScore: 0,
+    });
+    const detail: EventDetail = {
+      venue: 'Estadio Banorte · Mexico City',
+      stats: [{ label: 'Possession', home: '60.5%', away: '39.5%' }],
+      lineups: {
+        home: {
+          abbr: 'MEX',
+          name: 'Mexico',
+          formation: '4-1-4-1',
+          starters: [{ num: '9', name: 'Raúl Jiménez', line: 'FWD', marks: [] }],
+          subs: [],
+        },
+        away: { abbr: 'RSA', name: 'South Africa', formation: '4-4-2', starters: [], subs: [] },
+      },
+    };
+    render(
+      <MatchDetailPanel
+        game={game}
+        detail={detail}
+        loading={false}
+        now={new Date('2026-06-11T00:00:00Z')}
+        onPick={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Estadio Banorte/)).toBeInTheDocument();
+    expect(screen.getByText('Possession')).toBeInTheDocument();
+    expect(screen.getByText('Raúl Jiménez')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.test.tsx
@@ -36,6 +36,45 @@ describe('MatchDetailPanel', () => {
     expect(screen.getByText('Loading lineups…')).toBeInTheDocument();
   });
 
+  it('renders three pick buttons (home / draw / away) for a scheduled (not locked) game', () => {
+    render(
+      <MatchDetailPanel
+        game={baseGame({ kickoff: '2026-06-20T17:00:00Z', status: 'SCHEDULED' })}
+        detail={null}
+        loading={false}
+        now={now}
+        onPick={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // Home and away abbreviation buttons + Draw
+    expect(screen.getByRole('button', { name: 'MEX' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Draw' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'RSA' })).toBeInTheDocument();
+  });
+
+  it('does NOT render pick buttons for a locked (FINAL) game', () => {
+    const game = baseGame({
+      status: 'FINAL',
+      kickoff: '2026-06-01T17:00:00Z', // past → locked
+      homeScore: 1,
+      awayScore: 0,
+    });
+    render(
+      <MatchDetailPanel
+        game={game}
+        detail={null}
+        loading={false}
+        now={now}
+        onPick={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'MEX' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Draw' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'RSA' })).not.toBeInTheDocument();
+  });
+
   it('renders venue, a match stat, and a starter name for a final game with detail', () => {
     const game = baseGame({
       status: 'FINAL',

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.tsx
@@ -13,6 +13,7 @@ export interface MatchDetailPanelProps {
   now: Date;
   onPick: (gameId: number, result: MatchResult) => void;
   onClose: () => void;
+  disabled?: boolean;
 }
 
 const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
@@ -71,14 +72,14 @@ function TeamLineupView({ lineup }: { lineup: TeamLineup }) {
         return (
           <div key={ln.key}>
             <div className="px-xxs pb-xxs pt-sm text-[0.65rem] font-bold uppercase tracking-wide text-content-subtle">{ln.label}</div>
-            {players.map((p) => <PlayerRow key={p.num} p={p} />)}
+            {players.map((p) => <PlayerRow key={`${p.num}-${p.name}`} p={p} />)}
           </div>
         );
       })}
       {lineup.subs.length > 0 && (
         <>
           <div className="px-xxs pb-xxs pt-md text-[0.7rem] font-bold uppercase tracking-wide text-content-subtle">Substitutes used</div>
-          {lineup.subs.map((p) => <PlayerRow key={p.num} p={p} />)}
+          {lineup.subs.map((p) => <PlayerRow key={`${p.num}-${p.name}`} p={p} />)}
         </>
       )}
     </div>
@@ -143,7 +144,7 @@ function MatchStats({ game, detail }: { game: BrowseGame; detail: EventDetail })
   );
 }
 
-export default function MatchDetailPanel({ game, detail, loading, now, onPick, onClose }: MatchDetailPanelProps) {
+export default function MatchDetailPanel({ game, detail, loading, now, onPick, onClose, disabled }: MatchDetailPanelProps) {
   const locked = isLocked(game, now);
   const live = game.status === 'IN_PROGRESS';
   const kickoff = new Date(game.kickoff);
@@ -189,9 +190,9 @@ export default function MatchDetailPanel({ game, detail, loading, now, onPick, o
         {!locked && (
           <Section title="Your pick">
             <div className="flex gap-xs">
-              <ChoiceButton team={game.home} odds={game.home.moneyline} record={game.home.record} selected={game.picked === 'home'} onClick={() => onPick(game.id, 'home')} />
-              <ChoiceButton odds={game.drawOdds} selected={game.picked === 'draw'} onClick={() => onPick(game.id, 'draw')} />
-              <ChoiceButton team={game.away} odds={game.away.moneyline} record={game.away.record} selected={game.picked === 'away'} onClick={() => onPick(game.id, 'away')} />
+              <ChoiceButton team={game.home} odds={game.home.moneyline} record={game.home.record} selected={game.picked === 'home'} onClick={() => onPick(game.id, 'home')} disabled={disabled} />
+              <ChoiceButton odds={game.drawOdds} selected={game.picked === 'draw'} onClick={() => onPick(game.id, 'draw')} disabled={disabled} />
+              <ChoiceButton team={game.away} odds={game.away.moneyline} record={game.away.record} selected={game.picked === 'away'} onClick={() => onPick(game.id, 'away')} disabled={disabled} />
             </div>
             {game.overUnder && <p className="mt-xs text-center text-xs text-content-subtle">DraftKings · O/U {game.overUnder}</p>}
           </Section>

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.tsx
@@ -1,0 +1,226 @@
+import { useState } from 'react';
+import type { BrowseGame, MatchResult } from '../../../lib/wcGamesView';
+import { isLocked } from '../../../lib/wcGamesView';
+import type { EventDetail, MatchStat, PlayerMark, TeamLineup } from '../../../lib/wcMatchDetail';
+import MatchTimeline from '../MatchTimeline';
+import ChoiceButton from './ChoiceButton';
+
+export interface MatchDetailPanelProps {
+  game: BrowseGame;
+  /** /event payload; null while the fetch is in flight. */
+  detail: EventDetail | null;
+  loading: boolean;
+  now: Date;
+  onPick: (gameId: number, result: MatchResult) => void;
+  onClose: () => void;
+}
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div className="border-t border-border px-md py-sm">
+    <div className="mb-xs text-[0.7rem] font-bold uppercase tracking-wide text-content-subtle">{title}</div>
+    {children}
+  </div>
+);
+
+// Inline hexes: these W/D/L + marker bg utilities aren't in the compiled CSS, so
+// classed backgrounds (bg-success-500 etc.) wouldn't paint. Keep the prototype's
+// inline-style approach.
+const FORM_BG: Record<string, string> = { W: '#14a88e', L: '#ef4444', D: '#9b99bf' };
+const FormPills = ({ seq }: { seq: string }) => (
+  <div className="flex gap-xxs">
+    {seq.split('').map((r, i) => (
+      <span key={i} style={{ backgroundColor: FORM_BG[r] ?? '#9b99bf' }}
+        className="flex h-5 w-5 items-center justify-center rounded-sm text-[0.6rem] font-bold text-neutral-0">{r}</span>
+    ))}
+  </div>
+);
+
+function Marker({ m }: { m: PlayerMark }) {
+  if (m.kind === 'goal' || m.kind === 'own-goal') {
+    return <span className="inline-flex items-center gap-xxs text-content-muted">⚽<span className="tabular-nums">{m.min}</span></span>;
+  }
+  if (m.kind === 'yellow') return <span className="inline-flex items-center gap-xxs"><span className="inline-block h-3 w-[0.55rem] rounded-[1px]" style={{ background: '#f5c518' }} /><span className="tabular-nums text-content-muted">{m.min}</span></span>;
+  if (m.kind === 'red') return <span className="inline-flex items-center gap-xxs"><span className="inline-block h-3 w-[0.55rem] rounded-[1px]" style={{ background: '#ef4444' }} /><span className="tabular-nums text-content-muted">{m.min}</span></span>;
+  if (m.kind === 'off') return <span className="inline-flex items-center gap-xxs font-semibold" style={{ color: '#ef4444' }}>↓<span className="tabular-nums">{m.min}</span></span>;
+  return <span className="inline-flex items-center gap-xxs font-semibold" style={{ color: '#0c8772' }}>↑<span className="tabular-nums">{m.min}</span></span>;
+}
+
+const PlayerRow = ({ p }: { p: { num: string; name: string; marks: PlayerMark[] } }) => (
+  <div className="flex items-center gap-sm py-xs">
+    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-secondary-100 text-xs font-bold tabular-nums text-content-muted dark:bg-secondary-800">{p.num}</span>
+    <span className="flex-1 truncate text-sm font-medium text-content">{p.name}</span>
+    <span className="flex items-center gap-sm text-xs">{p.marks.map((m, i) => <Marker key={i} m={m} />)}</span>
+  </div>
+);
+
+const LINES: { key: 'GK' | 'DEF' | 'MID' | 'FWD'; label: string }[] = [
+  { key: 'GK', label: 'Goalkeeper' }, { key: 'DEF', label: 'Defenders' },
+  { key: 'MID', label: 'Midfielders' }, { key: 'FWD', label: 'Forwards' },
+];
+
+function TeamLineupView({ lineup }: { lineup: TeamLineup }) {
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <span className="text-[0.7rem] font-bold uppercase tracking-wide text-content-subtle">Starting XI</span>
+        {lineup.formation && <span className="text-xs font-semibold text-content-muted">{lineup.formation}</span>}
+      </div>
+      {LINES.map((ln) => {
+        const players = lineup.starters.filter((p) => p.line === ln.key);
+        if (!players.length) return null;
+        return (
+          <div key={ln.key}>
+            <div className="px-xxs pb-xxs pt-sm text-[0.65rem] font-bold uppercase tracking-wide text-content-subtle">{ln.label}</div>
+            {players.map((p) => <PlayerRow key={p.num} p={p} />)}
+          </div>
+        );
+      })}
+      {lineup.subs.length > 0 && (
+        <>
+          <div className="px-xxs pb-xxs pt-md text-[0.7rem] font-bold uppercase tracking-wide text-content-subtle">Substitutes used</div>
+          {lineup.subs.map((p) => <PlayerRow key={p.num} p={p} />)}
+        </>
+      )}
+    </div>
+  );
+}
+
+function Lineups({ game, detail, loading }: { game: BrowseGame; detail: EventDetail | null; loading: boolean }) {
+  const [side, setSide] = useState<'home' | 'away'>('home');
+  if (loading || !detail) return <p className="text-sm text-content-subtle">Loading lineups…</p>;
+  if (!detail.lineups) return <p className="text-sm text-content-subtle">Lineups not available.</p>;
+  const lineup = side === 'home' ? detail.lineups.home : detail.lineups.away;
+  return (
+    <div>
+      <div className="mb-sm flex gap-xs">
+        {(['home', 'away'] as const).map((s) => {
+          const t = s === 'home' ? game.home : game.away;
+          return (
+            <button key={s} type="button" onClick={() => setSide(s)}
+              className={`flex flex-1 items-center justify-center gap-xs rounded-md py-xxs text-sm font-semibold ${side === s ? 'bg-accent text-accent-fg' : 'border border-border text-content-muted'}`}>
+              <img src={t.logo} alt="" className="h-icon-sm w-icon-sm object-contain" /> {t.name}
+            </button>
+          );
+        })}
+      </div>
+      <TeamLineupView lineup={lineup} />
+    </div>
+  );
+}
+
+/** Parse a stat's display value to a number for bar proportioning ("60.5%" → 60.5). */
+function statValue(v: string): number | null {
+  const n = parseFloat(String(v).replace(/[^0-9.+-]/g, ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+function MatchStats({ game, detail }: { game: BrowseGame; detail: EventDetail }) {
+  if (!detail.stats.length) return null;
+  return (
+    <div className="space-y-sm">
+      {detail.stats.map((st: MatchStat) => {
+        const h = statValue(st.home);
+        const a = statValue(st.away);
+        const total = h != null && a != null ? h + a : null;
+        const homePct = total && total > 0 ? (h! / total) * 100 : null;
+        return (
+          <div key={st.label}>
+            <div className="flex justify-between text-xs">
+              <span className="font-bold tabular-nums text-content">{st.home}</span>
+              <span className="text-content-subtle">{st.label}</span>
+              <span className="font-bold tabular-nums text-content">{st.away}</span>
+            </div>
+            {homePct != null && (
+              <div className="mt-xxs flex h-1.5 overflow-hidden rounded-pill bg-secondary-200 dark:bg-secondary-700">
+                <div className="bg-accent" style={{ width: `${homePct}%` }} />
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <p className="text-[0.65rem] text-content-subtle">{game.home.abbr} (left) · {game.away.abbr} (right)</p>
+    </div>
+  );
+}
+
+export default function MatchDetailPanel({ game, detail, loading, now, onPick, onClose }: MatchDetailPanelProps) {
+  const locked = isLocked(game, now);
+  const live = game.status === 'IN_PROGRESS';
+  const kickoff = new Date(game.kickoff);
+  const dateLabel = kickoff.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  const timeLabel = kickoff.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  const venue = detail?.venue ?? null;
+  const meta = venue ? `${dateLabel} · ${timeLabel} · ${venue}` : `${dateLabel} · ${timeLabel}`;
+  const events = game.events ?? [];
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} aria-hidden="true" />
+      <div className="relative z-10 flex h-full w-full max-w-[460px] flex-col overflow-y-auto bg-surface shadow-2xl">
+        {/* header */}
+        <div className="px-md pb-sm pt-md">
+          <button type="button" onClick={onClose} className="mb-md text-sm font-semibold text-content-muted">‹ Back</button>
+          <div className="flex items-center justify-between">
+            <div className="w-28 text-center">
+              <img src={game.home.logo} alt="" className="mx-auto h-12 w-12 object-contain" />
+              <div className="mt-xs font-bold text-content">{game.home.name}</div>
+            </div>
+            <div className="text-center">
+              {locked ? (
+                <>
+                  <div className="text-2xl font-extrabold tabular-nums text-content">{game.homeScore} – {game.awayScore}</div>
+                  <div className={`text-xs font-bold ${live ? 'text-error-500' : 'text-content-subtle'}`}>{live ? 'LIVE' : 'FULL TIME'}</div>
+                </>
+              ) : (
+                <div className="text-xs font-bold uppercase tracking-wide text-content-subtle">Kickoff</div>
+              )}
+              <div className="mt-xxs text-xs text-content-subtle">{game.stageLabel}</div>
+            </div>
+            <div className="w-28 text-center">
+              <img src={game.away.logo} alt="" className="mx-auto h-12 w-12 object-contain" />
+              <div className="mt-xs font-bold text-content">{game.away.name}</div>
+            </div>
+          </div>
+          {/* date + time, plus venue from the /event fetch when present */}
+          <div className="mt-sm text-center text-xs text-content-subtle">{meta}</div>
+        </div>
+
+        {/* pick controls (only when not locked) */}
+        {!locked && (
+          <Section title="Your pick">
+            <div className="flex gap-xs">
+              <ChoiceButton team={game.home} odds={game.home.moneyline} record={game.home.record} selected={game.picked === 'home'} onClick={() => onPick(game.id, 'home')} />
+              <ChoiceButton odds={game.drawOdds} selected={game.picked === 'draw'} onClick={() => onPick(game.id, 'draw')} />
+              <ChoiceButton team={game.away} odds={game.away.moneyline} record={game.away.record} selected={game.picked === 'away'} onClick={() => onPick(game.id, 'away')} />
+            </div>
+            {game.overUnder && <p className="mt-xs text-center text-xs text-content-subtle">DraftKings · O/U {game.overUnder}</p>}
+          </Section>
+        )}
+
+        {/* locked: timeline + stats; scheduled: form */}
+        {locked ? (
+          <>
+            {events.length > 0 && <Section title="Timeline"><MatchTimeline events={events} /></Section>}
+            {detail && detail.stats.length > 0 && <Section title="Match stats"><MatchStats game={game} detail={detail} /></Section>}
+          </>
+        ) : (
+          (game.home.form || game.away.form) && (
+            <Section title="Form · last 5">
+              <div className="space-y-xs">
+                {game.home.form && (
+                  <div className="flex items-center justify-between"><span className="text-sm font-semibold text-content">{game.home.name}</span><FormPills seq={game.home.form} /></div>
+                )}
+                {game.away.form && (
+                  <div className="flex items-center justify-between"><span className="text-sm font-semibold text-content">{game.away.name}</span><FormPills seq={game.away.form} /></div>
+                )}
+              </div>
+            </Section>
+          )
+        )}
+
+        <Section title="Lineups"><Lineups game={game} detail={detail} loading={loading} /></Section>
+        <div className="h-lg" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import MatchListCard from './MatchListCard';
 import type { BrowseGame, BrowseTeam } from '../../../lib/wcGamesView';
 
@@ -50,5 +50,17 @@ describe('MatchListCard', () => {
   it('exposes a match-card testid on the root element', () => {
     render(<MatchListCard game={game({ id: 42 })} now={NOW} onPick={noop} />);
     expect(screen.getByTestId('match-card-42')).toBeInTheDocument();
+  });
+
+  it('calls onOpenDetail with the game id when "More ›" is clicked', () => {
+    const onOpenDetail = vi.fn();
+    render(<MatchListCard game={game({ id: 42 })} now={NOW} onPick={noop} onOpenDetail={onOpenDetail} />);
+    fireEvent.click(screen.getByRole('button', { name: /more/i }));
+    expect(onOpenDetail).toHaveBeenCalledWith(42);
+  });
+
+  it('omits the "More ›" button when no onOpenDetail handler is given', () => {
+    render(<MatchListCard game={game()} now={NOW} onPick={noop} />);
+    expect(screen.queryByRole('button', { name: /more/i })).toBeNull();
   });
 });

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
@@ -7,6 +7,8 @@ export interface MatchListCardProps {
   game: BrowseGame;
   now: Date;
   onPick: (gameId: number, result: MatchResult) => void;
+  /** Opens the match detail panel for this game. Omit to hide the "More ›" button. */
+  onOpenDetail?: (gameId: number) => void;
   disabled?: boolean;
 }
 
@@ -67,7 +69,7 @@ function ResultStrip({ game }: { game: BrowseGame }) {
  * full team names; the card body is the three-way bet (pickable) or a result
  * strip (locked).
  */
-export default function MatchListCard({ game, now, onPick, disabled }: MatchListCardProps) {
+export default function MatchListCard({ game, now, onPick, onOpenDetail, disabled }: MatchListCardProps) {
   const locked = isLocked(game, now);
   const lead =
     game.status === 'IN_PROGRESS' ? 'LIVE' : game.status === 'FINAL' ? 'FINAL' : formatTime(game.kickoff);
@@ -80,8 +82,8 @@ export default function MatchListCard({ game, now, onPick, disabled }: MatchList
 
   return (
     <div data-testid={`match-card-${game.id}`}>
-      {/* subheader: status/time + full names (wraps) */}
-      <div className="flex items-start gap-sm px-xxs pb-xxs pt-sm">
+      {/* subheader: status/time + full names (wraps), roomy More on the right */}
+      <div className="flex items-start justify-between gap-sm px-xxs pb-xxs pt-sm">
         <div className="min-w-0 text-xs leading-snug">
           <span className={`font-bold uppercase tracking-wide ${game.status === 'IN_PROGRESS' ? 'text-error-500' : 'text-content-subtle'}`}>
             {lead}
@@ -90,6 +92,15 @@ export default function MatchListCard({ game, now, onPick, disabled }: MatchList
             {game.home.name} <span className="text-content-subtle">vs</span> {game.away.name}
           </span>
         </div>
+        {onOpenDetail && (
+          <button
+            type="button"
+            onClick={() => onOpenDetail(game.id)}
+            className="shrink-0 rounded-md px-xs py-xxs text-sm font-semibold text-accent hover:bg-accent-subtle/50"
+          >
+            More ›
+          </button>
+        )}
       </div>
 
       {locked ? (

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
@@ -1,10 +1,16 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { WorldCupStage } from '../../../lib/types';
 import {
   buildSections, needsPick, pickVerdict, NO_FILTERS,
   type BrowseGame, type Filters, type GameStatus, type MatchResult, type SavedView, type SortKey,
 } from '../../../lib/wcGamesView';
+import type { EventDetail } from '../../../lib/wcMatchDetail';
+import { getMatchDetail } from '../../../lib/worldCupService.js';
 import MatchListCard from './MatchListCard';
+import MatchDetailPanel from './MatchDetailPanel';
+
+// Fallback so the panel still renders the game-side info when the /event fetch fails.
+const EMPTY_DETAIL: EventDetail = { venue: null, stats: [], lineups: null };
 
 export interface WorldCupGamesListProps {
   games: BrowseGame[];          // derived by the host from matches + draft
@@ -61,6 +67,47 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
   const [filters, setFilters] = useState<Filters>(NO_FILTERS);
   const [sort, setSort] = useState<SortKey>('kickoff');
   const [showFilters, setShowFilters] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [detail, setDetail] = useState<EventDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  // Bumped on every open so a fast close/reopen can't let a stale fetch win.
+  const fetchSeq = useRef(0);
+
+  const selectedGame = useMemo(
+    () => (selectedId == null ? null : games.find((g) => g.id === selectedId) ?? null),
+    [games, selectedId],
+  );
+
+  // If the selected game disappears from the list, drop the panel.
+  useEffect(() => {
+    if (selectedId != null && selectedGame == null) setSelectedId(null);
+  }, [selectedId, selectedGame]);
+
+  const openDetail = (gameId: number) => {
+    const game = games.find((g) => g.id === gameId);
+    if (!game) return;
+    const seq = ++fetchSeq.current;
+    setSelectedId(gameId);
+    setDetail(null);
+    setDetailLoading(true);
+    getMatchDetail(game.espnId)
+      .then((d: EventDetail) => {
+        if (fetchSeq.current === seq) setDetail(d);
+      })
+      .catch(() => {
+        if (fetchSeq.current === seq) setDetail(EMPTY_DETAIL);
+      })
+      .finally(() => {
+        if (fetchSeq.current === seq) setDetailLoading(false);
+      });
+  };
+
+  const closeDetail = () => {
+    fetchSeq.current++; // invalidate any in-flight fetch
+    setSelectedId(null);
+    setDetail(null);
+    setDetailLoading(false);
+  };
 
   const needsPickCount = useMemo(() => games.filter((g) => needsPick(g, now)).length, [games, now]);
   const correctCount = useMemo(() => games.filter((g) => pickVerdict(g) === 'correct').length, [games]);
@@ -174,12 +221,23 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
               </div>
               <div className="space-y-xs">
                 {sec.games.map((g) => (
-                  <MatchListCard key={g.id} game={g} now={now} onPick={onPick} disabled={disabled} />
+                  <MatchListCard key={g.id} game={g} now={now} onPick={onPick} onOpenDetail={openDetail} disabled={disabled} />
                 ))}
               </div>
             </section>
           ))}
         </div>
+      )}
+
+      {selectedGame && (
+        <MatchDetailPanel
+          game={selectedGame}
+          detail={detail}
+          loading={detailLoading}
+          now={now}
+          onPick={onPick}
+          onClose={closeDetail}
+        />
       )}
     </div>
   );

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
@@ -237,6 +237,7 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
           now={now}
           onPick={onPick}
           onClose={closeDetail}
+          disabled={disabled}
         />
       )}
     </div>

--- a/frontend/src/lib/wcGamesView.ts
+++ b/frontend/src/lib/wcGamesView.ts
@@ -3,7 +3,7 @@
 // pollIntervalFor). The host derives BrowseGame from API matches + draft via
 // worldCupBrowseAdapter.
 
-import type { WorldCupStage } from './types';
+import type { MatchEvent, WorldCupStage } from './types';
 
 export type MatchResult = 'home' | 'draw' | 'away';
 export type GameStatus = 'SCHEDULED' | 'IN_PROGRESS' | 'FINAL';
@@ -18,6 +18,8 @@ export interface BrowseTeam {
   record?: string;
   /** Moneyline for this team to win. Optional: absent until P2. */
   moneyline?: string;
+  /** Recent W/D/L form sequence, e.g. "WWDWL". Optional. */
+  form?: string;
 }
 
 export interface BrowseGame {
@@ -40,6 +42,8 @@ export interface BrowseGame {
   picked?: MatchResult;
   /** Knockout matches can't end in a draw (PKs decide) — disables the Draw pick. */
   isKnockout: boolean;
+  /** Goal/card timeline once the match has started. Absent before kickoff. */
+  events?: MatchEvent[];
 }
 
 /** A game is locked once it has kicked off — by status OR by the clock passing kickoff. */

--- a/frontend/src/lib/wcMatchDetail.ts
+++ b/frontend/src/lib/wcMatchDetail.ts
@@ -1,0 +1,46 @@
+// Real types for the World Cup match detail panel's N+1 fetch. The panel is fed
+// by two sources: the game itself (a BrowseGame — teams/scores/status/events/odds)
+// and this EventDetail, returned by GET /api/games/world-cup-2026/event/:espnId
+// (venue + curated match stats + per-side lineups). Head-to-head and standings
+// are deferred and intentionally absent from this shape.
+
+/** Coarse pitch line for grouping a starter. Subs carry no line. */
+export type LineupLine = 'GK' | 'DEF' | 'MID' | 'FWD';
+
+/** A per-player marker in the lineup (goal/card/sub on-off) with its minute. */
+export interface PlayerMark {
+  kind: 'goal' | 'own-goal' | 'yellow' | 'red' | 'on' | 'off';
+  /** ESPN display clock, e.g. "9'" or "90'+2'". */
+  min: string;
+}
+
+export interface LineupPlayer {
+  num: string;
+  name: string;
+  /** Present for starters (GK/DEF/MID/FWD); absent for substitutes. */
+  line?: LineupLine;
+  marks: PlayerMark[];
+}
+
+export interface TeamLineup {
+  abbr: string;
+  name: string;
+  formation: string;
+  starters: LineupPlayer[];
+  subs: LineupPlayer[];
+}
+
+/** One curated match-stat row: a label with each side's display value. */
+export interface MatchStat {
+  label: string;
+  home: string;
+  away: string;
+}
+
+/** The /event/:espnId payload. Every field is best-effort: venue may be null,
+ *  stats may be empty, and lineups may be null when ESPN hasn't posted them. */
+export interface EventDetail {
+  venue: string | null;
+  stats: MatchStat[];
+  lineups: { home: TeamLineup; away: TeamLineup } | null;
+}

--- a/frontend/src/lib/worldCupBrowseAdapter.test.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.test.ts
@@ -70,4 +70,27 @@ describe('toBrowseGames', () => {
     expect(g.drawOdds).toBeUndefined();
     expect(g.overUnder).toBeUndefined();
   });
+
+  it('carries team form and the match events timeline through', () => {
+    const events: WorldCupMatch['events'] = [
+      { type: 'goal', minute: "9'", player: 'J. Quiñones', side: 'home', teamAbbr: 'MEX' },
+    ];
+    const m = match({
+      id: 55,
+      homeTeam: { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: 'mex.png', form: 'WWDWL' },
+      awayTeam: { id: '2', name: 'South Africa', abbreviation: 'RSA', logo: 'rsa.png', form: 'LDWWD' },
+      events,
+    });
+    const [g] = toBrowseGames([m], {});
+    expect(g.home.form).toBe('WWDWL');
+    expect(g.away.form).toBe('LDWWD');
+    expect(g.events).toEqual(events);
+  });
+
+  it('leaves form and events undefined when the match omits them', () => {
+    const [g] = toBrowseGames([match({ id: 56 })], {});
+    expect(g.home.form).toBeUndefined();
+    expect(g.away.form).toBeUndefined();
+    expect(g.events).toBeUndefined();
+  });
 });

--- a/frontend/src/lib/worldCupBrowseAdapter.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.ts
@@ -25,6 +25,7 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap): Browse
       logo: m.homeTeam.logo,
       record: m.homeTeam.record || undefined,
       moneyline: m.odds?.threeWay?.home || undefined,
+      form: m.homeTeam.form || undefined,
     },
     away: {
       abbr: m.awayTeam.abbreviation,
@@ -32,6 +33,7 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap): Browse
       logo: m.awayTeam.logo,
       record: m.awayTeam.record || undefined,
       moneyline: m.odds?.threeWay?.away || undefined,
+      form: m.awayTeam.form || undefined,
     },
     // `|| undefined` (not `??`) so an empty-string odds/record from ESPN also
     // collapses to absent — the card renders nothing rather than an empty line.
@@ -46,5 +48,6 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap): Browse
     // pick enabled on knockout matches. Every non-group stage is single-elimination
     // (PKs decide), so Draw must be disabled — see MatchListCard.
     isKnockout: m.stage !== 'group',
+    events: m.events,
   }));
 }

--- a/frontend/src/lib/worldCupService.d.ts
+++ b/frontend/src/lib/worldCupService.d.ts
@@ -11,6 +11,7 @@ import type {
   MatchPickResult,
   TournamentLeaderboardRow,
 } from './types';
+import type { EventDetail } from './wcMatchDetail';
 
 /** Response shape of GET /api/games/world-cup-2026/stage/:stage. */
 export interface StageMatchesResponse {
@@ -78,5 +79,12 @@ export function submitUserWorldCupPicks(
   userId: string | number,
   picks: MatchPick[],
 ): Promise<{ picks?: MatchPick[]; targetUserId?: number; isAdminOverride?: boolean } & Record<string, unknown>>;
+
+/**
+ * Fetch on-demand match detail (venue + curated stats + per-side lineups) for the
+ * detail panel, keyed by the real ESPN event id. The backend is resilient, so the
+ * panel renders the game-side info even if this rejects.
+ */
+export function getMatchDetail(espnId: string): Promise<EventDetail>;
 
 export type { MatchPickResult };

--- a/frontend/src/lib/worldCupService.js
+++ b/frontend/src/lib/worldCupService.js
@@ -93,3 +93,15 @@ export async function getWorldCupLeaderboard(groupId) {
   }
   return res.json();
 }
+
+// On-demand match detail (venue + curated stats + per-side lineups) for the
+// detail panel. Keyed by the real ESPN event id; resilient on the backend, so
+// the panel still renders the game-side info if this throws.
+export async function getMatchDetail(espnId) {
+  const res = await authFetch(`${apiBase()}/api/games/world-cup-2026/event/${espnId}`);
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || 'Failed to load match detail');
+  }
+  return res.json();
+}

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../lib/worldCupService.js', () => ({
   getMyWorldCupPicks: vi.fn(),
   getUserWorldCupPicks: vi.fn(),
   submitUserWorldCupPicks: vi.fn(),
+  getMatchDetail: vi.fn().mockResolvedValue({ venue: null, stats: [], lineups: null }),
 }));
 vi.mock('../../lib/groupsService.js', () => ({
   getMyGroups: vi.fn(),

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -82,22 +82,18 @@ function showAllGames() {
 }
 
 // Each game renders a MatchListCard whose subheader carries the full matchup
-// ("Mexico vs United States"). There's no per-row testid in the flat list, so we
-// locate a card by its home-team name and scope queries to it. Only the group
-// game shows a Draw button (knockout games offer just the two teams), but we keep
-// queries card-scoped anyway since team abbreviations could repeat across cards.
+// ("Mexico vs United States") and whose root holds a `match-card-<id>` testid. We
+// find the card by its home-team name, then climb to that testid'd root — robust
+// whether or not the card shows a Draw button (knockout games offer just the two
+// teams) or a "More ›" button.
 function cardFor(homeName: string): HTMLElement {
   const label = screen.getByText(
     (_content, node) => node?.textContent?.startsWith(homeName + ' vs ') ?? false,
     { selector: 'span' },
   );
-  // Climb to the card root: the nearest ancestor that also holds the pick buttons.
-  let el: HTMLElement | null = label;
-  while (el && within(el).queryAllByRole('button').length === 0) {
-    el = el.parentElement;
-  }
-  if (!el) throw new Error(`No card found for ${homeName}`);
-  return el;
+  const card = label.closest('[data-testid^="match-card-"]');
+  if (!card) throw new Error(`No card found for ${homeName}`);
+  return card as HTMLElement;
 }
 
 // A game's outcome buttons by accessible name (team abbreviation, or 'Draw' on


### PR DESCRIPTION
**P3 of the stacked WC browse view — the match detail panel + a per-event summary endpoint.** Tapping **"More ›"** on a card opens a slide-over with venue, the timeline, match stats, form, and lineups.

### ✅ Prod-safety: NO schema, NO persistence, never-500
Per the audit, this is the one phase that adds a backend endpoint — designed to be incapable of the events-SEV class:
- **`GET /api/games/world-cup-2026/event/:espnId`** fetches ESPN `/summary` **live, on demand** (the detail is opened per-match, not on every list load) and parses venue + match stats + lineups. **No DB write, no new column, no migration.**
- The route **never 500s**: any fetch/parse failure returns HTTP 200 with a sparse `{ venue:null, stats:[], lineups:null }` (verified by a route-layer test). A broken `/summary` only blanks the detail panel — it can't touch the list/picks/leaderboard.
- The parser (`SoccerSummaryService`) is pure and fully null-safe (verified by walking every access). H2H + group standings are deliberately deferred.

### Frontend
- New `MatchDetailPanel` slide-over (desktop right / mobile full-screen), fed by `getMatchDetail(espnId)` **plus the game's own data** (events→timeline, form→pills, odds→pick controls). Loading + "lineups not available" + sparse-detail states all handled; the detail fetch failing never blanks the list (cancel/sequence-guarded).
- "More ›" restored on the card; `disabled` threaded so read-only viewers can't pick in the panel.

### Tests
Backend: 22 pass incl. the route never-500 + robust position→line bucketing. Frontend: tsc clean, 644 tests, build OK. Zero coverage/schema churn in the diff.
