### PR TITLE
WC browse hotfix: Today default, edge-to-edge chips, knockout Draw disabled

### DIFF
--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import WorldCupGamesList from './WorldCupGamesList';
+import type { BrowseGame, BrowseTeam } from '../../../lib/wcGamesView';
+
+const NOW = new Date('2026-06-12T16:00:00');
+
+const team = (abbr: string, name: string): BrowseTeam => ({ abbr, name, logo: '' });
+
+function game(over: Partial<BrowseGame> = {}): BrowseGame {
+  return {
+    id: 1, espnId: 'e1', stage: 'group', stageLabel: 'Group Stage',
+    kickoff: '2026-06-12T20:00:00', // same day as NOW
+    home: team('MEX', 'Mexico'), away: team('CAN', 'Canada'),
+    status: 'SCHEDULED', isKnockout: false,
+    ...over,
+  };
+}
+
+describe('WorldCupGamesList', () => {
+  it("defaults to the Today view — only today's games are listed", () => {
+    const today = game({ id: 1, kickoff: '2026-06-12T20:00:00' });
+    const tomorrow = game({
+      id: 2, kickoff: '2026-06-13T20:00:00',
+      home: team('BRA', 'Brazil'), away: team('ARG', 'Argentina'),
+    });
+    render(<WorldCupGamesList games={[today, tomorrow]} now={NOW} onPick={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
+    expect(screen.getByTestId('match-card-1')).toBeInTheDocument();
+    // Tomorrow's game is filtered out by the default Today view.
+    expect(screen.queryByTestId('match-card-2')).toBeNull();
+  });
+});

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
@@ -56,7 +56,7 @@ const selectCls =
   'rounded-md border border-border bg-neutral-0 px-xs py-xxs text-sm text-content dark:bg-secondary-900';
 
 export default function WorldCupGamesList({ games, now, onPick, disabled }: WorldCupGamesListProps) {
-  const [view, setView] = useState<SavedView>('needs-pick');
+  const [view, setView] = useState<SavedView>('today');
   const [query, setQuery] = useState('');
   const [filters, setFilters] = useState<Filters>(NO_FILTERS);
   const [sort, setSort] = useState<SortKey>('kickoff');
@@ -105,8 +105,10 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
         </button>
       </div>
 
-      {/* saved-view chips */}
-      <div className="mb-xs flex gap-xs overflow-x-auto pb-xxs">
+      {/* saved-view chips — full-bleed horizontal scroller. The negative margins
+          cancel the host page's px-sm/sm:px-lg gutters so the chips run edge to
+          edge, and the scrollbar is hidden (it overlapped the chips on overflow). */}
+      <div className="mb-xs -mx-sm flex gap-xs overflow-x-auto [scrollbar-width:none] sm:-mx-lg [&::-webkit-scrollbar]:hidden">
         {VIEWS.map((v) => (
           <Chip
             key={v.key}

--- a/frontend/src/lib/worldCupBrowseAdapter.test.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.test.ts
@@ -25,9 +25,17 @@ describe('toBrowseGames', () => {
   it('maps the stageLabel for a knockout stage', () => {
     expect(toBrowseGames([match({ stage: 'r16' })], {})[0].stageLabel).toBe('Round of 16');
   });
-  it('maps the isKnockout flag through', () => {
-    expect(toBrowseGames([match({ isKnockout: true })], {})[0].isKnockout).toBe(true);
-    expect(toBrowseGames([match({ isKnockout: false })], {})[0].isKnockout).toBe(false);
+  it('derives isKnockout from the stage — every non-group stage is knockout', () => {
+    expect(toBrowseGames([match({ stage: 'group' })], {})[0].isKnockout).toBe(false);
+    for (const stage of ['r32', 'r16', 'qf', 'sf', 'third', 'final'] as const) {
+      expect(toBrowseGames([match({ stage })], {})[0].isKnockout).toBe(true);
+    }
+  });
+  it('ignores the unreliable m.isKnockout flag (the stage route never emits it)', () => {
+    // A knockout match whose isKnockout arrives false/undefined must still be
+    // flagged knockout from its stage — this is the prod bug that re-enabled Draw.
+    expect(toBrowseGames([match({ stage: 'r16', isKnockout: false })], {})[0].isKnockout).toBe(true);
+    expect(toBrowseGames([match({ stage: 'group', isKnockout: true })], {})[0].isKnockout).toBe(false);
   });
   it('normalizes an unknown status to SCHEDULED', () => {
     expect(toBrowseGames([match({ status: 'POSTPONED' as WorldCupMatch['status'] })], {})[0].status).toBe('SCHEDULED');

--- a/frontend/src/lib/worldCupBrowseAdapter.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.ts
@@ -25,6 +25,10 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap): Browse
     homeScore: m.homeScore,
     awayScore: m.awayScore,
     picked: draft[m.id],
-    isKnockout: m.isKnockout,
+    // Derive from the stage rather than trusting m.isKnockout: the stage route
+    // doesn't actually emit that flag, so it arrives undefined and left the Draw
+    // pick enabled on knockout matches. Every non-group stage is single-elimination
+    // (PKs decide), so Draw must be disabled — see MatchListCard.
+    isKnockout: m.stage !== 'group',
   }));
 }

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -34,6 +34,15 @@ const usa = { id: '2', name: 'United States', abbreviation: 'USA', logo: '' };
 const can = { id: '3', name: 'Canada', abbreviation: 'CAN', logo: '' };
 const arg = { id: '4', name: 'Argentina', abbreviation: 'ARG', logo: '' };
 
+// End of the local day: the match shows under the default "Today" view AND stays
+// ahead of the clock (pre-kickoff / pickable) whenever the suite runs. Kickoff-time
+// locking is exercised directly in the card component's own tests.
+function endOfToday(): string {
+  const d = new Date();
+  d.setHours(23, 59, 59, 999);
+  return d.toISOString();
+}
+
 function match(overrides: Partial<WorldCupMatch>): WorldCupMatch {
   return {
     id: 0,
@@ -44,10 +53,7 @@ function match(overrides: Partial<WorldCupMatch>): WorldCupMatch {
     awayScore: 0,
     status: 'SCHEDULED',
     isKnockout: false,
-    // Relative to now (tomorrow) so an upcoming match is always pre-kickoff and
-    // pickable whenever the suite runs — kickoff-time locking is exercised
-    // directly in the card component's own tests.
-    gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    gameDate: endOfToday(),
     ...overrides,
   };
 }
@@ -68,10 +74,9 @@ function renderTab(identifier = 'la-crew') {
   return render(<WorldCupPicksTab identifier={identifier} />);
 }
 
-// The flat browse list defaults to the "Needs pick" view, which HIDES games that
-// are already picked or locked. Clicking the "All" chip forces every game to be
-// visible so a card stays in the DOM after it's picked (needed by toggle /
-// aria-pressed / hydration assertions).
+// The flat browse list defaults to the "Today" view; the fixtures above are dated
+// today so they show there. A couple of assertions still force the "All" view via
+// this helper to keep a card visible irrespective of date/pick filters.
 function showAllGames() {
   fireEvent.click(screen.getByRole('button', { name: 'All' }));
 }

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -283,8 +283,9 @@ describe('GroupDetailsPage', () => {
       awayScore: 0,
       status: 'SCHEDULED',
       isKnockout: false,
-      // Tomorrow, so the match stays pre-kickoff and pickable whenever CI runs.
-      gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      // End of today: visible under the default "Today" view AND pre-kickoff /
+      // pickable whenever CI runs.
+      gameDate: (() => { const d = new Date(); d.setHours(23, 59, 59, 999); return d.toISOString(); })(),
     };
     const stageResponder = (stage: WorldCupStage) => {
       const games = stage === 'group' ? [wcMatch] : [];

--- a/frontend/src/pages/WorldCupPicksPage.test.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.test.tsx
@@ -36,8 +36,9 @@ const groupMatch: WorldCupMatch = {
   awayScore: 0,
   status: 'SCHEDULED',
   isKnockout: false,
-  // Tomorrow, so the match stays pre-kickoff and pickable whenever CI runs.
-  gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  // End of today: visible under the default "Today" view AND pre-kickoff /
+  // pickable whenever CI runs.
+  gameDate: (() => { const d = new Date(); d.setHours(23, 59, 59, 999); return d.toISOString(); })(),
 };
 
 function renderPage(route = '/world-cup?group=la-crew') {

--- a/frontend/tests/e2e/world-cup-picks-person-selector.spec.ts
+++ b/frontend/tests/e2e/world-cup-picks-person-selector.spec.ts
@@ -132,6 +132,8 @@ test('admin can override a teammate and save via the per-user endpoint', async (
 
   await page.goto('/group-details?group=wc-group')
   await page.getByRole('tab', { name: 'Picks' }).click()
+  // Default "Today" view hides the future-dated seed; switch to "All".
+  await page.getByRole('button', { name: 'All' }).click()
   await expect(page.getByTestId('match-card-101')).toBeVisible()
 
   // The selector defaults to the caller.
@@ -144,8 +146,7 @@ test('admin can override a teammate and save via the per-user endpoint', async (
   await expect(page.getByText(/Admin override/)).toBeVisible()
   await expect(page.getByText('Saved to this group only')).toBeVisible()
 
-  // Make a pick for Bob and save it. The default "Needs pick" view drops the
-  // game from the list once picked, so the save flows through the sticky bar.
+  // Make a pick for Bob and save it through the sticky bar.
   await page.getByTestId('match-card-101').getByRole('button', { name: 'MEX' }).click()
   const save = page.getByRole('button', { name: "Save Bob's Picks" })
   await expect(save).toBeEnabled()
@@ -186,11 +187,12 @@ test('non-admin viewing a teammate is strictly read-only — no submit affordanc
 
   await page.goto('/group-details?group=wc-group')
   await page.getByRole('tab', { name: 'Picks' }).click()
-  await expect(page.getByTestId('match-card-101')).toBeVisible()
 
-  // Switch to "All" so Bob's already-picked game stays in the list — the default
-  // "Needs pick" view hides picked games.
+  // Switch to "All" so the future-dated seed (and, after the person switch,
+  // Bob's already-picked game) stays in the list — the default "Today" view
+  // hides it by date and "Needs pick" would hide it once picked.
   await page.getByRole('button', { name: 'All' }).click()
+  await expect(page.getByTestId('match-card-101')).toBeVisible()
 
   // Switch to Bob — read-only banner, no submit button anywhere.
   await page.getByRole('button', { name: 'Choose whose picks to view or edit' }).click()

--- a/frontend/tests/e2e/world-cup-picks-renders.spec.ts
+++ b/frontend/tests/e2e/world-cup-picks-renders.spec.ts
@@ -105,8 +105,10 @@ test('world cup picks page renders the stage match list with pick buttons', asyn
   await page.goto('/world-cup?group=test-group')
 
   // The page owns the single "World Cup 2026 Picks" <h1>. The flat browse list
-  // defaults to the "Needs pick" view; both unpicked future games appear there.
+  // defaults to the "Today" view; the seeded games are future-dated, so switch
+  // to "All" to surface both regardless of date.
   await expect(page.getByRole('heading', { name: 'World Cup 2026 Picks' })).toBeVisible()
+  await page.getByRole('button', { name: 'All' }).click()
   await expect(page.getByTestId('match-card-101')).toBeVisible()
 
   // MatchListCard surfaces the three outcomes as buttons labeled by team
@@ -241,6 +243,9 @@ test('makes world cup picks inline on the group detail Picks tab', async ({ page
   // Entering the Picks tab renders the flat match list inline — we stay on
   // /group-details, no separate page.
   await page.getByRole('tab', { name: 'Picks' }).click()
+  // The list defaults to the "Today" view; the seeded match is future-dated, so
+  // switch to "All" to surface it.
+  await page.getByRole('button', { name: 'All' }).click()
   const card = page.getByTestId('match-card-101')
   await expect(card).toBeVisible()
   await expect(card.getByRole('button', { name: 'MEX' })).toBeVisible()
@@ -254,9 +259,8 @@ test('makes world cup picks inline on the group detail Picks tab', async ({ page
   await expect(submit).toBeDisabled()
   await expect(page.getByText('0 picks selected')).toBeVisible()
 
-  // Make a pick and submit it straight from the tab. The default "Needs pick"
-  // view drops the game from the list the instant it's picked, so we drive the
-  // rest of the flow through the sticky save bar (which stays mounted).
+  // Make a pick and submit it straight from the tab via the sticky save bar
+  // (which stays mounted regardless of which view filters the list).
   await card.getByRole('button', { name: 'MEX' }).click()
   await expect(page.getByText('1 pick selected')).toBeVisible()
   await expect(submit).toBeEnabled()


### PR DESCRIPTION
Four quick post-P1 fixes to the World Cup picks browse list, reported from prod. **Frontend-only — no backend or schema change.**

## Fixes
1. **Default view is now "Today"** — the list opens on the Today chip instead of "Needs pick".
2. **Chip scrollbar hidden** — the horizontal scrollbar that overlapped the filter chips on overflow is gone (`scrollbar-width: none` + webkit rule), scrolling still works.
3. **Chips go edge to edge** — the chip strip is now full-bleed: negative margins cancel the host page's `px-sm`/`sm:px-lg` gutters so it runs to the screen edges instead of being inset.
4. **Knockout Draw is disabled** — *root cause:* the `/stage/:stage` route never emits the `isKnockout` flag the `WorldCupMatch` type assumes, so it arrived `undefined` and left Draw clickable on knockout games with assigned teams. Fixed **on the frontend** by deriving `isKnockout` from the stage in `worldCupBrowseAdapter` (`stage !== 'group'` — every non-group stage is single-elimination), so it no longer depends on a flag the backend doesn't send. No backend deploy needed.

## Tests
- `worldCupBrowseAdapter.test.ts`: asserts `isKnockout` is derived from the stage, including the regression where `m.isKnockout` is `false`/absent.
- New `WorldCupGamesList.test.tsx`: locks the "Today" default (only today's games listed).
- WC unit/integration/e2e fixtures re-dated to **today** (end of local day — visible under the default view yet still pre-kickoff/pickable); e2e flows click **All** before asserting future-dated cards.

Local: tsc clean · 641 vitest · build · 4 WC e2e — all green.

## Stacking note
This lands on `main` first. After it merges, PRs #124 (P2) and #125 (P3) will be rebased on top so they carry these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)