### PR TITLE
Add unread chat indicator to group view

### DIFF
--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -145,6 +145,22 @@ CREATE TABLE IF NOT EXISTS group_messages (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Per-user chat read markers. One row per (group, user) recording the last time
+-- that user visited the group chat. The absence of a row is meaningful: it means
+-- the user has never read the chat, so every message reads as unread. This is the
+-- intended initial state for everyone — no backfill is required to "put everyone
+-- in the unread state". A message counts as unread for a user when it was authored
+-- by someone else and created after that user's last_read_at (or no marker exists).
+CREATE TABLE IF NOT EXISTS group_message_reads (
+  id SERIAL PRIMARY KEY,
+  group_id INTEGER REFERENCES groups(id) ON DELETE CASCADE,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  last_read_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(group_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_message_reads_group_user ON group_message_reads(group_id, user_id);
+
 -- User picks table (for confidence picks) now that groups exists
 CREATE TABLE IF NOT EXISTS user_picks (
   id SERIAL PRIMARY KEY,

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -308,11 +308,40 @@ export class Group {
     return result.rows[0];
   }
 
+  // Ensure the chat read-marker table exists. Production resilience: prod runs
+  // with INIT_DB unset, so schema.sql is NOT synced on deploy — mirror the
+  // GroupInvite.ensureLinkInviteSchema self-heal so this feature works on a plain
+  // deploy with no manual migration step. Cheap: a single catalog lookup that
+  // early-returns once the table is present.
+  static async ensureChatReadsSchema() {
+    try {
+      const check = await pool.query(
+        `SELECT 1 FROM information_schema.tables WHERE table_name = 'group_message_reads'`
+      );
+      if (check.rows.length > 0) return; // already present
+      console.log('[chat] Missing group_message_reads table – creating');
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS group_message_reads (
+          id SERIAL PRIMARY KEY,
+          group_id INTEGER REFERENCES groups(id) ON DELETE CASCADE,
+          user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+          last_read_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(group_id, user_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_group_message_reads_group_user ON group_message_reads(group_id, user_id);
+      `);
+      console.log('[chat] group_message_reads table created');
+    } catch (e) {
+      console.warn('[chat] Failed to ensure chat reads schema (may already exist):', e.message);
+    }
+  }
+
   // Whether the given user has unread chat messages in the group. A message is
   // unread when it was authored by someone else and is newer than the user's last
   // read marker. With no marker row (the default for everyone), every message from
   // another member reads as unread — the intended "nobody has read chat yet" state.
   static async getUnreadStatus(groupId, userId) {
+    await this.ensureChatReadsSchema();
     const query = `
       SELECT EXISTS (
         SELECT 1
@@ -331,6 +360,7 @@ export class Group {
   // Mark the group chat as read for the user (upsert the last_read_at marker to
   // now). Called when a member opens the chat tab so the unread indicator clears.
   static async markMessagesRead(groupId, userId) {
+    await this.ensureChatReadsSchema();
     const query = `
       INSERT INTO group_message_reads (group_id, user_id, last_read_at)
       VALUES ($1, $2, CURRENT_TIMESTAMP)

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -303,9 +303,43 @@ export class Group {
       VALUES ($1, $2, $3)
       RETURNING *
     `;
-    
+
     const result = await pool.query(query, [groupId, userId, message]);
     return result.rows[0];
+  }
+
+  // Whether the given user has unread chat messages in the group. A message is
+  // unread when it was authored by someone else and is newer than the user's last
+  // read marker. With no marker row (the default for everyone), every message from
+  // another member reads as unread — the intended "nobody has read chat yet" state.
+  static async getUnreadStatus(groupId, userId) {
+    const query = `
+      SELECT EXISTS (
+        SELECT 1
+        FROM group_messages gm
+        LEFT JOIN group_message_reads r
+          ON r.group_id = gm.group_id AND r.user_id = $2
+        WHERE gm.group_id = $1
+          AND gm.user_id <> $2
+          AND (r.last_read_at IS NULL OR gm.created_at > r.last_read_at)
+      ) AS has_unread
+    `;
+    const result = await pool.query(query, [groupId, userId]);
+    return result.rows[0].has_unread;
+  }
+
+  // Mark the group chat as read for the user (upsert the last_read_at marker to
+  // now). Called when a member opens the chat tab so the unread indicator clears.
+  static async markMessagesRead(groupId, userId) {
+    const query = `
+      INSERT INTO group_message_reads (group_id, user_id, last_read_at)
+      VALUES ($1, $2, CURRENT_TIMESTAMP)
+      ON CONFLICT (group_id, user_id)
+      DO UPDATE SET last_read_at = CURRENT_TIMESTAMP
+      RETURNING last_read_at
+    `;
+    const result = await pool.query(query, [groupId, userId]);
+    return result.rows[0].last_read_at;
   }
 
   // Update group

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -273,6 +273,51 @@ router.get('/:identifier/messages', authenticateToken, async (req, res) => {
   }
 });
 
+// Get unread chat status for the current user. Returns { hasUnread } so the
+// group view can show a red dot on the Chat tab when there are messages the
+// caller has not read yet.
+router.get('/:identifier/messages/unread', authenticateToken, async (req, res) => {
+  try {
+    const { identifier } = req.params;
+
+    const group = await Group.findByIdentifier(identifier, req.user.id);
+    if (!group) {
+      return res.status(404).json({ error: 'Group not found' });
+    }
+
+    if (!group.userRole) {
+      return res.status(403).json({ error: 'Must be a group member to view messages' });
+    }
+
+    const hasUnread = await Group.getUnreadStatus(group.id, req.user.id);
+    res.json({ hasUnread });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Mark the group chat as read for the current user. Called when the member opens
+// the Chat tab so the unread indicator clears.
+router.post('/:identifier/messages/read', authenticateToken, async (req, res) => {
+  try {
+    const { identifier } = req.params;
+
+    const group = await Group.findByIdentifier(identifier, req.user.id);
+    if (!group) {
+      return res.status(404).json({ error: 'Group not found' });
+    }
+
+    if (!group.userRole) {
+      return res.status(403).json({ error: 'Must be a group member to mark messages read' });
+    }
+
+    const lastReadAt = await Group.markMessagesRead(group.id, req.user.id);
+    res.json({ lastReadAt });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // Post message to group
 router.post('/:identifier/messages', authenticateToken, async (req, res) => {
   try {

--- a/backend/tests/group-messages-unread-route.test.js
+++ b/backend/tests/group-messages-unread-route.test.js
@@ -1,0 +1,129 @@
+import { test, describe, before, after, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import groupsRouter from '../src/routes/groups.js';
+import { AuthService } from '../src/services/AuthService.js';
+import { User } from '../src/models/User.js';
+import { Group } from '../src/models/Group.js';
+
+// Exercises the unread-chat endpoints on the groups router without a live
+// Postgres. Auth is faked by stubbing the same seam the real authenticateToken
+// middleware reads (AuthService.verifyAccessToken + User.findById); the Group
+// model methods are stubbed per test so only the route + membership gating is
+// under test.
+
+const AUTH_HEADER = { Authorization: 'Bearer test-token' };
+
+describe('group chat unread routes', () => {
+  let server;
+  let baseURL;
+
+  before(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/groups', groupsRouter);
+    await new Promise((resolve) => {
+      server = app.listen(0, () => {
+        baseURL = `http://localhost:${server.address().port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    mock.method(AuthService, 'verifyAccessToken', () => ({ userId: 1 }));
+    mock.method(User, 'findById', async () => ({ id: 1, name: 'Tester', email: 't@x.io' }));
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  describe('GET /:identifier/messages/unread', () => {
+    test('rejects an unauthenticated request', async () => {
+      const res = await fetch(`${baseURL}/api/groups/squad/messages/unread`);
+      assert.strictEqual(res.status, 401);
+    });
+
+    test('returns 404 for an unknown group', async () => {
+      mock.method(Group, 'findByIdentifier', async () => null);
+      const res = await fetch(`${baseURL}/api/groups/nope/messages/unread`, { headers: { ...AUTH_HEADER } });
+      assert.strictEqual(res.status, 404);
+    });
+
+    test('returns 403 when the caller is not a group member', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: null }));
+      const res = await fetch(`${baseURL}/api/groups/squad/messages/unread`, { headers: { ...AUTH_HEADER } });
+      assert.strictEqual(res.status, 403);
+    });
+
+    test('reports hasUnread true when the model finds unread messages', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member' }));
+      const unread = mock.method(Group, 'getUnreadStatus', async () => true);
+
+      const res = await fetch(`${baseURL}/api/groups/squad/messages/unread`, { headers: { ...AUTH_HEADER } });
+      assert.strictEqual(res.status, 200);
+      const data = await res.json();
+      assert.strictEqual(data.hasUnread, true);
+      // Computed for the resolved group id and the authenticated caller.
+      assert.deepStrictEqual(unread.mock.calls[0].arguments, [9, 1]);
+    });
+
+    test('reports hasUnread false when there is nothing new', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'admin' }));
+      mock.method(Group, 'getUnreadStatus', async () => false);
+
+      const res = await fetch(`${baseURL}/api/groups/squad/messages/unread`, { headers: { ...AUTH_HEADER } });
+      assert.strictEqual(res.status, 200);
+      const data = await res.json();
+      assert.strictEqual(data.hasUnread, false);
+    });
+  });
+
+  describe('POST /:identifier/messages/read', () => {
+    test('rejects an unauthenticated request', async () => {
+      const res = await fetch(`${baseURL}/api/groups/squad/messages/read`, { method: 'POST' });
+      assert.strictEqual(res.status, 401);
+    });
+
+    test('returns 404 for an unknown group', async () => {
+      mock.method(Group, 'findByIdentifier', async () => null);
+      const res = await fetch(`${baseURL}/api/groups/nope/messages/read`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADER },
+      });
+      assert.strictEqual(res.status, 404);
+    });
+
+    test('returns 403 when the caller is not a group member', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: null }));
+      const mark = mock.method(Group, 'markMessagesRead', async () => new Date().toISOString());
+      const res = await fetch(`${baseURL}/api/groups/squad/messages/read`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADER },
+      });
+      assert.strictEqual(res.status, 403);
+      assert.strictEqual(mark.mock.callCount(), 0, 'a non-member must not write a read marker');
+    });
+
+    test('marks the chat read for the caller and echoes the timestamp', async () => {
+      const lastReadAt = '2026-06-14T12:00:00.000Z';
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member' }));
+      const mark = mock.method(Group, 'markMessagesRead', async () => lastReadAt);
+
+      const res = await fetch(`${baseURL}/api/groups/squad/messages/read`, {
+        method: 'POST',
+        headers: { ...AUTH_HEADER },
+      });
+      assert.strictEqual(res.status, 200);
+      const data = await res.json();
+      assert.strictEqual(data.lastReadAt, lastReadAt);
+      // Read marker upserted for the resolved group id and authenticated caller.
+      assert.deepStrictEqual(mark.mock.calls[0].arguments, [9, 1]);
+    });
+  });
+});

--- a/frontend/src/lib/groupsService.d.ts
+++ b/frontend/src/lib/groupsService.d.ts
@@ -59,6 +59,10 @@ export function getMessages(
   opts?: { limit?: number; offset?: number },
 ): Promise<GroupMessage[]>;
 export function postMessage(identifier: string, message: string): Promise<GroupMessage>;
+// Whether the caller has unread chat messages in the group (drives the Chat tab's
+// red dot). markMessagesRead clears that state server-side when the chat is opened.
+export function getUnreadStatus(identifier: string): Promise<boolean>;
+export function markMessagesRead(identifier: string): Promise<void>;
 export function leaveGroup(identifier: string): Promise<void>;
 export function joinGroup(identifier: string): Promise<void>;
 export function updateGroup(

--- a/frontend/src/lib/groupsService.js
+++ b/frontend/src/lib/groupsService.js
@@ -120,6 +120,18 @@ export async function getMessages(identifier, { limit = 50, offset = 0 } = {}) {
   }));
 }
 
+export async function getUnreadStatus(identifier) {
+  const res = await authFetch(`${apiBase()}/${identifier}/messages/unread`);
+  if (!res.ok) throw new Error('Failed to load unread status');
+  const data = await res.json();
+  return Boolean(data.hasUnread);
+}
+
+export async function markMessagesRead(identifier) {
+  const res = await authFetch(`${apiBase()}/${identifier}/messages/read`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to mark messages read');
+}
+
 export async function postMessage(identifier, message) {
   const res = await authFetch(`${apiBase()}/${identifier}/messages`, {
     method: 'POST',

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -16,6 +16,8 @@ vi.mock('../lib/groupsService.js', () => ({
   getMembers: vi.fn(),
   getMessages: vi.fn(),
   getMyGroups: vi.fn(),
+  getUnreadStatus: vi.fn(),
+  markMessagesRead: vi.fn(),
 }));
 
 // PicksTab and LeaderboardTab own their own fetches (seasons -> closest week ->
@@ -62,7 +64,14 @@ vi.mock('react-router-dom', async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-import { getGroup, getMembers, getMessages, getMyGroups } from '../lib/groupsService.js';
+import {
+  getGroup,
+  getMembers,
+  getMessages,
+  getMyGroups,
+  getUnreadStatus,
+  markMessagesRead,
+} from '../lib/groupsService.js';
 import { getClosestWeek, getPickSeasons, getScoreboard } from '../lib/picksService.js';
 import {
   getWorldCupLeaderboard,
@@ -73,6 +82,8 @@ const mockGetGroup = vi.mocked(getGroup);
 const mockGetMembers = vi.mocked(getMembers);
 const mockGetMessages = vi.mocked(getMessages);
 const mockGetMyGroups = vi.mocked(getMyGroups);
+const mockGetUnreadStatus = vi.mocked(getUnreadStatus);
+const mockMarkMessagesRead = vi.mocked(markMessagesRead);
 const mockGetClosestWeek = vi.mocked(getClosestWeek);
 const mockGetPickSeasons = vi.mocked(getPickSeasons);
 const mockGetScoreboard = vi.mocked(getScoreboard);
@@ -140,6 +151,11 @@ describe('GroupDetailsPage', () => {
     // empty list defaults them to the (mocked) current season.
     mockGetPickSeasons.mockResolvedValue({ seasons: [] });
     mockGetScoreboard.mockResolvedValue({ season: 2025, seasonType: 2, weeks: [], users: [] });
+    // Chat unread state is resolved independently of the mount fetch. Default to
+    // "no unread" so the existing navigation/leaderboard tests see no dot; the
+    // unread-indicator suite overrides this per test.
+    mockGetUnreadStatus.mockResolvedValue(false);
+    mockMarkMessagesRead.mockResolvedValue(undefined);
   });
 
   it('renders the group name as the heading once the parallel fetch resolves', async () => {
@@ -387,6 +403,75 @@ describe('GroupDetailsPage', () => {
       fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
       expect(screen.queryByRole('button', { name: 'Submit Picks' })).not.toBeInTheDocument();
       expect(screen.queryByText('0 picks selected')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('unread chat indicator', () => {
+    beforeEach(() => {
+      mockGetGroup.mockResolvedValue(memberGroup);
+      mockGetMembers.mockResolvedValue(members);
+      mockGetMessages.mockResolvedValue(messages);
+    });
+
+    it('shows a red dot on the Chat tab when the group has unread messages', async () => {
+      mockGetUnreadStatus.mockResolvedValue(true);
+
+      renderPage();
+      await screen.findByRole('heading', { name: memberGroup.name });
+
+      // The indicator resolves asynchronously, independently of the mount fetch.
+      expect(await screen.findByTestId('chat-unread-indicator')).toBeInTheDocument();
+      expect(mockGetUnreadStatus).toHaveBeenCalledWith('sunday-squad');
+    });
+
+    it('shows no dot when there is nothing unread', async () => {
+      mockGetUnreadStatus.mockResolvedValue(false);
+
+      renderPage();
+      await screen.findByRole('heading', { name: memberGroup.name });
+      await waitFor(() => expect(mockGetUnreadStatus).toHaveBeenCalled());
+
+      expect(screen.queryByTestId('chat-unread-indicator')).not.toBeInTheDocument();
+    });
+
+    it('leaves the dot off when the unread fetch fails (non-fatal, page still renders)', async () => {
+      mockGetUnreadStatus.mockRejectedValue(new Error('backend down'));
+
+      renderPage();
+      // The page renders normally despite the unread fetch rejecting.
+      await screen.findByRole('heading', { name: memberGroup.name });
+      await waitFor(() => expect(mockGetUnreadStatus).toHaveBeenCalled());
+
+      expect(screen.queryByTestId('chat-unread-indicator')).not.toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: /Group Not Found/i })).not.toBeInTheDocument();
+    });
+
+    it('clears the dot and marks the chat read when the Chat tab is opened', async () => {
+      mockGetUnreadStatus.mockResolvedValue(true);
+
+      renderPage();
+      await screen.findByRole('heading', { name: memberGroup.name });
+      await screen.findByTestId('chat-unread-indicator');
+
+      fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
+
+      // Chat content renders, the dot disappears, and the read marker persists.
+      expect(screen.getByText('Welcome!')).toBeInTheDocument();
+      expect(screen.queryByTestId('chat-unread-indicator')).not.toBeInTheDocument();
+      expect(mockMarkMessagesRead).toHaveBeenCalledWith('sunday-squad');
+    });
+
+    it('does not mark the chat read when Chat is opened with nothing unread', async () => {
+      mockGetUnreadStatus.mockResolvedValue(false);
+
+      renderPage();
+      await screen.findByRole('heading', { name: memberGroup.name });
+      await waitFor(() => expect(mockGetUnreadStatus).toHaveBeenCalled());
+
+      fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
+
+      expect(screen.getByText('Welcome!')).toBeInTheDocument();
+      expect(mockMarkMessagesRead).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -227,7 +227,10 @@ export default function GroupDetailsPage() {
 
         {/* Tab Navigation */}
         <div className="border-b border-secondary-200 dark:border-secondary-700">
-          <div className="flex gap-lg overflow-x-auto" role="tablist" aria-label="Group sections">
+          {/* pt-1 gives the Chat tab's unread dot room: overflow-x-auto forces
+              overflow-y to clip at the row's top edge, which would otherwise
+              shave the top off the dot's negative offset. */}
+          <div className="flex gap-lg overflow-x-auto pt-1" role="tablist" aria-label="Group sections">
             {TABS.map((tab) => (
               <button
                 key={tab.key}

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { getGroup, getMembers, getMessages } from '../lib/groupsService.js';
+import { getGroup, getMembers, getMessages, getUnreadStatus, markMessagesRead } from '../lib/groupsService.js';
 import type { GroupDetail, GroupMember, GroupMessage } from '../lib/groupsService';
 import Button from '../designsystem/components/Button';
 import PageContainer from '../designsystem/components/PageContainer';
@@ -70,6 +70,10 @@ export default function GroupDetailsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabKey>('leaderboard');
+  // Drives the red dot on the Chat tab. Fetched independently of the mount fetch
+  // (a failure here must not collapse the whole page into the Not Found UI), and
+  // cleared the moment the user opens the chat.
+  const [hasUnreadChat, setHasUnreadChat] = useState(false);
 
   useEffect(() => {
     if (!identifier) return;
@@ -110,6 +114,25 @@ export default function GroupDetailsPage() {
     };
   }, [identifier]);
 
+  // Resolve the Chat tab's unread state separately from the mount fetch. Kept off
+  // the Promise.all so an older backend (or a transient failure) leaves the dot
+  // off rather than failing the whole page. Everyone starts unread by default,
+  // so a fresh group surfaces the dot until the chat is opened.
+  useEffect(() => {
+    if (!identifier) return;
+    let cancelled = false;
+    getUnreadStatus(identifier)
+      .then((unread) => {
+        if (!cancelled) setHasUnreadChat(unread);
+      })
+      .catch(() => {
+        /* non-fatal: leave the indicator off */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [identifier]);
+
   // No identifier in the query string: nothing to load, show the error UI early.
   if (!identifier) {
     return (
@@ -137,6 +160,17 @@ export default function GroupDetailsPage() {
         onBack={() => navigate('/groups')}
       />
     );
+  }
+
+  // Switch tabs; opening Chat clears the unread dot and marks the chat read
+  // server-side (fire-and-forget — the local clear is what the user sees, and a
+  // failed write just means the dot reappears on the next visit).
+  function handleSelectTab(key: TabKey) {
+    setActiveTab(key);
+    if (key === 'chat' && hasUnreadChat && identifier) {
+      setHasUnreadChat(false);
+      markMessagesRead(identifier).catch(() => {});
+    }
   }
 
   // getGroup returns userRole (NOT isOwner); admin is the owning role.
@@ -200,14 +234,21 @@ export default function GroupDetailsPage() {
                 type="button"
                 role="tab"
                 aria-selected={activeTab === tab.key}
-                onClick={() => setActiveTab(tab.key)}
-                className={`pb-sm px-xs text-sm font-medium border-b-2 transition-colors ${
+                onClick={() => handleSelectTab(tab.key)}
+                className={`relative pb-sm px-xs text-sm font-medium border-b-2 transition-colors ${
                   activeTab === tab.key
                     ? 'border-primary-500 text-primary-600 dark:text-primary-400'
                     : 'border-transparent text-secondary-600 dark:text-secondary-400 hover:text-secondary-900 dark:hover:text-secondary-100'
                 }`}
               >
                 {tab.label}
+                {tab.key === 'chat' && hasUnreadChat && (
+                  <span
+                    data-testid="chat-unread-indicator"
+                    aria-label="Unread messages"
+                    className="absolute -top-0.5 -right-1.5 h-2 w-2 rounded-full bg-error-500"
+                  />
+                )}
               </button>
             ))}
           </div>

--- a/frontend/tests/e2e/group-chat-unread-indicator.spec.ts
+++ b/frontend/tests/e2e/group-chat-unread-indicator.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test'
+
+// The group detail Chat tab shows a red unread dot when the group has chat
+// messages the current user has not read yet, and the dot clears the moment the
+// user opens the Chat tab (which also marks the chat read on the backend). We
+// seed a valid, far-future JWT-shaped accessToken (same pattern as the other
+// authed specs) and stub the group endpoints — including the new unread/read
+// endpoints — so the flow never reaches a real backend.
+test('chat tab shows an unread dot that clears when the chat is opened', async ({ page }) => {
+  // Visit the app first so localStorage is writable for this origin.
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Track whether the client marked the chat read so we can assert the side
+  // effect of opening the tab.
+  let markedRead = false
+
+  // Catch-all safety net first (lowest precedence): any unstubbed API call
+  // resolves to an empty object so the test can never reach a real backend.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  await page.route('**/api/groups/**', async (route) => {
+    const url = route.request().url()
+    // Order matters: the more specific message routes must be matched before the
+    // bare /messages list route ('/messages/unread' contains '/messages').
+    if (url.includes('/messages/unread')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ hasUnread: true }) })
+      return
+    }
+    if (url.includes('/messages/read')) {
+      markedRead = true
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ lastReadAt: '2026-06-14T12:00:00.000Z' }) })
+      return
+    }
+    if (url.includes('/messages')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 'msg1',
+            authorId: 'u2',
+            authorName: 'Grace Hopper',
+            authorPictureUrl: null,
+            content: 'Who do we like for the final?',
+            createdAt: '2026-06-09T18:00:00.000Z',
+          },
+        ]),
+      })
+      return
+    }
+    if (url.includes('/members')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        name: 'World Cup Squad',
+        identifier: 'wc-group',
+        memberCount: 2,
+        userRole: 'member',
+        pool_type: 'world_cup_2026',
+      }),
+    })
+  })
+
+  await page.goto('/group-details?group=wc-group')
+  await expect(page.getByRole('heading', { name: 'World Cup Squad' })).toBeVisible()
+
+  // The unread dot shows on the Chat tab before the user has opened the chat.
+  await expect(page.getByTestId('chat-unread-indicator')).toBeVisible()
+
+  // Opening the Chat tab clears the dot and marks the chat read on the backend.
+  await page.getByRole('tab', { name: 'Chat' }).click()
+  await expect(page.getByText('Who do we like for the final?')).toBeVisible()
+  await expect(page.getByTestId('chat-unread-indicator')).toHaveCount(0)
+  await expect.poll(() => markedRead).toBe(true)
+})


### PR DESCRIPTION
## What & why

When members open a group, there was no way to tell whether the Chat tab had new messages. This adds a simple **red dot on the top-right of the Chat tab** that shows when the current user has unread chat messages, and clears the moment they open the chat.

Per the request, everyone starts in the unread state with no backfill required — the absence of a read marker is treated as "never read", so any existing message reads as unread until the chat is opened.

## How it works

**Backend**
- New `group_message_reads` table: one row per `(group, user)` recording `last_read_at`. No row ⇒ everything is unread (the intended initial state for everyone). FK `ON DELETE CASCADE` cleans up with the group.
- `Group.getUnreadStatus(groupId, userId)` — a message is unread when it was authored by *someone else* and is newer than the user's marker (or no marker exists). So your own posts never light up your own dot.
- `Group.markMessagesRead(groupId, userId)` — upserts the marker to now.
- `GET /:identifier/messages/unread` → `{ hasUnread }` and `POST /:identifier/messages/read` → `{ lastReadAt }`, both member-gated (404 unknown group, 403 non-member).

**Frontend**
- `groupsService.getUnreadStatus` / `markMessagesRead`.
- `GroupDetailsPage` resolves unread state in a **separate, non-fatal effect** (kept off the mount `Promise.all` so a failure leaves the dot off rather than collapsing the page into the Not Found UI). The dot renders on the Chat tab; opening Chat clears it locally and persists the read marker fire-and-forget.

## Tests

- **Backend** (`group-messages-unread-route.test.js`): both endpoints — unauthenticated, unknown group, non-member, and success payloads, asserting the model is called with `(groupId, callerId)`.
- **Unit** (`GroupDetailsPage.test.tsx`): dot shows when unread, hidden when not, stays off (and page still renders) when the unread fetch fails, clears + marks read on opening Chat, and does *not* mark read when there's nothing unread.
- **E2E** (`group-chat-unread-indicator.spec.ts`): dot is visible before opening chat, disappears on open, and the read endpoint is hit.

Frontend unit (`vitest run --coverage`: 691 passed) and backend route tests pass locally. The new Playwright spec is discovered/validated via `--list`; the browser binary could not be downloaded in the sandbox (network policy), but it mirrors the existing passing chat e2e spec.

https://claude.ai/code/session_01REM2ACCweomdSCgwEjXX69

---
_Generated by [Claude Code](https://claude.ai/code/session_01REM2ACCweomdSCgwEjXX69)_