### PR TITLE
Fix needs-pick: detect real ESPN knockout placeholders (2A, "Group C Winner", …)

### DIFF
--- a/frontend/src/lib/wcGamesView.test.ts
+++ b/frontend/src/lib/wcGamesView.test.ts
@@ -37,34 +37,41 @@ describe('isLocked / needsPick', () => {
     expect(needsPick(game({ picked: 'home' }), NOW)).toBe(false);
   });
   it('a knockout game with an undecided slot never needs a pick', () => {
-    // Open + unpicked, but a bracket slot isn't a real team yet → unpickable.
-    expect(needsPick(game({ away: team('TBD', 'TBD') }), NOW)).toBe(false);
-    expect(needsPick(game({ home: team('TBD', 'TBD') }), NOW)).toBe(false);
-    // ESPN's authoritative flag: a descriptive placeholder marked isActive:false.
-    expect(needsPick(game({ away: { ...team('WIN', 'Winner Group A'), isActive: false } }), NOW)).toBe(false);
-    // Fallback by name even when the flag is absent (legacy/cached rows).
-    expect(needsPick(game({ away: team('B1', 'Winner Group B') }), NOW)).toBe(false);
+    // Real R32 placeholders (abbr/name as ESPN actually emits them) → unpickable.
+    expect(needsPick(game({ away: team('2A', 'Group A 2nd Place') }), NOW)).toBe(false);
+    expect(needsPick(game({ home: team('1C', 'Group C Winner') }), NOW)).toBe(false);
+    // ESPN's authoritative flag, when present.
+    expect(needsPick(game({ away: { ...team('WGA', 'Winner Group A'), isActive: false } }), NOW)).toBe(false);
   });
 });
 
 describe('teamDecided / teamsDecided', () => {
   it('a real qualified team is decided', () => {
     expect(teamDecided(team('USA', 'United States'))).toBe(true);
+    expect(teamDecided(team('FRA', 'France'))).toBe(true);
     expect(teamDecided({ ...team('BRA', 'Brazil'), isActive: true })).toBe(true);
   });
   it('isActive:false is the authoritative undecided signal, regardless of name', () => {
     expect(teamDecided({ ...team('USA', 'United States'), isActive: false })).toBe(false);
   });
-  it('falls back to placeholder name/abbr when isActive is absent', () => {
+  it('detects the real ESPN R32 placeholders by abbreviation and name', () => {
+    // Exact strings observed in live production data (see issue screenshot).
+    expect(teamDecided(team('2A', 'Group A 2nd Place'))).toBe(false);
+    expect(teamDecided(team('2B', 'Group B 2nd Place'))).toBe(false);
+    expect(teamDecided(team('1C', 'Group C Winner'))).toBe(false);
+    expect(teamDecided(team('2F', 'Group F 2nd Place'))).toBe(false);
+    expect(teamDecided(team('1E', 'Group E Winner'))).toBe(false);
+    expect(teamDecided(team('3RD', 'Third Place Group A/B/C/D/F'))).toBe(false);
+  });
+  it('also catches the older TBD / Winner-Group placeholder forms', () => {
     expect(teamDecided(team('TBD', 'TBD'))).toBe(false);
-    expect(teamDecided(team('WIN', 'Winner Group A'))).toBe(false);
-    expect(teamDecided(team('RU', 'Runner-up Group C'))).toBe(false);
-    expect(teamDecided(team('L73', 'Loser Match 73'))).toBe(false);
+    expect(teamDecided(team('WGA', 'Winner Group A'))).toBe(false);
+    expect(teamDecided(team('RUC', 'Runner-up Group C'))).toBe(false);
   });
   it('a game is decided only when both slots are', () => {
     expect(teamsDecided(game())).toBe(true);
-    expect(teamsDecided(game({ home: team('TBD', 'TBD') }))).toBe(false);
-    expect(teamsDecided(game({ away: { ...team('W', 'Winner Group D'), isActive: false } }))).toBe(false);
+    expect(teamsDecided(game({ home: team('2A', 'Group A 2nd Place') }))).toBe(false);
+    expect(teamsDecided(game({ away: { ...team('WGD', 'Winner Group D'), isActive: false } }))).toBe(false);
   });
 });
 
@@ -81,11 +88,12 @@ describe('applyView', () => {
     expect(applyView(games, 'needs-pick', NOW).map((g) => g.id)).toEqual([1]);
   });
   it('needs-pick excludes undecided knockout games even when open + unpicked', () => {
-    const withTbd = [
+    const withPlaceholder = [
       ...games,
-      game({ id: 6, stage: 'r16', kickoff: '2026-06-12T20:00:00', away: team('TBD', 'TBD') }),
+      game({ id: 6, stage: 'r32', kickoff: '2026-06-12T20:00:00',
+        home: team('2A', 'Group A 2nd Place'), away: team('1C', 'Group C Winner') }),
     ];
-    expect(applyView(withTbd, 'needs-pick', NOW).map((g) => g.id)).toEqual([1]);
+    expect(applyView(withPlaceholder, 'needs-pick', NOW).map((g) => g.id)).toEqual([1]);
   });
   it('today = kickoff on NOW’s date', () => {
     expect(applyView(games, 'today', NOW).map((g) => g.id).sort()).toEqual([1, 2]);

--- a/frontend/src/lib/wcGamesView.ts
+++ b/frontend/src/lib/wcGamesView.ts
@@ -59,21 +59,26 @@ export function isLocked(g: BrowseGame, now: Date): boolean {
 }
 
 /**
- * A knockout slot that hasn't been decided yet, by NAME, for cached/legacy games
- * that predate the isActive flag. ESPN seeds such slots with descriptive
- * placeholders — literal "TBD", or "Winner Group A" / "Runner-up Group B" /
- * "Loser Match 101" — none of which is a real qualified team. Matched
- * case-insensitively on the abbreviation and full name.
+ * Matches ESPN's knockout-slot placeholder NAMES — the qualification path shown
+ * before the bracket is decided, never a real nation. Observed in live R32 data:
+ * "Group A 2nd Place", "Group C Winner", "Third Place Group A/B/C/D/F", plus the
+ * older "TBD" / "Winner Group A" / "Runner-up …" forms. Matched anywhere in the
+ * string (not anchored) and case-insensitively; the slash also flags the
+ * multi-group third-place placeholder. No country name contains these tokens.
  */
-const PLACEHOLDER_NAME = /^(tbd|winner|runner[- ]?up|loser|1st|2nd)\b/i;
+const PLACEHOLDER_NAME = /\b(winner|runner-?up|loser|place|group|tbd)\b|\//i;
 
 /** A single slot holds a real, qualified team (not a bracket placeholder). */
 export function teamDecided(t: BrowseTeam): boolean {
-  // ESPN's authoritative signal: placeholders are flagged isActive:false.
+  // ESPN's authoritative signal when present: placeholders are flagged isActive:false.
   if (t.isActive === false) return false;
-  // Fallback for games stored before isActive was carried through: detect the
-  // placeholder by its abbreviation or name.
-  return !PLACEHOLDER_NAME.test(t.abbr) && !PLACEHOLDER_NAME.test(t.name);
+  // Real FIFA national-team abbreviations are alphabetic 3-letter codes (FRA,
+  // ESP, BRA). ESPN's knockout placeholders use digit-bearing codes instead
+  // (2A, 1C, 2F, 3RD), so any digit in the abbreviation marks an undecided slot.
+  // This is the workhorse for already-cached games that have no isActive flag.
+  if (/\d/.test(t.abbr)) return false;
+  // Belt-and-suspenders: also catch the placeholder by its qualification-path name.
+  return !PLACEHOLDER_NAME.test(t.name);
 }
 
 /**

--- a/frontend/tests/e2e/world-cup-needs-pick-knockout.spec.ts
+++ b/frontend/tests/e2e/world-cup-needs-pick-knockout.spec.ts
@@ -14,10 +14,12 @@ import { test, expect } from '@playwright/test'
 // filename-derived substring match keeps registering this page's coverage.
 
 const inDays = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000).toISOString()
-const realTeam = (id: string, name: string, abbr: string) => ({ id, name, abbreviation: abbr, logo: '', isActive: true })
-// An undecided knockout slot, as real ESPN data shapes it: a descriptive
-// placeholder name flagged isActive:false (see WORLD_CUP_2026_API.md).
-const placeholder = (name: string, abbr: string) => ({ id: `tbd-${abbr}`, name, abbreviation: abbr, logo: '', isActive: false })
+const realTeam = (id: string, name: string, abbr: string) => ({ id, name, abbreviation: abbr, logo: '' })
+// An undecided knockout slot exactly as live ESPN R32 data shapes it: a
+// qualification-path name ("Group A 2nd Place", "Group C Winner") and a
+// digit-bearing abbreviation ("2A", "1C"), with NO isActive flag — the real
+// cached-data case that the first fix missed.
+const placeholder = (name: string, abbr: string) => ({ id: `ph-${abbr}`, name, abbreviation: abbr, logo: '' })
 
 const decidedGame = {
   id: 301, stage: 'r32', isKnockout: true, status: 'SCHEDULED', homeScore: 0, awayScore: 0,
@@ -27,7 +29,7 @@ const decidedGame = {
 const undecidedGame = {
   id: 302, stage: 'r32', isKnockout: true, status: 'SCHEDULED', homeScore: 0, awayScore: 0,
   gameDate: inDays(3), winnerTeamId: null,
-  homeTeam: realTeam('382', 'Portugal', 'POR'), awayTeam: placeholder('Winner Group A', 'WGA'),
+  homeTeam: placeholder('Group A 2nd Place', '2A'), awayTeam: placeholder('Group C Winner', '1C'),
 }
 
 async function seed(page: import('@playwright/test').Page) {
@@ -61,6 +63,6 @@ test('the undecided game still lists under "All", with its picks disabled', asyn
   await expect(page.getByTestId('match-card-301')).toBeVisible()
   const undecided = page.getByTestId('match-card-302')
   await expect(undecided).toBeVisible()
-  await expect(undecided.getByRole('button', { name: 'POR' })).toBeDisabled()
-  await expect(undecided.getByRole('button', { name: 'WGA' })).toBeDisabled()
+  await expect(undecided.getByRole('button', { name: '2A' })).toBeDisabled()
+  await expect(undecided.getByRole('button', { name: '1C' })).toBeDisabled()
 })


### PR DESCRIPTION
## Follow-up to #128 — the first fix didn't catch real production data

After #128 deployed, the "needs pick" filter still showed every Round-of-32 game (see screenshot below). The first fix was built around *assumed* placeholder formats (`"TBD"` / `"Winner Group A"` with `isActive:false`), but **live ESPN R32 data is shaped completely differently**:

| Field | Real production value |
|---|---|
| Name | `"Group A 2nd Place"`, `"Group C Winner"`, `"Third Place Group A/B/C/D/F"` |
| Abbreviation | `"2A"`, `"1C"`, `"2F"`, `"3RD"` |

Two gaps caused the miss:
1. The name regex was **anchored** (`^(tbd|winner|...)`), so `"Group A 2nd Place"` (starts with "Group") never matched.
2. `isActive` is **absent on already-cached DB rows**, so that signal was undefined.

Net result: every placeholder read as a real, pickable team.

## Fix

Harden `teamDecided` to match reality:
- **Any digit in the abbreviation marks a placeholder** — real FIFA codes are alphabetic (`FRA`, `ESP`, `BRA`); placeholders are `2A` / `1C` / `3RD`. This is the workhorse for cached rows with no `isActive`.
- **Broaden the name match** (now unanchored): `winner | runner-up | loser | place | group | tbd`, plus a `/` for the multi-group third-place slot.
- Keep `isActive === false` as the authoritative signal for freshly-fetched data.

## Verification (against the real strings this time)

- Unit tests assert the **exact** abbreviations/names from the production screenshot resolve to `teamDecided === false`, while real teams (`FRA`/`France`) stay `true`.
- The e2e regression now seeds the real placeholder shapes (digit abbrevs, qualification names, **no `isActive`**) so it exercises the heuristic that runs against cached data.
- Reproduced the production R32 slate end-to-end: "Needs pick" chip drops to **0** / "All caught up 🎉", and the games still list under "All" with disabled pick buttons.
- Full frontend suite (659) green; `tsc --noEmit` clean.

https://claude.ai/code/session_013C8FR9bz333yPmVagBcA56

---
_Generated by [Claude Code](https://claude.ai/code/session_013C8FR9bz333yPmVagBcA56)_