### PR TITLE
Show live match minute on World Cup card and detail view

### DIFF
--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.test.tsx
@@ -110,4 +110,48 @@ describe('MatchDetailPanel', () => {
     expect(screen.getByText('Possession')).toBeInTheDocument();
     expect(screen.getByText('Raúl Jiménez')).toBeInTheDocument();
   });
+
+  it('shows the live minute mark alongside LIVE for an in-progress game', () => {
+    const game = baseGame({
+      status: 'IN_PROGRESS',
+      kickoff: '2026-06-01T17:00:00Z', // in the past → locked
+      homeScore: 1,
+      awayScore: 0,
+      displayClock: "63'",
+      statusDetail: '2nd Half',
+      period: 2,
+    });
+    render(
+      <MatchDetailPanel
+        game={game}
+        detail={null}
+        loading={false}
+        now={new Date('2026-06-01T18:00:00Z')}
+        onPick={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('detail-status')).toHaveTextContent("LIVE · 63'");
+  });
+
+  it('shows plain FULL TIME (no clock) for a final game', () => {
+    const game = baseGame({
+      status: 'FINAL',
+      kickoff: '2026-06-01T17:00:00Z',
+      homeScore: 2,
+      awayScore: 0,
+      displayClock: "90'",
+    });
+    render(
+      <MatchDetailPanel
+        game={game}
+        detail={null}
+        loading={false}
+        now={new Date('2026-06-11T00:00:00Z')}
+        onPick={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('detail-status')).toHaveTextContent('FULL TIME');
+  });
 });

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchDetailPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { BrowseGame, MatchResult } from '../../../lib/wcGamesView';
-import { isLocked } from '../../../lib/wcGamesView';
+import { isLocked, liveClockLabel } from '../../../lib/wcGamesView';
 import type { EventDetail, MatchStat, PlayerMark, TeamLineup } from '../../../lib/wcMatchDetail';
 import MatchTimeline from '../MatchTimeline';
 import ChoiceButton from './ChoiceButton';
@@ -147,6 +147,8 @@ function MatchStats({ game, detail }: { game: BrowseGame; detail: EventDetail })
 export default function MatchDetailPanel({ game, detail, loading, now, onPick, onClose, disabled }: MatchDetailPanelProps) {
   const locked = isLocked(game, now);
   const live = game.status === 'IN_PROGRESS';
+  // Minute mark for a live match ("63'" / "HT"); null otherwise.
+  const clock = liveClockLabel(game);
   const kickoff = new Date(game.kickoff);
   const dateLabel = kickoff.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
   const timeLabel = kickoff.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
@@ -170,7 +172,9 @@ export default function MatchDetailPanel({ game, detail, loading, now, onPick, o
               {locked ? (
                 <>
                   <div className="text-2xl font-extrabold tabular-nums text-content">{game.homeScore} – {game.awayScore}</div>
-                  <div className={`text-xs font-bold ${live ? 'text-error-500' : 'text-content-subtle'}`}>{live ? 'LIVE' : 'FULL TIME'}</div>
+                  <div className={`text-xs font-bold ${live ? 'text-error-500' : 'text-content-subtle'}`} data-testid="detail-status">
+                    {live ? (clock ? `LIVE · ${clock}` : 'LIVE') : 'FULL TIME'}
+                  </div>
                 </>
               ) : (
                 <div className="text-xs font-bold uppercase tracking-wide text-content-subtle">Kickoff</div>

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.test.tsx
@@ -63,4 +63,34 @@ describe('MatchListCard', () => {
     render(<MatchListCard game={game()} now={NOW} onPick={noop} />);
     expect(screen.queryByRole('button', { name: /more/i })).toBeNull();
   });
+
+  it('shows the live minute mark next to the LIVE badge for an in-progress game', () => {
+    render(
+      <MatchListCard
+        game={game({ id: 77, status: 'IN_PROGRESS', displayClock: "63'", homeScore: 1, awayScore: 0 })}
+        now={NOW}
+        onPick={noop}
+      />,
+    );
+    expect(screen.getByText('LIVE')).toBeInTheDocument();
+    expect(screen.getByTestId('match-clock-77')).toHaveTextContent("63'");
+  });
+
+  it('collapses a halftime break to HT on the card', () => {
+    render(
+      <MatchListCard
+        game={game({ id: 78, status: 'IN_PROGRESS', displayClock: "45'", statusDetail: 'Halftime' })}
+        now={NOW}
+        onPick={noop}
+      />,
+    );
+    expect(screen.getByTestId('match-clock-78')).toHaveTextContent('HT');
+  });
+
+  it('renders no clock chip for a scheduled or final game', () => {
+    const { rerender } = render(<MatchListCard game={game({ id: 79 })} now={NOW} onPick={noop} />);
+    expect(screen.queryByTestId('match-clock-79')).toBeNull();
+    rerender(<MatchListCard game={game({ id: 79, status: 'FINAL', homeScore: 2, awayScore: 1 })} now={NOW} onPick={noop} />);
+    expect(screen.queryByTestId('match-clock-79')).toBeNull();
+  });
 });

--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
@@ -1,5 +1,5 @@
 import type { BrowseGame, MatchResult } from '../../../lib/wcGamesView';
-import { isLocked, outcomeOf, resultShade, teamsDecided } from '../../../lib/wcGamesView';
+import { isLocked, liveClockLabel, outcomeOf, resultShade, teamsDecided } from '../../../lib/wcGamesView';
 import ChoiceButton from './ChoiceButton';
 import { SHADE_TINT } from './resultShade';
 
@@ -73,6 +73,9 @@ export default function MatchListCard({ game, now, onPick, onOpenDetail, disable
   const locked = isLocked(game, now);
   const lead =
     game.status === 'IN_PROGRESS' ? 'LIVE' : game.status === 'FINAL' ? 'FINAL' : formatTime(game.kickoff);
+  // Minute mark for a live match ("63'" / "HT"); null otherwise. Shown next to
+  // the LIVE badge so the card hints at how far along the game is.
+  const clock = liveClockLabel(game);
 
   // Knockout slots are scheduled with placeholders before participants are
   // known; no outcome is pickable until both teams are decided. Shares the
@@ -89,6 +92,11 @@ export default function MatchListCard({ game, now, onPick, onOpenDetail, disable
           <span className={`font-bold uppercase tracking-wide ${game.status === 'IN_PROGRESS' ? 'text-error-500' : 'text-content-subtle'}`}>
             {lead}
           </span>
+          {clock && (
+            <span className="ml-xs font-bold tabular-nums text-error-500" data-testid={`match-clock-${game.id}`}>
+              {clock}
+            </span>
+          )}
           <span className="ml-xs font-semibold text-content-muted">
             {game.home.name} <span className="text-content-subtle">vs</span> {game.away.name}
           </span>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -169,6 +169,17 @@ export interface WorldCupMatch {
   isKnockout: boolean;
   gameDate?: string;
   winnerTeamId?: string | null;
+  /**
+   * Live match progress, parsed by the backend from ESPN's `status` block and
+   * persisted (display_clock / period / status_detail columns), so they survive
+   * the stage cache. `displayClock` is ESPN's minute mark for a soccer match in
+   * progress, e.g. "63'" or "90'+2'"; `statusDetail` carries the descriptive
+   * state, e.g. "Halftime" or "1st Half"; `period` is 1 = first half, 2 = second
+   * half, 3+ = extra time. All absent before kickoff.
+   */
+  displayClock?: string;
+  statusDetail?: string;
+  period?: number;
   /** Goal/card timeline once the match has started. Absent before kickoff. */
   events?: MatchEvent[];
   /** Pre-match odds from the odds JSONB column. */

--- a/frontend/src/lib/wcGamesView.test.ts
+++ b/frontend/src/lib/wcGamesView.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
-  applyFilters, applyView, buildSections, groupByDate, isLocked, matchesSearch,
-  needsPick, NO_FILTERS, outcomeOf, pickVerdict, resultShade, sortGames,
+  applyFilters, applyView, buildSections, groupByDate, isLocked, liveClockLabel,
+  matchesSearch, needsPick, NO_FILTERS, outcomeOf, pickVerdict, resultShade, sortGames,
   teamDecided, teamsDecided,
   type BrowseGame, type BrowseTeam,
 } from './wcGamesView';
@@ -19,6 +19,32 @@ function game(over: Partial<BrowseGame> = {}): BrowseGame {
     ...over,
   };
 }
+
+describe('liveClockLabel', () => {
+  it('returns null for a game that is not in progress', () => {
+    expect(liveClockLabel(game({ status: 'SCHEDULED', displayClock: "63'" }))).toBeNull();
+    expect(liveClockLabel(game({ status: 'FINAL', displayClock: "90'" }))).toBeNull();
+  });
+  it('returns the minute mark for a live game', () => {
+    expect(liveClockLabel(game({ status: 'IN_PROGRESS', displayClock: "63'" }))).toBe("63'");
+  });
+  it('passes ESPN stoppage-time clocks through verbatim (never re-derived)', () => {
+    expect(liveClockLabel(game({ status: 'IN_PROGRESS', displayClock: "90'+2'" }))).toBe("90'+2'");
+  });
+  it('collapses a halftime break to "HT" rather than showing a stale 45\'', () => {
+    expect(liveClockLabel(game({ status: 'IN_PROGRESS', displayClock: "45'", statusDetail: 'Halftime' }))).toBe('HT');
+  });
+  it('does NOT collapse an in-half detail like "1st Half" to HT', () => {
+    expect(liveClockLabel(game({ status: 'IN_PROGRESS', displayClock: "12'", statusDetail: '1st Half' }))).toBe("12'");
+  });
+  it('falls back to the descriptive detail when the clock is the pre-kickoff "0\'"', () => {
+    expect(liveClockLabel(game({ status: 'IN_PROGRESS', displayClock: "0'", statusDetail: '1st Half' }))).toBe('1st Half');
+  });
+  it('returns null for a live game with no clock or detail at all', () => {
+    expect(liveClockLabel(game({ status: 'IN_PROGRESS' }))).toBeNull();
+    expect(liveClockLabel(game({ status: 'IN_PROGRESS', displayClock: "0'" }))).toBeNull();
+  });
+});
 
 describe('isLocked / needsPick', () => {
   it('a scheduled match before kickoff is unlocked and needs a pick', () => {

--- a/frontend/src/lib/wcGamesView.ts
+++ b/frontend/src/lib/wcGamesView.ts
@@ -44,6 +44,16 @@ export interface BrowseGame {
   status: GameStatus;
   homeScore?: number;
   awayScore?: number;
+  /**
+   * Live match progress from ESPN's `status` block (see WorldCupMatch). Present
+   * once a match is in progress: `displayClock` is the minute mark ("63'"),
+   * `statusDetail` the descriptive state ("Halftime", "1st Half"), `period` the
+   * half (1/2, 3+ for extra time). Fed to liveClockLabel to show how far along
+   * a live match is.
+   */
+  displayClock?: string;
+  statusDetail?: string;
+  period?: number;
   /** The viewer's current pick, if any. */
   picked?: MatchResult;
   /** Knockout matches can't end in a draw (PKs decide) — disables the Draw pick. */
@@ -58,6 +68,38 @@ export interface BrowseGame {
 export function isLocked(g: BrowseGame, now: Date): boolean {
   if (g.status !== 'SCHEDULED') return true;
   return new Date(g.kickoff).getTime() <= now.getTime();
+}
+
+/**
+ * A short, human label for how far along a live match is — ESPN gives us the
+ * minute mark, not a real-time stream, so this is a progress snapshot, not a
+ * ticking clock. Returns null for any non-live game (the caller renders nothing).
+ *
+ * Precedence:
+ *   1. Halftime/break — ESPN freezes the clock and flags it in statusDetail
+ *      ("Halftime"); collapse to "HT" so we don't show a stale "45'".
+ *   2. The minute mark — displayClock, e.g. "63'" or "90'+2'" (stoppage time
+ *      already formatted by ESPN; never re-derived here). Skipped when it's the
+ *      pre-kickoff "0'" placeholder so a just-flipped-live match falls through.
+ *   3. The descriptive detail as a last resort, e.g. "1st Half".
+ *
+ * Pure and `Pick`-typed so the label logic is unit-tested in isolation from the
+ * card/panel that render it.
+ */
+export function liveClockLabel(
+  g: Pick<BrowseGame, 'status' | 'displayClock' | 'statusDetail'>,
+): string | null {
+  if (g.status !== 'IN_PROGRESS') return null;
+  const detail = (g.statusDetail ?? '').trim();
+  // "Halftime" → "HT". Anchored to the half[-/space]time word so a live-half
+  // detail like "1st Half" does NOT collapse to HT.
+  if (/half[\s-]?time/i.test(detail) || /\bHT\b/.test(detail)) return 'HT';
+  const clock = (g.displayClock ?? '').trim();
+  // ESPN seeds an in-progress status with a "0'" clock at the instant of
+  // kickoff before the minute ticks; treat it as "no minute yet" and fall back.
+  if (clock && clock !== "0'" && clock !== '0') return clock;
+  if (detail) return detail;
+  return null;
 }
 
 /**

--- a/frontend/src/lib/worldCupBrowseAdapter.test.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.test.ts
@@ -94,6 +94,21 @@ describe('toBrowseGames', () => {
     expect(g.events).toBeUndefined();
   });
 
+  it('carries live progress (displayClock / statusDetail / period) through', () => {
+    const m = match({ id: 57, status: 'IN_PROGRESS', displayClock: "63'", statusDetail: '2nd Half', period: 2 });
+    const [g] = toBrowseGames([m], {});
+    expect(g.displayClock).toBe("63'");
+    expect(g.statusDetail).toBe('2nd Half');
+    expect(g.period).toBe(2);
+  });
+
+  it('collapses an empty-string displayClock/statusDetail to undefined', () => {
+    const m = match({ id: 58, displayClock: '', statusDetail: '' });
+    const [g] = toBrowseGames([m], {});
+    expect(g.displayClock).toBeUndefined();
+    expect(g.statusDetail).toBeUndefined();
+  });
+
   it('populates wcGroup from the home team abbreviation for group-stage games', () => {
     // USA is in Group D
     const m = match({ stage: 'group', homeTeam: { id: '660', name: 'United States', abbreviation: 'USA', logo: '' } });

--- a/frontend/src/lib/worldCupBrowseAdapter.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.ts
@@ -45,6 +45,12 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap): Browse
     status: NORMALIZED[m.status] ?? 'SCHEDULED',
     homeScore: m.homeScore,
     awayScore: m.awayScore,
+    // Live progress (minute mark / half / descriptive state). `|| undefined` so
+    // an empty-string clock from a cached pre-kickoff row collapses to absent
+    // and liveClockLabel reads it as "no minute yet".
+    displayClock: m.displayClock || undefined,
+    statusDetail: m.statusDetail || undefined,
+    period: m.period,
     picked: draft[m.id],
     // Derive from the stage rather than trusting m.isKnockout: the stage route
     // doesn't actually emit that flag, so it arrives undefined and left the Draw

--- a/frontend/tests/e2e/world-cup-live-clock.spec.ts
+++ b/frontend/tests/e2e/world-cup-live-clock.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test'
+
+// A live World Cup match surfaces how far along it is — ESPN gives us the minute
+// mark (status.displayClock, e.g. "63'") parsed onto the game and persisted, so
+// the picks page can show it without streaming. This spec stubs one in-progress
+// group-stage match and asserts the minute mark appears both on the basic card
+// (next to the LIVE badge) and inside the detail panel (LIVE · 63').
+//
+// Route coverage: the live App route is '/world-cup' (App.tsx). The page is
+// WorldCupPicksPage.tsx, whose filename-derived route literal is '/world-cup-picks';
+// naming it here registers coverage for check-page-spec-coverage.mjs.
+test('world cup picks page shows the live minute mark on the card and in the detail panel /world-cup-picks', async ({
+  page,
+}) => {
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Catch-all safety net first (lowest precedence): any unstubbed API call
+  // resolves to an empty object so the test never reaches a real backend.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  // The detail panel deep-fetches /event/<espnId>. Mirror the backend's resilient
+  // contract — a sparse-but-valid { venue, stats, lineups } body — so the panel
+  // renders the game-side status (LIVE · 63') rather than crashing on a bare {}.
+  await page.route('**/api/games/world-cup-2026/event/**', (route) =>
+    route.fulfill({ json: { venue: null, stats: [], lineups: null } }),
+  )
+
+  // Stub the per-stage endpoint. Only the group stage returns the live match;
+  // every other stage returns an empty list so the match renders exactly once.
+  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
+    const isGroup = route.request().url().includes('/stage/group')
+    const games = isGroup
+      ? [
+          {
+            id: 301,
+            espnId: '760603',
+            stage: 'group',
+            isKnockout: false,
+            status: 'IN_PROGRESS',
+            homeScore: 1,
+            awayScore: 0,
+            // Kicked off ~70 minutes ago; the Live view filters purely on status.
+            gameDate: new Date(Date.now() - 70 * 60 * 1000).toISOString(),
+            winnerTeamId: null,
+            // ESPN live-match progress fields, parsed by the backend and persisted.
+            displayClock: "63'",
+            statusDetail: '2nd Half',
+            period: 2,
+            homeTeam: {
+              id: '1',
+              name: 'Argentina',
+              abbreviation: 'ARG',
+              logo: 'https://example.test/arg.png',
+            },
+            awayTeam: {
+              id: '2',
+              name: 'France',
+              abbreviation: 'FRA',
+              logo: 'https://example.test/fra.png',
+            },
+          },
+        ]
+      : []
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, count: games.length, cached: false }),
+    })
+  })
+
+  await page.goto('/world-cup?group=test-group')
+
+  await expect(page.getByRole('heading', { name: 'World Cup 2026 Picks' })).toBeVisible()
+
+  // The Live view filters to in-progress matches regardless of date.
+  await page.getByRole('button', { name: 'Live' }).click()
+
+  // Basic card: the LIVE badge plus the minute-mark chip carrying "63'".
+  const card = page.getByTestId('match-card-301')
+  await expect(card).toBeVisible()
+  await expect(card.getByText('LIVE')).toBeVisible()
+  await expect(card.getByTestId('match-clock-301')).toHaveText("63'")
+
+  // Detail panel: open it and confirm the status line reads "LIVE · 63'".
+  await card.getByRole('button', { name: /more/i }).click()
+  await expect(page.getByTestId('detail-status')).toHaveText("LIVE · 63'")
+})


### PR DESCRIPTION
## Summary

The ESPN feed does give us a sense of how far along a live game is — not a stream, but the **match minute**. Each match's `status` block carries `status.displayClock` (e.g. `"63'"`, `"90'+2'"`), `status.period` (1/2, 3+ for extra time), and `status.type.detail` (`"Halftime"`, `"1st Half"`). The backend already parses these into the `Game` model and **persists** `display_clock` / `period` / `status_detail`, so they survive the stage cache and reach the client via `toJSON()`. The data was there — it just wasn't surfaced.

This PR wires that existing data into both World Cup game views so a live match shows how far in it is.

## Changes

- **`types.ts` / `wcGamesView.ts`** — carry `displayClock`, `statusDetail`, `period` on `WorldCupMatch` and `BrowseGame`.
- **`wcGamesView.liveClockLabel()`** — pure, unit-tested helper that turns the status block into a short label:
  - the minute mark (`"63'"`, `"90'+2'"`) for a live half (ESPN's stoppage-time formatting passed through verbatim),
  - `"HT"` for a halftime break (so we don't show a stale `45'`),
  - the pre-kickoff `"0'"` placeholder falls back to the descriptive detail,
  - `null` for any non-live game.
- **`worldCupBrowseAdapter.ts`** — thread the three fields onto `BrowseGame`.
- **`MatchListCard`** (basic card) — render the minute-mark chip next to the `LIVE` badge.
- **`MatchDetailPanel`** (detail view) — show `LIVE · 63'` in the status line.

No backend changes were needed.

## Testing

- **Unit:** `liveClockLabel` (8 cases incl. halftime, stoppage time, pre-kickoff fallback), adapter field mapping, and both components (card chip + detail status line). Full suite: 686 passing.
- **E2E:** new `world-cup-live-clock.spec.ts` stubs a live group-stage match (`displayClock: "63'"`) and asserts the minute mark appears on the card and as `LIVE · 63'` in the detail panel. All 9 World Cup e2e specs pass.
- `tsc --noEmit` clean.

https://claude.ai/code/session_01QKSYAkkxeSrnd5uwJHzwJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKSYAkkxeSrnd5uwJHzwJB)_