### PR TITLE
Make picks filter controls sticky and re-anchor scroll on filter change

### DIFF
--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import WorldCupGamesList from './WorldCupGamesList';
 import type { BrowseGame, BrowseTeam } from '../../../lib/wcGamesView';
 
@@ -48,5 +48,61 @@ describe('WorldCupGamesList', () => {
     expect(search).toHaveValue('');
     expect(screen.getByTestId('match-card-1')).toBeInTheDocument();
     expect(screen.getByTestId('match-card-2')).toBeInTheDocument();
+  });
+
+  describe('sticky controls + scroll re-anchoring on filter change', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('keeps the search box and view chips in a sticky, pinned container', () => {
+      const today = game({ id: 1 });
+      const { container } = render(
+        <WorldCupGamesList games={[today]} now={NOW} onPick={() => {}} />,
+      );
+      // The search input and the view chips share one sticky, top-pinned wrapper
+      // so they stay visible as the match list scrolls beneath them.
+      const sticky = container.querySelector('.sticky');
+      expect(sticky).not.toBeNull();
+      expect(sticky?.className).toContain('top-0');
+      expect(sticky).toContainElement(screen.getByPlaceholderText('Search teams…'));
+      expect(sticky).toContainElement(screen.getByRole('button', { name: 'All' }));
+    });
+
+    it('re-anchors to the list when a filter changes after scrolling past it', () => {
+      const today = game({ id: 1 });
+      const tomorrow = game({
+        id: 2, kickoff: '2026-06-13T20:00:00',
+        home: team('BRA', 'Brazil'), away: team('ARG', 'Argentina'),
+      });
+      render(<WorldCupGamesList games={[today, tomorrow]} now={NOW} onPick={() => {}} />);
+
+      const region = screen.getByTestId('games-list-region');
+      // Simulate the list having scrolled up behind the sticky header.
+      vi.spyOn(region, 'getBoundingClientRect').mockReturnValue({ top: -400 } as DOMRect);
+      const scrollIntoView = vi.spyOn(region, 'scrollIntoView');
+
+      // Switch the view — content changes, and since we're scrolled past the
+      // list top, the scroll is re-anchored to the start of the new results.
+      fireEvent.click(screen.getByRole('button', { name: 'All' }));
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start' });
+    });
+
+    it('leaves the scroll alone when the list top is already on screen', () => {
+      const today = game({ id: 1 });
+      const tomorrow = game({
+        id: 2, kickoff: '2026-06-13T20:00:00',
+        home: team('BRA', 'Brazil'), away: team('ARG', 'Argentina'),
+      });
+      render(<WorldCupGamesList games={[today, tomorrow]} now={NOW} onPick={() => {}} />);
+
+      const region = screen.getByTestId('games-list-region');
+      // List top is still below the (zero-height in jsdom) sticky header.
+      vi.spyOn(region, 'getBoundingClientRect').mockReturnValue({ top: 120 } as DOMRect);
+      const scrollIntoView = vi.spyOn(region, 'scrollIntoView');
+
+      fireEvent.click(screen.getByRole('button', { name: 'All' }));
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
@@ -73,6 +73,12 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
   // Bumped on every open so a fast close/reopen can't let a stale fetch win.
   const fetchSeq = useRef(0);
 
+  // The sticky controls block (search + chips + filters) and the results region
+  // below it, measured so a filter change can re-anchor the scroll to content
+  // rather than stranding the viewport in empty space — see the effect below.
+  const headerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
   const selectedGame = useMemo(
     () => (selectedId == null ? null : games.find((g) => g.id === selectedId) ?? null),
     [games, selectedId],
@@ -125,6 +131,31 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
 
   const empty = sections.length === 0;
 
+  // Re-anchor the scroll on a filter change. The controls above are sticky, so a
+  // change made while scrolled deep into the list would otherwise leave the
+  // viewport stranded below the (possibly shorter) new results — staring at empty
+  // space instead of matches. When the start of the list has scrolled up behind
+  // the sticky controls, bring it back to just under them so the user lands on
+  // content. We deliberately do NOT jump to the very top of the page on every
+  // change: if the list start is still on screen, the scroll is left untouched.
+  const filterKey = `${view}|${query}|${filters.stage ?? ''}|${filters.status ?? ''}|${
+    filters.picked == null ? '' : filters.picked
+  }|${sort}`;
+  const prevFilterKey = useRef(filterKey);
+  useEffect(() => {
+    if (prevFilterKey.current === filterKey) return; // initial mount — nothing changed
+    prevFilterKey.current = filterKey;
+    const list = listRef.current;
+    if (!list) return;
+    const headerH = headerRef.current?.offsetHeight ?? 0;
+    // Only re-anchor when the list's top has scrolled up behind the sticky
+    // controls; if it's still in view, the current scroll is already reasonable.
+    if (list.getBoundingClientRect().top < headerH) {
+      list.style.scrollMarginTop = `${headerH}px`;
+      list.scrollIntoView({ block: 'start' });
+    }
+  }, [filterKey]);
+
   return (
     <div className="mx-auto w-full max-w-[520px]">
       {/* header */}
@@ -133,6 +164,16 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
         {needsPickCount > 0 && <span className="text-sm font-semibold text-accent">{needsPickCount} left to pick</span>}
       </div>
 
+      {/* Sticky controls — search + view chips + filters stay pinned to the top
+          of the viewport while the match list scrolls beneath them. The negative
+          margins bleed the backdrop out to the host page gutters so list rows
+          never show through the gap as they scroll under it; the matching px
+          re-pads the inner controls back to the column. z-10 keeps it above the
+          rows but below the detail panel (z-40). */}
+      <div
+        ref={headerRef}
+        className="sticky top-0 z-10 -mx-sm bg-neutral-0/95 px-sm pt-xs pb-xs backdrop-blur dark:bg-secondary-900/95 sm:-mx-lg sm:px-lg"
+      >
       {/* search + filters toggle + sort */}
       <div className="mb-sm flex gap-xs">
         <div className="relative flex-1">
@@ -221,8 +262,10 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
           </select>
         </div>
       )}
+      </div>
 
       {/* list */}
+      <div ref={listRef} data-testid="games-list-region">
       {empty ? (
         <div className="rounded-xl border border-dashed border-border py-2xl text-center text-content-subtle">
           {view === 'needs-pick' ? 'All caught up — every game here is picked or locked. 🎉' : 'No games match these filters.'}
@@ -243,6 +286,7 @@ export default function WorldCupGamesList({ games, now, onPick, disabled }: Worl
           ))}
         </div>
       )}
+      </div>
 
       {selectedGame && (
         <MatchDetailPanel

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -3,6 +3,13 @@ import '@testing-library/jest-dom'
 // jsdom has no matchMedia. Default every query to "not matching" so responsive
 // components (useMediaQuery) render their desktop/base layout in tests unless a
 // test explicitly overrides window.matchMedia to simulate a smaller viewport.
+// jsdom doesn't implement scrollIntoView. Provide a no-op so components that
+// re-anchor the scroll (e.g. the picks list on a filter change) don't throw,
+// and so tests can spy on it.
+if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = () => {};
+}
+
 if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
   window.matchMedia = (query: string): MediaQueryList =>
     ({

--- a/frontend/tests/e2e/world-cup-sticky-filters.spec.ts
+++ b/frontend/tests/e2e/world-cup-sticky-filters.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test'
+
+// The picks page (/world-cup) keeps its controls — the search box and the
+// view chips — pinned to the top of the viewport while the match list scrolls
+// beneath them, and re-anchors the scroll to the start of the results when a
+// filter changes (rather than stranding the viewport in empty space below a
+// now-shorter list). We seed a long group-stage slate so the page is taller
+// than the viewport and actually scrolls.
+
+const inDays = (n: number) => new Date(Date.now() + n * 24 * 60 * 60 * 1000).toISOString()
+const realTeam = (id: string, name: string, abbr: string) => ({ id, name, abbreviation: abbr, logo: '' })
+
+// 20 distinct group-stage ties, all scheduled in the future so they only show
+// under "All" (not the default "Today" view). One tie features Wales so a
+// search can narrow the list to a single result.
+const TEAMS: [string, string][] = [
+  ['Mexico', 'MEX'], ['Canada', 'CAN'], ['Brazil', 'BRA'], ['Argentina', 'ARG'],
+  ['France', 'FRA'], ['Spain', 'ESP'], ['Germany', 'GER'], ['Italy', 'ITA'],
+  ['England', 'ENG'], ['Portugal', 'POR'], ['Netherlands', 'NED'], ['Belgium', 'BEL'],
+  ['Croatia', 'CRO'], ['Uruguay', 'URU'], ['Japan', 'JPN'], ['Korea', 'KOR'],
+  ['Senegal', 'SEN'], ['Morocco', 'MAR'], ['Wales', 'WAL'], ['Ghana', 'GHA'],
+]
+
+const games = Array.from({ length: 10 }, (_, i) => {
+  const [hn, ha] = TEAMS[i * 2]
+  const [an, aa] = TEAMS[i * 2 + 1]
+  return {
+    id: 500 + i, stage: 'group', isKnockout: false, status: 'SCHEDULED',
+    homeScore: 0, awayScore: 0, gameDate: inDays(2 + i), winnerTeamId: null,
+    homeTeam: realTeam(`h${i}`, hn, ha), awayTeam: realTeam(`a${i}`, an, aa),
+  }
+})
+
+// Wales plays in game 509 (TEAMS[18]).
+const WALES_CARD = 'match-card-509'
+
+async function seed(page: import('@playwright/test').Page) {
+  await page.goto('/login')
+  await page.evaluate(() => {
+    const payload = { userId: 1, email: 'ada@example.com', name: 'Ada Lovelace', pictureUrl: null, exp: 9999999999 }
+    localStorage.setItem('accessToken', `header.${btoa(JSON.stringify(payload))}.sig`)
+  })
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
+    const list = route.request().url().includes('/stage/group') ? games : []
+    await route.fulfill({ json: { games: list, count: list.length, cached: false } })
+  })
+  await page.goto('/world-cup?group=test-group')
+  await expect(page.getByRole('heading', { name: 'World Cup 2026 Picks' })).toBeVisible()
+  // Show every game regardless of date so the list is long enough to scroll.
+  await page.getByRole('button', { name: 'All' }).click()
+  await expect(page.getByTestId('match-card-500')).toBeVisible()
+}
+
+test('the search box and view chips stay pinned to the top while the list scrolls', async ({ page }) => {
+  await seed(page)
+
+  const search = page.getByPlaceholder('Search teams…')
+  await expect(search).toBeInViewport()
+
+  // Scroll deep into the list. The last card sits well below the fold.
+  await page.getByTestId('match-card-509').scrollIntoViewIfNeeded()
+  await page.mouse.wheel(0, 1200)
+
+  // The controls remain pinned: still in the viewport, and near its top edge.
+  await expect(search).toBeInViewport()
+  await expect(page.getByRole('button', { name: 'All' })).toBeInViewport()
+  const box = await search.boundingBox()
+  expect(box!.y).toBeLessThan(160)
+})
+
+test('changing a filter while scrolled re-anchors the viewport onto the results', async ({ page }) => {
+  await seed(page)
+
+  // Scroll to the very bottom so the viewport is far past the start of the list.
+  await page.mouse.wheel(0, 6000)
+
+  // Narrow to a single match by searching a team near the end of the slate.
+  await page.getByPlaceholder('Search teams…').fill('Wales')
+
+  // With only one result, a naive scroll would leave the viewport stranded in
+  // the empty space below. The re-anchor brings the lone result back on screen.
+  const card = page.getByTestId(WALES_CARD)
+  await expect(card).toBeVisible()
+  await expect(card).toBeInViewport()
+})


### PR DESCRIPTION
The picks list controls (search box + view chips + filters row) now stick to
the top of the viewport while the match list scrolls beneath them, with a
backdrop that bleeds to the page gutters so rows never show through.

When a filter changes while scrolled deep into the list, re-anchor the scroll
to the start of the results instead of leaving the viewport stranded in the
empty space below a now-shorter list. If the list start is still on screen the
scroll is left untouched, so it never jumps to the top unnecessarily.

Adds unit coverage for the sticky container and the re-anchor behaviour, plus
an e2e spec that scrolls the page and verifies the controls stay pinned and a
filter change brings results back into view. Stubs scrollIntoView in the test
setup for jsdom.