### PR TITLE
Make groups page search/filter bar sticky like World Cup picks

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,2 +1,4 @@
 .vercel
 coverage/
+test-results/
+playwright-report/

--- a/frontend/src/pages/GroupsPage.test.tsx
+++ b/frontend/src/pages/GroupsPage.test.tsx
@@ -182,6 +182,24 @@ describe('GroupsPage', () => {
     expect(screen.getByRole('button', { name: /join group/i })).toBeInTheDocument();
   });
 
+  it('pins the search/filter bar to the top in a sticky container', async () => {
+    mockGetMyGroups.mockResolvedValue([groupA, groupB]);
+
+    renderPage();
+    await screen.findByRole('heading', { name: groupA.name });
+
+    // The search/filter bar must live inside a sticky wrapper that pins it to
+    // the top of the viewport while the cards scroll beneath it — matching the
+    // World Cup picks page. Walk up from the search input to that wrapper.
+    const search = screen.getByPlaceholderText(/search groups/i);
+    const sticky = search.closest('.sticky');
+    expect(sticky).not.toBeNull();
+    expect(sticky).toHaveClass('top-0');
+    // It backs the bar with an opaque, blurred backdrop so cards never show
+    // through the gap as they pass under it.
+    expect(sticky).toHaveClass('backdrop-blur');
+  });
+
   it('shows a loading indicator before getMyGroups resolves', async () => {
     // A never-resolving promise keeps the page in its loading state.
     mockGetMyGroups.mockReturnValue(new Promise<GroupData[]>(() => {}));

--- a/frontend/src/pages/GroupsPage.tsx
+++ b/frontend/src/pages/GroupsPage.tsx
@@ -143,7 +143,17 @@ export default function GroupsPage() {
              Create/Join actions are rendered by GroupsList directly below the
              bar, matching the layout: my groups → search → create → join. */
           <div className="space-y-lg">
-            <GroupsSearchFilter onChange={setFilters} />
+            {/* Sticky search + filter bar — pinned to the top of the viewport
+                while the groups list scrolls beneath it, mirroring the World Cup
+                picks page (see WorldCupGamesList). The negative margins bleed the
+                backdrop out to the page gutters (Layout's px-sm/sm:px-lg) so cards
+                never show through the gap as they scroll under it; the matching
+                px re-pads the bar back to the column. z-10 keeps it above the
+                cards; the filter popover (z-20, anchored inside the bar) still
+                layers above it. */}
+            <div className="sticky top-0 z-10 -mx-sm bg-neutral-0/95 px-sm py-xs backdrop-blur dark:bg-secondary-900/95 sm:-mx-lg sm:px-lg">
+              <GroupsSearchFilter onChange={setFilters} />
+            </div>
 
             {visibleGroups.length === 0 ? (
               <>

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,4 +1,7 @@
 {
-  "status": "passed",
-  "failedTests": []
+  "status": "failed",
+  "failedTests": [
+    "04f01da45f3b681779ea-525d8820f4fbd6c953b5",
+    "04f01da45f3b681779ea-b3cc9ddfce30f4073ab0"
+  ]
 }

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,7 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": [
-    "04f01da45f3b681779ea-525d8820f4fbd6c953b5",
-    "04f01da45f3b681779ea-b3cc9ddfce30f4073ab0"
-  ]
-}

--- a/frontend/tests/e2e/groups-sticky-filter.spec.ts
+++ b/frontend/tests/e2e/groups-sticky-filter.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+
+// The groups page (/groups) keeps its search + filter bar pinned to the top of
+// the viewport while the list of group cards scrolls beneath it — the same
+// sticky behavior the World Cup picks page uses (see
+// world-cup-sticky-filters.spec.ts). We seed a long list of groups so the page
+// is taller than the viewport and actually scrolls. The literal '/groups' below
+// is what check-page-spec-coverage.mjs scans for to confirm route coverage.
+
+// 24 groups, enough to push the page well past the fold. One is named "Wales
+// Watchers" so a search can narrow the list to a single result.
+const groups = Array.from({ length: 24 }, (_, i) => ({
+  id: `g${i}`,
+  name: i === 20 ? 'Wales Watchers' : `Group ${String(i).padStart(2, '0')}`,
+  identifier: `group-${i}`,
+  description: 'Weekly confidence picks',
+  memberCount: 4 + i,
+  isOwner: i % 2 === 0,
+  userRole: i % 2 === 0 ? 'admin' : 'member',
+  createdAt: '2026-01-15T00:00:00.000Z',
+  poolType: 'nfl_weekly',
+}))
+
+async function seed(page: import('@playwright/test').Page) {
+  await page.goto('/login')
+  await page.evaluate(() => {
+    const payload = { userId: 1, email: 'ada@example.com', name: 'Ada Lovelace', pictureUrl: null, exp: 9999999999 }
+    localStorage.setItem('accessToken', `header.${btoa(JSON.stringify(payload))}.sig`)
+  })
+  await page.route('**/api/groups/my-groups', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(groups) })
+  })
+  await page.goto('/groups')
+  await expect(page.getByRole('heading', { name: 'My Groups' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Group 00' })).toBeVisible()
+}
+
+test('the search and filter bar stays pinned to the top while the list scrolls', async ({ page }) => {
+  await seed(page)
+
+  const search = page.getByPlaceholder('Search groups…')
+  await expect(search).toBeInViewport()
+
+  // Scroll deep into the list — the last cards sit well below the fold.
+  await page.getByRole('heading', { name: 'Wales Watchers' }).scrollIntoViewIfNeeded()
+  await page.mouse.wheel(0, 1200)
+
+  // The bar remains pinned: still in the viewport, and near its top edge.
+  await expect(search).toBeInViewport()
+  await expect(page.getByRole('button', { name: /filters/i })).toBeInViewport()
+  const box = await search.boundingBox()
+  expect(box!.y).toBeLessThan(160)
+})
+
+test('the pinned search bar still filters the list while scrolled', async ({ page }) => {
+  await seed(page)
+
+  // Scroll to the bottom so the bar is doing the pinning work, then search from
+  // it — the bar is reachable because it is stuck to the top.
+  await page.mouse.wheel(0, 6000)
+  await page.getByPlaceholder('Search groups…').fill('Wales')
+
+  await expect(page.getByRole('heading', { name: 'Wales Watchers' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Group 00' })).toBeHidden()
+})


### PR DESCRIPTION
## Summary

The World Cup picks page pins its search + filter controls to the top of the viewport while the match list scrolls beneath them. The main **Groups** page bar was in normal flow and scrolled away. This makes the groups bar behave the same way.

## What changed

**`GroupsPage.tsx`** — Wrapped `<GroupsSearchFilter>` in the same sticky container used by `WorldCupGamesList`:

```
sticky top-0 z-10 -mx-sm bg-neutral-0/95 px-sm py-xs backdrop-blur dark:bg-secondary-900/95 sm:-mx-lg sm:px-lg
```

The negative margins bleed the blurred backdrop out to Layout's `px-sm`/`sm:px-lg` gutters so cards never show through the gap as they pass under it. `z-10` keeps it above the cards; the filter popover (`z-20`, anchored inside the bar) still layers above it. Both pages rely on the top nav not being fixed, so `top-0` pins to the viewport once the nav scrolls off.

## Test coverage

- **Unit (`GroupsPage.test.tsx`)** — asserts the search input lives inside a `.sticky` wrapper that also carries `top-0` and `backdrop-blur`.
- **E2E (`groups-sticky-filter.spec.ts`)** — mirrors `world-cup-sticky-filters.spec.ts`: seeds 24 groups so the page scrolls, confirms the bar stays in-viewport near the top edge after scrolling deep, and confirms the pinned bar still filters the list down to a single result while scrolled to the bottom.

## Verification (local)

- `npx tsc --noEmit` — clean
- Unit tests — 43 passed (GroupsPage + GroupsSearchFilter)
- `npm run verify:coverage` — OK, 13 pages covered

The Playwright e2e could not run locally (the sandbox network policy blocked the Chromium download) — relying on CI to exercise it.

https://claude.ai/code/session_01W3boFRzqH3cVRFMA2SesQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3boFRzqH3cVRFMA2SesQS)_