### PR TITLE
WC browse polish: bigger pick labels, shaded mobile leaderboard, search clear + no iOS zoom

### DIFF
--- a/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.tsx
+++ b/frontend/src/designsystem/components/TournamentLeaderboard/TournamentLeaderboard.tsx
@@ -1,5 +1,7 @@
 import Avatar from '../Avatar';
 import type { TournamentLeaderboardRow } from '../../../lib/types';
+import type { ResultShade } from '../../../lib/wcGamesView';
+import { SHADE_TINT } from '../WorldCupBrowse/resultShade';
 
 export interface TournamentLeaderboardProps {
   /**
@@ -23,11 +25,13 @@ type StatKey = 'wins_correct' | 'losses' | 'draws_correct' | 'draws_incorrect';
 // The four tiebreaker stats, in tiebreaker order. Shared between the desktop
 // table columns and the mobile stat-chip grid so the two layouts can never
 // drift out of sync. `key` indexes the row; `label` is the human-facing header.
-const STAT_COLUMNS: { key: StatKey; label: string; short: string }[] = [
-  { key: 'wins_correct', label: 'Wins Correct', short: 'Wins' },
-  { key: 'losses', label: 'Losses', short: 'Losses' },
-  { key: 'draws_correct', label: 'Draws Correct', short: 'D ✓' },
-  { key: 'draws_incorrect', label: 'Draws Incorrect', short: 'D ✗' },
+// `shade` maps each stat onto the picks-view result palette (win/draw/partial/
+// loss) so the mobile chips read with the same colour coding as a scored game.
+const STAT_COLUMNS: { key: StatKey; label: string; short: string; shade: ResultShade }[] = [
+  { key: 'wins_correct', label: 'Wins Correct', short: 'Wins', shade: 'win' },
+  { key: 'losses', label: 'Losses', short: 'Losses', shade: 'loss' },
+  { key: 'draws_correct', label: 'Draws Correct', short: 'D ✓', shade: 'draw' },
+  { key: 'draws_incorrect', label: 'Draws Incorrect', short: 'D ✗', shade: 'partial' },
 ];
 
 const EMPTY_STATE = 'No standings yet — picks will appear here once the tournament begins.';
@@ -84,7 +88,8 @@ export default function TournamentLeaderboard({ rows }: TournamentLeaderboardPro
               {STAT_COLUMNS.map((col) => (
                 <div
                   key={col.key}
-                  className="rounded-base bg-secondary-50 dark:bg-secondary-800 px-xs py-xs text-center"
+                  style={SHADE_TINT[col.shade]}
+                  className="rounded-base border px-xs py-xs text-center"
                 >
                   <div className="text-[10px] font-semibold uppercase tracking-wide text-secondary-500 dark:text-secondary-400">
                     {col.short}

--- a/frontend/src/designsystem/components/WorldCupBrowse/ChoiceButton.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/ChoiceButton.tsx
@@ -31,13 +31,13 @@ export default function ChoiceButton({ team, odds, record, selected, onClick, di
       onClick={onClick}
       aria-pressed={selected}
       disabled={disabled}
-      className={`flex flex-1 flex-col items-center gap-xxs rounded-md py-sm text-center transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+      className={`flex flex-1 flex-col items-center gap-xxs rounded-md px-sm py-sm text-center transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
         selected ? 'bg-accent text-accent-fg' : 'border border-border bg-neutral-0 hover:bg-secondary-50 dark:bg-secondary-900'
       }`}
     >
-      <span className="flex h-6 items-center justify-center gap-xs">
-        {team && <img src={team.logo} alt="" className="h-icon-sm w-icon-sm object-contain" />}
-        <span className={`text-base font-extrabold ${selected ? '' : 'text-content'}`}>{label}</span>
+      <span className="flex h-7 w-full items-center justify-center gap-sm">
+        {team && <img src={team.logo} alt="" className="h-icon-md w-icon-md object-contain" />}
+        <span className={`text-lg font-extrabold ${selected ? '' : 'text-content'}`}>{label}</span>
       </span>
       {odds && <span className={`text-xs font-bold tabular-nums ${oddsClass(odds, selected)}`}>{odds}</span>}
       {record && (

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import WorldCupGamesList from './WorldCupGamesList';
 import type { BrowseGame, BrowseTeam } from '../../../lib/wcGamesView';
@@ -29,5 +29,24 @@ describe('WorldCupGamesList', () => {
     expect(screen.getByTestId('match-card-1')).toBeInTheDocument();
     // Tomorrow's game is filtered out by the default Today view.
     expect(screen.queryByTestId('match-card-2')).toBeNull();
+  });
+
+  it('clears the search via the clear button, restoring the unfiltered list', () => {
+    const mex = game({ id: 1, home: team('MEX', 'Mexico'), away: team('CAN', 'Canada') });
+    const bra = game({ id: 2, home: team('BRA', 'Brazil'), away: team('ARG', 'Argentina') });
+    render(<WorldCupGamesList games={[mex, bra]} now={NOW} onPick={() => {}} />);
+
+    // No clear button until there's a query.
+    expect(screen.queryByRole('button', { name: 'Clear search' })).toBeNull();
+
+    const search = screen.getByPlaceholderText('Search teams…');
+    fireEvent.change(search, { target: { value: 'BRA' } });
+    expect(screen.getByTestId('match-card-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('match-card-1')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+    expect(search).toHaveValue('');
+    expect(screen.getByTestId('match-card-1')).toBeInTheDocument();
+    expect(screen.getByTestId('match-card-2')).toBeInTheDocument();
   });
 });

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
@@ -135,12 +135,27 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
 
       {/* search + filters toggle + sort */}
       <div className="mb-sm flex gap-xs">
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search teams…"
-          className="flex-1 rounded-md border border-border bg-neutral-0 px-sm py-xxs text-sm text-content placeholder:text-content-subtle dark:bg-secondary-900"
-        />
+        <div className="relative flex-1">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search teams…"
+            // text-base (16px) keeps mobile Safari from auto-zooming on focus —
+            // it zooms any input under 16px and never zooms back out on blur.
+            // pr-lg leaves room for the clear button.
+            className="w-full rounded-md border border-border bg-neutral-0 px-sm py-xxs pr-lg text-base text-content placeholder:text-content-subtle dark:bg-secondary-900"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => setQuery('')}
+              aria-label="Clear search"
+              className="absolute inset-y-0 right-0 flex items-center px-sm text-content-subtle hover:text-content"
+            >
+              ✕
+            </button>
+          )}
+        </div>
         <button
           type="button"
           onClick={() => setShowFilters((s) => !s)}


### PR DESCRIPTION
Four small UI fixes on the World Cup browse surface, reported from prod. **Frontend-only — no backend or schema change.**

1. **Bigger pick labels** — the team flag (16→20px) and abbreviation (`text-base`→`text-lg`) are larger, with side padding so the flag + code fill more of each button.
2. **Shaded mobile leaderboard chips** — each stat chip now uses the same result palette as the picks view, reusing `SHADE_TINT`:
   - Wins → win (green) · Losses → loss (red) · Draws ✓ → draw (amber) · Draws ✗ → partial (orange)
   - **Desktop table left unchanged**, as requested.
3. **Search clear button** — a `✕` "Clear search" button resets the field to empty (only shown when there's a query).
4. **No stuck zoom on the search field** — the input is now 16px (`text-base`), which stops mobile Safari from auto-zooming on focus. (iOS zooms any input under 16px and never zooms back out on blur — that was the "doesn't revert" behavior.) If you'd prefer a *deliberate* animated focus-zoom instead, say so and I'll add a controlled one.

## Tests
- `WorldCupGamesList.test.tsx`: new case for the clear button — type a query (list filters), click clear (full list restored, field empty).
- Leaderboard + ChoiceButton changes are visual; existing suites pass.

Local: tsc clean · 652 vitest · build · 4 WC e2e — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)