### PR TITLE
Fix mobile picks z-index so pick selector sits above filter bar

### DIFF
--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -500,9 +500,13 @@ export default function WorldCupPicksTab({
           end. It lives inside this component, so it appears when the picks
           surface mounts (e.g. entering the group's Picks tab) and disappears
           when it unmounts. The negative margins cancel the px-sm/sm:px-lg
-          gutters both host pages use, so the bar spans edge-to-edge. */}
+          gutters both host pages use, so the bar spans edge-to-edge. z-20
+          keeps it above the list's sticky search/filter controls (z-10) as the
+          two bars cross while scrolling, but below the match detail panel
+          (z-40) — so the filter bar reads as tethered to the content sliding
+          under it while this bar floats cleanly on top. */}
       {fetchState.matches.length > 0 && (
-        <div className="sticky bottom-0 -mx-sm sm:-mx-lg mt-lg border-t border-border bg-neutral-0/95 px-sm sm:px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
+        <div className="sticky bottom-0 z-20 -mx-sm sm:-mx-lg mt-lg border-t border-border bg-neutral-0/95 px-sm sm:px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
           <div className="mx-auto flex max-w-4xl flex-col gap-sm sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-col gap-xxs sm:flex-row sm:items-center sm:gap-md">
               <span className="text-sm text-content-muted">


### PR DESCRIPTION
## Problem

On the mobile layout of the World Cup picks panel, the two sticky bars stacked incorrectly when scrolled past one another:

- The **search + filter bar** (top, in `WorldCupGamesList.tsx`) is `sticky top-0 z-10`.
- The **bottom pick selector** (Save-to dropdown + Submit Picks, in `WorldCupPicksTab.tsx`) is `sticky bottom-0` but had **no z-index**, so it defaulted to `z-auto`.

Because the filter bar had an explicit `z-10` and the pick selector had none, the filter bar won the stacking contest. As the two bars crossed during scroll, the order from bottom to top was:

- main content
- bottom pick selector
- filter bar ← incorrectly on top

## Fix

Add `z-20` to the sticky pick selector bar so it stacks **above** the filter controls (`z-10`) but remains **below** the match detail panel (`z-40`).

Now the search/filter bar reads as tethered to the content sliding under it, while the pick selector floats cleanly on top — both still sticky to their respective edges.

This is a one-line CSS-class change (plus an explanatory comment documenting the stacking order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015DUXSBpPpU4VuASUoTimWN)_