### PR TITLE
Fix "needs pick" filter showing undecided knockout games

### DIFF
--- a/backend/src/models/Game.js
+++ b/backend/src/models/Game.js
@@ -156,6 +156,10 @@ static fromESPNData(espnGame, opts = {}) {
   altColor: homeTeam.team.alternateColor,
   record: homeTeam.records?.find(r => r.type === 'total')?.summary ?? null,
   form: homeTeam.form ?? null,
+  // ESPN flags undecided knockout slots (e.g. "Winner Group A") with
+  // isActive:false; carry it so the client can tell a real team from a
+  // bracket placeholder. Default true when ESPN omits it (group/decided games).
+  isActive: homeTeam.team.isActive ?? true,
     },
     awayTeam: {
   id: awayTeam.id,
@@ -166,6 +170,7 @@ static fromESPNData(espnGame, opts = {}) {
   altColor: awayTeam.team.alternateColor,
   record: awayTeam.records?.find(r => r.type === 'total')?.summary ?? null,
   form: awayTeam.form ?? null,
+  isActive: awayTeam.team.isActive ?? true,
     },
     gameDate: new Date(espnGame.date),
     status: normalized,

--- a/backend/tests/game-soccer.test.js
+++ b/backend/tests/game-soccer.test.js
@@ -84,6 +84,36 @@ describe('Game.fromESPNData soccer competitor parsing', () => {
   });
 });
 
+describe('Game.fromESPNData team.isActive (undecided knockout slots)', () => {
+  test('carries isActive through for both competitors', () => {
+    // Mock teams are real/active, so both slots should report isActive:true.
+    const [drawMatch] = generateMockWorldCupStage({ stage: 'group' });
+    const game = Game.fromESPNData(drawMatch, { league: 'world_cup', stage: 'group' });
+
+    assert.strictEqual(game.homeTeam.isActive, true);
+    assert.strictEqual(game.awayTeam.isActive, true);
+  });
+
+  test('preserves isActive:false for an undecided bracket placeholder', () => {
+    // ESPN seeds an undecided knockout slot ("Winner Group A") with isActive:false.
+    const [match] = generateMockWorldCupStage({ stage: 'knockout' });
+    match.competitions[0].competitors.find(c => c.homeAway === 'away').team.isActive = false;
+    const game = Game.fromESPNData(match, { league: 'world_cup', stage: 'r16' });
+
+    assert.strictEqual(game.homeTeam.isActive, true);
+    assert.strictEqual(game.awayTeam.isActive, false);
+  });
+
+  test('defaults to true when ESPN omits the flag', () => {
+    const [match] = generateMockWorldCupStage({ stage: 'group' });
+    for (const c of match.competitions[0].competitors) delete c.team.isActive;
+    const game = Game.fromESPNData(match, { league: 'world_cup', stage: 'group' });
+
+    assert.strictEqual(game.homeTeam.isActive, true);
+    assert.strictEqual(game.awayTeam.isActive, true);
+  });
+});
+
 describe('Game.toJSON surfaces league and stage', () => {
   test('includes league and stage for a soccer game', () => {
     const [drawMatch] = generateMockWorldCupStage({ stage: 'group' });

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
@@ -1,5 +1,5 @@
 import type { BrowseGame, MatchResult } from '../../../lib/wcGamesView';
-import { isLocked, outcomeOf, resultShade } from '../../../lib/wcGamesView';
+import { isLocked, outcomeOf, resultShade, teamsDecided } from '../../../lib/wcGamesView';
 import ChoiceButton from './ChoiceButton';
 import { SHADE_TINT } from './resultShade';
 
@@ -74,11 +74,12 @@ export default function MatchListCard({ game, now, onPick, onOpenDetail, disable
   const lead =
     game.status === 'IN_PROGRESS' ? 'LIVE' : game.status === 'FINAL' ? 'FINAL' : formatTime(game.kickoff);
 
-  // Knockout slots are scheduled with TBD placeholders before participants are
-  // known; no outcome is pickable until both teams are assigned. And a knockout
-  // can't end in a draw (PKs decide), so the Draw choice isn't offered at all
-  // there — only the two teams.
-  const teamsAssigned = game.home.abbr !== 'TBD' && game.away.abbr !== 'TBD';
+  // Knockout slots are scheduled with placeholders before participants are
+  // known; no outcome is pickable until both teams are decided. Shares the
+  // exact rule the "needs pick" filter uses so the card and the filter can't
+  // disagree. And a knockout can't end in a draw (PKs decide), so the Draw
+  // choice isn't offered at all there — only the two teams.
+  const teamsAssigned = teamsDecided(game);
 
   return (
     <div data-testid={`match-card-${game.id}`}>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,6 +46,12 @@ export interface TeamData {
   altColor?: string;
   record?: string;
   form?: string;
+  /**
+   * False when this slot is an undecided knockout placeholder (ESPN's
+   * "Winner Group A" etc.) rather than a real qualified team. Absent on older
+   * cached games and on group-stage teams, where it should be treated as true.
+   */
+  isActive?: boolean;
 }
 
 export interface GameData {

--- a/frontend/src/lib/wcGamesView.test.ts
+++ b/frontend/src/lib/wcGamesView.test.ts
@@ -35,6 +35,11 @@ describe('isLocked / needsPick', () => {
   it('a picked-but-open game no longer needs a pick', () => {
     expect(needsPick(game({ picked: 'home' }), NOW)).toBe(false);
   });
+  it('a knockout game with undecided (TBD) teams never needs a pick', () => {
+    // Open + unpicked, but a bracket slot is still TBD → unpickable.
+    expect(needsPick(game({ away: team('TBD', 'TBD') }), NOW)).toBe(false);
+    expect(needsPick(game({ home: team('TBD', 'TBD') }), NOW)).toBe(false);
+  });
 });
 
 describe('applyView', () => {
@@ -48,6 +53,13 @@ describe('applyView', () => {
 
   it('needs-pick = open + unpicked only', () => {
     expect(applyView(games, 'needs-pick', NOW).map((g) => g.id)).toEqual([1]);
+  });
+  it('needs-pick excludes undecided knockout games even when open + unpicked', () => {
+    const withTbd = [
+      ...games,
+      game({ id: 6, stage: 'r16', kickoff: '2026-06-12T20:00:00', away: team('TBD', 'TBD') }),
+    ];
+    expect(applyView(withTbd, 'needs-pick', NOW).map((g) => g.id)).toEqual([1]);
   });
   it('today = kickoff on NOW’s date', () => {
     expect(applyView(games, 'today', NOW).map((g) => g.id).sort()).toEqual([1, 2]);

--- a/frontend/src/lib/wcGamesView.test.ts
+++ b/frontend/src/lib/wcGamesView.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   applyFilters, applyView, buildSections, groupByDate, isLocked, matchesSearch,
   needsPick, NO_FILTERS, outcomeOf, pickVerdict, resultShade, sortGames,
+  teamDecided, teamsDecided,
   type BrowseGame, type BrowseTeam,
 } from './wcGamesView';
 
@@ -35,10 +36,35 @@ describe('isLocked / needsPick', () => {
   it('a picked-but-open game no longer needs a pick', () => {
     expect(needsPick(game({ picked: 'home' }), NOW)).toBe(false);
   });
-  it('a knockout game with undecided (TBD) teams never needs a pick', () => {
-    // Open + unpicked, but a bracket slot is still TBD → unpickable.
+  it('a knockout game with an undecided slot never needs a pick', () => {
+    // Open + unpicked, but a bracket slot isn't a real team yet → unpickable.
     expect(needsPick(game({ away: team('TBD', 'TBD') }), NOW)).toBe(false);
     expect(needsPick(game({ home: team('TBD', 'TBD') }), NOW)).toBe(false);
+    // ESPN's authoritative flag: a descriptive placeholder marked isActive:false.
+    expect(needsPick(game({ away: { ...team('WIN', 'Winner Group A'), isActive: false } }), NOW)).toBe(false);
+    // Fallback by name even when the flag is absent (legacy/cached rows).
+    expect(needsPick(game({ away: team('B1', 'Winner Group B') }), NOW)).toBe(false);
+  });
+});
+
+describe('teamDecided / teamsDecided', () => {
+  it('a real qualified team is decided', () => {
+    expect(teamDecided(team('USA', 'United States'))).toBe(true);
+    expect(teamDecided({ ...team('BRA', 'Brazil'), isActive: true })).toBe(true);
+  });
+  it('isActive:false is the authoritative undecided signal, regardless of name', () => {
+    expect(teamDecided({ ...team('USA', 'United States'), isActive: false })).toBe(false);
+  });
+  it('falls back to placeholder name/abbr when isActive is absent', () => {
+    expect(teamDecided(team('TBD', 'TBD'))).toBe(false);
+    expect(teamDecided(team('WIN', 'Winner Group A'))).toBe(false);
+    expect(teamDecided(team('RU', 'Runner-up Group C'))).toBe(false);
+    expect(teamDecided(team('L73', 'Loser Match 73'))).toBe(false);
+  });
+  it('a game is decided only when both slots are', () => {
+    expect(teamsDecided(game())).toBe(true);
+    expect(teamsDecided(game({ home: team('TBD', 'TBD') }))).toBe(false);
+    expect(teamsDecided(game({ away: { ...team('W', 'Winner Group D'), isActive: false } }))).toBe(false);
   });
 });
 

--- a/frontend/src/lib/wcGamesView.ts
+++ b/frontend/src/lib/wcGamesView.ts
@@ -52,9 +52,22 @@ export function isLocked(g: BrowseGame, now: Date): boolean {
   return new Date(g.kickoff).getTime() <= now.getTime();
 }
 
-/** Needs a pick = startable window still open and no pick recorded. */
+/**
+ * Both participants are known. Knockout slots are seeded with ESPN's "TBD"
+ * placeholder until the bracket decides them, and nothing is pickable until
+ * then — mirrors the `teamsAssigned` guard in MatchListCard.
+ */
+export function teamsDecided(g: BrowseGame): boolean {
+  return g.home.abbr !== 'TBD' && g.away.abbr !== 'TBD';
+}
+
+/**
+ * Needs a pick = startable window still open, no pick recorded, and both teams
+ * decided. The last guard matters in knockout rounds: a game whose participants
+ * are still TBD can't be picked, so it must not appear in the "needs pick" view.
+ */
 export function needsPick(g: BrowseGame, now: Date): boolean {
-  return !isLocked(g, now) && g.picked == null;
+  return !isLocked(g, now) && g.picked == null && teamsDecided(g);
 }
 
 function isSameDay(a: Date, b: Date): boolean {

--- a/frontend/src/lib/wcGamesView.ts
+++ b/frontend/src/lib/wcGamesView.ts
@@ -20,6 +20,12 @@ export interface BrowseTeam {
   moneyline?: string;
   /** Recent W/D/L form sequence, e.g. "WWDWL". Optional. */
   form?: string;
+  /**
+   * False when this slot is still an undecided knockout placeholder rather than
+   * a real qualified team. ESPN's authoritative signal (team.isActive). Absent
+   * on group-stage/decided teams and older cached games → treated as decided.
+   */
+  isActive?: boolean;
 }
 
 export interface BrowseGame {
@@ -53,12 +59,30 @@ export function isLocked(g: BrowseGame, now: Date): boolean {
 }
 
 /**
- * Both participants are known. Knockout slots are seeded with ESPN's "TBD"
- * placeholder until the bracket decides them, and nothing is pickable until
- * then — mirrors the `teamsAssigned` guard in MatchListCard.
+ * A knockout slot that hasn't been decided yet, by NAME, for cached/legacy games
+ * that predate the isActive flag. ESPN seeds such slots with descriptive
+ * placeholders — literal "TBD", or "Winner Group A" / "Runner-up Group B" /
+ * "Loser Match 101" — none of which is a real qualified team. Matched
+ * case-insensitively on the abbreviation and full name.
+ */
+const PLACEHOLDER_NAME = /^(tbd|winner|runner[- ]?up|loser|1st|2nd)\b/i;
+
+/** A single slot holds a real, qualified team (not a bracket placeholder). */
+export function teamDecided(t: BrowseTeam): boolean {
+  // ESPN's authoritative signal: placeholders are flagged isActive:false.
+  if (t.isActive === false) return false;
+  // Fallback for games stored before isActive was carried through: detect the
+  // placeholder by its abbreviation or name.
+  return !PLACEHOLDER_NAME.test(t.abbr) && !PLACEHOLDER_NAME.test(t.name);
+}
+
+/**
+ * Both participants are known. Knockout slots are seeded with placeholders until
+ * the bracket decides them, and nothing is pickable until then — mirrors the
+ * guard MatchListCard uses to disable the pick buttons.
  */
 export function teamsDecided(g: BrowseGame): boolean {
-  return g.home.abbr !== 'TBD' && g.away.abbr !== 'TBD';
+  return teamDecided(g.home) && teamDecided(g.away);
 }
 
 /**

--- a/frontend/src/lib/worldCupBrowseAdapter.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.ts
@@ -26,6 +26,7 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap): Browse
       record: m.homeTeam.record || undefined,
       moneyline: m.odds?.threeWay?.home || undefined,
       form: m.homeTeam.form || undefined,
+      isActive: m.homeTeam.isActive,
     },
     away: {
       abbr: m.awayTeam.abbreviation,
@@ -34,6 +35,7 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap): Browse
       record: m.awayTeam.record || undefined,
       moneyline: m.odds?.threeWay?.away || undefined,
       form: m.awayTeam.form || undefined,
+      isActive: m.awayTeam.isActive,
     },
     // `|| undefined` (not `??`) so an empty-string odds/record from ESPN also
     // collapses to absent — the card renders nothing rather than an empty line.

--- a/frontend/tests/e2e/world-cup-needs-pick-knockout.spec.ts
+++ b/frontend/tests/e2e/world-cup-needs-pick-knockout.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test'
+
+// Regression: the "needs pick" view must exclude knockout games whose
+// participants aren't decided yet. We seed TWO structurally identical r32 ties —
+// both future-dated, unpicked, single-elimination — differing ONLY in whether the
+// bracket has decided their teams:
+//   - game 301 (FRA vs ESP): two real, qualified teams           -> needs a pick
+//   - game 302 (POR vs "Winner Group A", isActive:false): a slot
+//     is still an undecided bracket placeholder                  -> must NOT need a pick
+// Before the fix, game 302 wrongly appeared in "Needs pick" even though its pick
+// buttons are disabled (you can't pick a team that isn't decided yet).
+//
+// '/world-cup-needs-pick' is named here purely so check-page-spec-coverage.mjs's
+// filename-derived substring match keeps registering this page's coverage.
+
+const inDays = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000).toISOString()
+const realTeam = (id: string, name: string, abbr: string) => ({ id, name, abbreviation: abbr, logo: '', isActive: true })
+// An undecided knockout slot, as real ESPN data shapes it: a descriptive
+// placeholder name flagged isActive:false (see WORLD_CUP_2026_API.md).
+const placeholder = (name: string, abbr: string) => ({ id: `tbd-${abbr}`, name, abbreviation: abbr, logo: '', isActive: false })
+
+const decidedGame = {
+  id: 301, stage: 'r32', isKnockout: true, status: 'SCHEDULED', homeScore: 0, awayScore: 0,
+  gameDate: inDays(3), winnerTeamId: null,
+  homeTeam: realTeam('478', 'France', 'FRA'), awayTeam: realTeam('164', 'Spain', 'ESP'),
+}
+const undecidedGame = {
+  id: 302, stage: 'r32', isKnockout: true, status: 'SCHEDULED', homeScore: 0, awayScore: 0,
+  gameDate: inDays(3), winnerTeamId: null,
+  homeTeam: realTeam('382', 'Portugal', 'POR'), awayTeam: placeholder('Winner Group A', 'WGA'),
+}
+
+async function seed(page: import('@playwright/test').Page) {
+  await page.goto('/login')
+  await page.evaluate(() => {
+    const payload = { userId: 1, email: 'ada@example.com', name: 'Ada Lovelace', pictureUrl: null, exp: 9999999999 }
+    localStorage.setItem('accessToken', `header.${btoa(JSON.stringify(payload))}.sig`)
+  })
+  // Catch-all so nothing escapes to a real backend; the stage stub wins (registered last).
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
+    const games = route.request().url().includes('/stage/r32') ? [decidedGame, undecidedGame] : []
+    await route.fulfill({ json: { games, count: games.length, cached: false } })
+  })
+  await page.goto('/world-cup?group=test-group')
+  await expect(page.getByRole('heading', { name: 'World Cup 2026 Picks' })).toBeVisible()
+}
+
+test('needs-pick excludes an undecided knockout game but keeps the decided one', async ({ page }) => {
+  await seed(page)
+  await page.getByRole('button', { name: 'Needs pick' }).click()
+
+  await expect(page.getByTestId('match-card-301')).toBeVisible()
+  await expect(page.getByTestId('match-card-302')).toHaveCount(0)
+})
+
+test('the undecided game still lists under "All", with its picks disabled', async ({ page }) => {
+  await seed(page)
+  await page.getByRole('button', { name: 'All', exact: true }).click()
+
+  await expect(page.getByTestId('match-card-301')).toBeVisible()
+  const undecided = page.getByTestId('match-card-302')
+  await expect(undecided).toBeVisible()
+  await expect(undecided.getByRole('button', { name: 'POR' })).toBeDisabled()
+  await expect(undecided.getByRole('button', { name: 'WGA' })).toBeDisabled()
+})


### PR DESCRIPTION
## Problem

The "needs pick" filter showed games that can't actually be picked. In a knockout round, the bracket slots are seeded with placeholders ("Winner Group A", etc.) until the participants are decided — those games are future-dated and unpicked, so they slipped into "needs pick" even though no pick is possible. The result: someone who had picked every group game still saw a non-empty "needs pick" list.

The rule should be: **a game belongs in "needs pick" if and only if both teams are decided.**

## Root cause

`needsPick()` only checked `!isLocked && picked == null`. It never checked whether the game's two slots hold real teams. The UI already disabled the pick buttons for undecided slots (`MatchListCard`), so the filter and the card disagreed.

The first cut gated on a literal `abbr !== 'TBD'` string. But per `WORLD_CUP_2026_API.md`, real ESPN data labels undecided slots with descriptive names like `"Winner Group A"` and flags them authoritatively with `team.isActive: false` — and that flag was being dropped at the backend boundary, so real placeholders would still slip through.

## Fix

- **`needsPick`** now also requires both teams decided.
- **`isActive` plumbed end to end**: `Game.fromESPNData` carries `team.isActive` (default `true`) → persists via `toJSON` → `TeamData`/`BrowseTeam` → browse adapter.
- **`teamDecided` / `teamsDecided`** treat `isActive === false` as the authoritative "undecided" signal, with a placeholder name/abbr regex (`TBD`, `Winner`, `Runner-up`, `Loser`, ...) as a fallback for cached rows predating the flag.
- **`MatchListCard`** now shares `teamsDecided`, so the card's disabled-buttons rule and the filter's rule are one piece of code and can't drift apart.

## Tests

- Backend `game-soccer.test.js`: added coverage for `isActive` true / false / omitted (23 pass).
- Frontend `wcGamesView.test.ts`: added `teamDecided`/`teamsDecided` + `needsPick` cases covering `isActive:false` and the `"Winner Group A"` name fallback. Full frontend suite (658) and `tsc --noEmit` clean.

https://claude.ai/code/session_013C8FR9bz333yPmVagBcA56

---
_Generated by [Claude Code](https://claude.ai/code/session_013C8FR9bz333yPmVagBcA56)_