### PR TITLE
Optimistically restore returning users from cached profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+Project notes for Claude Code. Append durable findings here so future
+investigations start with context instead of rediscovering it.
+
+## Stack
+
+- **Frontend** (`frontend/`): React 18 + TypeScript, React Router v6, Vite 4,
+  Context API for state (no Redux), native `fetch` (no axios), Vitest for unit
+  tests, Playwright for e2e. Package manager: **pnpm**.
+- **Backend** (`backend/`): Express (ES modules), Passport (Google + Apple
+  OAuth), `jsonwebtoken`, PostgreSQL.
+
+## Auth & session model
+
+Tokens live in `localStorage`:
+
+- `accessToken` — JWT, **15 min** TTL (`AuthService.ACCESS_TOKEN_EXPIRES`),
+  payload carries `userId`, `email`, `name`, `pictureUrl`.
+- `refreshToken` — JWT, **30 day** TTL, payload is just `userId`; also stored
+  server-side so it can be revoked.
+- `user` — the full profile last fetched from `GET /auth/me`, cached so the UI
+  can render the avatar/name without re-deriving it from the token.
+
+Key files:
+
+- `frontend/src/lib/authService.js` — token storage, JWT decode, `refreshToken`,
+  `getCurrentUser`, and `makeAuthenticatedRequest` (Bearer header + 401/403
+  retry-after-refresh). `picksService.js` has its own parallel `authFetch` with
+  the same retry shape.
+- `frontend/src/contexts/AuthContext.tsx` — `AuthProvider` derives initial auth
+  state and runs the silent session restore on mount. `isRestoring` tells route
+  guards a refresh is in flight so they don't bounce to `/login`.
+- `frontend/src/components/ProtectedRoute.tsx` — renders nothing while
+  `isRestoring`, else gates on `isAuthenticated`.
+- `frontend/src/designsystem/components/Navigation/Navigation.tsx` — shows the
+  avatar menu when `isAuthenticated && user`, else a "Sign In" CTA. It does
+  **not** consult `isRestoring` (see follow-up below).
+- Backend: `backend/src/routes/auth.js` (`/auth/refresh`, `/auth/me`, OAuth
+  callbacks), `backend/src/services/AuthService.js`, `backend/src/middleware/auth.js`.
+
+## Investigation: slow / "logged out" profile load on revisit (2026-06)
+
+**Symptom:** returning to the site after the access token expired felt slow and
+briefly looked logged out before resolving.
+
+**Root cause:** the app discarded the cached identity and rebuilt it over the
+network behind a logged-out shell. `getUser()` returns `null` the moment the
+15-min access token expires (even though the cached profile + a valid 30-day
+refresh token are both present), so `AuthProvider` initialized logged-out, the
+navbar flashed "Sign In", `ProtectedRoute` blanked the page, and a blocking
+`POST /auth/refresh` (+ possible `GET /auth/me`) round-trip gated first render.
+
+**Fix (committed):** optimistic hydration + background reconcile.
+
+- `AuthService.getCachedUser()` returns the persisted profile **independent of
+  token expiry**; `isAccessTokenValid()` is a clean validity check.
+- `AuthProvider` now hydrates from the cached profile when the access token is
+  expired but a refresh token exists, so `isAuthenticated` is true on first
+  paint. The refresh runs as a silent, non-blocking background reconcile;
+  `isRestoring` only blocks in the rare refresh-token-but-no-cached-profile case.
+- `refreshToken()` de-duplicates concurrent refreshes behind one in-flight
+  promise, so the restore and the first protected API calls don't stampede
+  `/auth/refresh`.
+
+**Mental model:** cached data should paint immediately; the network should only
+*reconcile*, never gate first render. When touching auth state, check all four
+seams together — `getUser`/`getCachedUser`, `AuthProvider` init + effect,
+`ProtectedRoute`, and `Navigation` — they each independently decide "logged in?"
+and can disagree during restore.
+
+**Test seam:** `AuthContext.test.tsx` and `App.test.tsx` mock
+`../lib/authService.js`. When adding methods that `AuthProvider` calls during
+init/restore (e.g. `getCachedUser`, `isAccessTokenValid`), add them to **both**
+mocks or the providers throw "X is not a function" at mount.
+
+### Open follow-ups (not yet done)
+
+- `Navigation.tsx` could consult `isRestoring` to suppress the "Sign In" CTA in
+  the rare no-cache cold-start; mostly moot after optimistic hydration.
+- 15-min access-token TTL means frequent background refreshes. Lengthening it or
+  refreshing proactively before expiry would cut churn — a security tradeoff,
+  get owner sign-off first.
+- Other latency to investigate next: the picks/scoreboard fetches in
+  `frontend/src/lib/picksService.js` (no client-side caching; each page mount
+  re-fetches).
+
+## Commands
+
+```bash
+# from frontend/
+pnpm install
+pnpm exec vitest run --no-coverage   # unit tests
+pnpm build                           # production build (no separate typecheck step)
+```

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -11,8 +11,12 @@ import { AuthProvider } from './contexts/AuthContext';
 vi.mock('./lib/authService.js', () => ({
   default: {
     getUser: vi.fn(),
-    // Returns undefined → AuthProvider skips the silent-refresh path, keeping
-    // these routing tests synchronous.
+    // Returns undefined → AuthProvider has no cached profile to hydrate.
+    getCachedUser: vi.fn(),
+    // Returns undefined (falsy) → AuthProvider's effect treats the token as
+    // expired, but with no refresh token below it skips the silent-refresh
+    // path entirely, keeping these routing tests synchronous.
+    isAccessTokenValid: vi.fn(),
     getRefreshToken: vi.fn(),
     setTokens: vi.fn(),
     getCurrentUser: vi.fn(),

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -7,6 +7,8 @@ import type { User } from './AuthContext';
 vi.mock('../lib/authService.js', () => ({
   default: {
     getUser: vi.fn(),
+    getCachedUser: vi.fn(),
+    isAccessTokenValid: vi.fn(),
     getRefreshToken: vi.fn(),
     refreshToken: vi.fn(),
     getCurrentUser: vi.fn(),
@@ -16,6 +18,8 @@ vi.mock('../lib/authService.js', () => ({
 
 import AuthService from '../lib/authService.js';
 const mockGetUser = vi.mocked(AuthService.getUser);
+const mockGetCachedUser = vi.mocked(AuthService.getCachedUser);
+const mockIsAccessTokenValid = vi.mocked(AuthService.isAccessTokenValid);
 const mockGetRefreshToken = vi.mocked(AuthService.getRefreshToken);
 const mockRefreshToken = vi.mocked(AuthService.refreshToken);
 const mockGetCurrentUser = vi.mocked(AuthService.getCurrentUser);
@@ -32,6 +36,10 @@ const testUser: User = {
 describe('AuthContext', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Safe defaults: no cached profile, access token treated as expired. Tests
+    // that exercise the warm-cache / valid-token paths override these.
+    mockGetCachedUser.mockReturnValue(null);
+    mockIsAccessTokenValid.mockReturnValue(false);
   });
 
   // Test 1: getUser() returns null → isAuthenticated=false, user=null
@@ -177,6 +185,7 @@ describe('AuthContext', () => {
 
   it('does not attempt a refresh when the access token is still valid', () => {
     mockGetUser.mockReturnValue(testUser as any);
+    mockIsAccessTokenValid.mockReturnValue(true);
     mockGetRefreshToken.mockReturnValue('valid-refresh-token');
 
     const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
@@ -184,6 +193,32 @@ describe('AuthContext', () => {
     expect(result.current.isRestoring).toBe(false);
     expect(result.current.isAuthenticated).toBe(true);
     expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  // The key returning-visitor optimization: when the access token has expired
+  // but we still have the cached profile + a refresh token, the app paints the
+  // user immediately (no logged-out flash, no blocking) and refreshes silently
+  // in the background.
+  it('optimistically authenticates from the cached profile while refreshing in the background', async () => {
+    mockGetUser.mockReturnValue(null); // access token expired
+    mockGetCachedUser.mockReturnValue(testUser as any); // but profile is cached
+    mockGetRefreshToken.mockReturnValue('valid-refresh-token');
+    mockRefreshToken.mockResolvedValue('new-access-token');
+    mockGetCurrentUser.mockResolvedValue(testUser as any); // background reconcile
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    // Painted immediately — no blank/logged-out interstitial.
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(testUser);
+    expect(result.current.isRestoring).toBe(false);
+
+    // And the token is refreshed silently in the background.
+    await waitFor(() => {
+      expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(mockClearTokens).not.toHaveBeenCalled();
   });
 
   it('setAuthUser followed by clearAuth returns to unauthenticated state', () => {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -24,22 +24,37 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [auth, setAuth] = useState<{ isAuthenticated: boolean; user: User | null }>(() => {
-    const user = AuthService.getUser() as User | null;
+    // getUser() returns null once the short-lived (~15m) access token expires.
+    // But a returning visitor almost always still has BOTH a valid refresh
+    // token and the full profile we cached from /auth/me last time. Rather than
+    // render a logged-out shell while we round-trip to refresh, optimistically
+    // paint that cached identity immediately and reconcile in the background.
+    const user =
+      (AuthService.getUser() as User | null) ??
+      (AuthService.getRefreshToken()
+        ? (AuthService.getCachedUser() as User | null)
+        : null);
     return { isAuthenticated: !!user, user };
   });
 
-  // getUser() returns null once the short-lived access token expires, even
-  // though the long-lived refresh token may still be valid. The pre-React app
-  // silently refreshed on startup (App.svelte's checkAuthStatus); without
-  // that, returning to the site after ~15 minutes looks like a logout.
+  // We only need to block the UI when there's a refresh token but nothing to
+  // paint yet (e.g. cached profile was cleared but tokens remain). With a warm
+  // cache the app is already showing the user, so the refresh below is silent.
   const [isRestoring, setIsRestoring] = useState<boolean>(
     () => !auth.isAuthenticated && !!AuthService.getRefreshToken()
   );
 
   useEffect(() => {
-    if (!isRestoring) return;
+    // Nothing to reconcile: either the access token is still valid, or the user
+    // is genuinely signed out (no refresh token).
+    if (AuthService.isAccessTokenValid() || !AuthService.getRefreshToken()) {
+      return;
+    }
     let cancelled = false;
 
+    // Silent background restore. The UI is already showing the cached user
+    // (isRestoring=false), so this just swaps the expired access token for a
+    // fresh one and refreshes the profile — without any logged-out flash.
     async function restoreSession() {
       try {
         await AuthService.refreshToken();
@@ -51,10 +66,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           setAuth({ isAuthenticated: true, user });
         } else {
           AuthService.clearTokens();
+          setAuth({ isAuthenticated: false, user: null });
         }
       } catch {
         if (!cancelled) {
           AuthService.clearTokens();
+          setAuth({ isAuthenticated: false, user: null });
         }
       } finally {
         if (!cancelled) {
@@ -67,7 +84,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => {
       cancelled = true;
     };
-    // Runs once on mount; isRestoring can only go true→false after this.
+    // Runs once on mount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/lib/authService.js
+++ b/frontend/src/lib/authService.js
@@ -41,32 +41,59 @@ class AuthService {
     localStorage.setItem('user', JSON.stringify(user));
   }
   
+  // Decode the access token payload, or null if missing/malformed.
+  static decodeToken() {
+    const token = this.getToken();
+    if (!token) return null;
+    try {
+      return JSON.parse(atob(token.split('.')[1]));
+    } catch {
+      return null;
+    }
+  }
+
+  // True only while the access token is present and unexpired. Used to decide
+  // whether a silent refresh is needed before the UI can trust API calls.
+  static isAccessTokenValid() {
+    const payload = this.decodeToken();
+    if (!payload) return false;
+    if (payload.exp && Date.now() / 1000 >= payload.exp) return false;
+    return true;
+  }
+
+  // The last full profile we fetched from /auth/me, persisted across reloads.
+  // Unlike getUser(), this does NOT depend on the access token still being
+  // valid — it lets the app paint a returning user's identity immediately on
+  // load while a refresh happens in the background. Returns null if no cached
+  // profile exists.
+  static getCachedUser() {
+    try {
+      const stored = localStorage.getItem('user');
+      if (!stored) return null;
+      const parsed = JSON.parse(stored);
+      return parsed && parsed.id ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
   static getUser() {
     // Prefer enriched cached user (may include pictureUrl) if available and token valid
     const token = this.getToken();
     if (!token) return null;
 
-    let payload;
-    try {
-      payload = JSON.parse(atob(token.split('.')[1]));
-    } catch {
-      return null;
-    }
+    const payload = this.decodeToken();
+    if (!payload) return null;
 
-    if (payload?.exp && Date.now() / 1000 >= payload.exp) {
+    if (payload.exp && Date.now() / 1000 >= payload.exp) {
       return null; // caller should attempt refresh
     }
 
     // If we previously fetched the full profile (/auth/me) use that (ensures pictureUrl present)
-    try {
-      const stored = localStorage.getItem('user');
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (parsed && parsed.id === payload.userId) {
-          return parsed;
-        }
-      }
-    } catch {/* ignore */}
+    const cached = this.getCachedUser();
+    if (cached && cached.id === payload.userId) {
+      return cached;
+    }
 
     // Fallback to basic token-derived user (without pictureUrl)
     return {
@@ -143,25 +170,39 @@ class AuthService {
   }
   
   static async refreshToken() {
+    // De-duplicate concurrent refreshes. On a returning visit the silent
+    // restore in AuthContext and the first protected API calls can all notice
+    // the expired token at once; without this they would each POST /auth/refresh
+    // and stampede the endpoint (and the DB lookup behind it). Share one
+    // in-flight request so every caller awaits the same new token.
+    if (this._refreshPromise) return this._refreshPromise;
+
+    this._refreshPromise = this._performRefresh().finally(() => {
+      this._refreshPromise = null;
+    });
+    return this._refreshPromise;
+  }
+
+  static async _performRefresh() {
     const apiBase = this.getApiBaseUrl();
     const refreshToken = this.getRefreshToken();
     if (!refreshToken) throw new Error('No refresh token');
-    
+
     const response = await fetch(`${apiBase}/auth/refresh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refreshToken })
     });
-    
+
     if (!response.ok) {
       throw new Error('Failed to refresh token');
     }
-    
+
     const data = await response.json();
     if (data.accessToken) {
       localStorage.setItem('accessToken', data.accessToken);
     }
-    
+
     return data.accessToken;
   }
   

--- a/frontend/src/lib/authService.test.js
+++ b/frontend/src/lib/authService.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import AuthService from './authService.js';
+
+// Builds a JWT-shaped string ("header.payload.sig") whose payload is the given
+// object. AuthService only ever decodes the middle segment, so the header/sig
+// are throwaway. exp is in seconds since epoch, matching the real backend.
+function makeToken(payload) {
+  const body = btoa(JSON.stringify(payload));
+  return `header.${body}.sig`;
+}
+
+const NOW = Math.floor(Date.now() / 1000);
+const USER = { id: 7, email: 'a@b.com', name: 'Ada', pictureUrl: null };
+
+describe('AuthService cache + token helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('getCachedUser', () => {
+    it('returns the stored profile regardless of access-token expiry', () => {
+      localStorage.setItem('user', JSON.stringify(USER));
+      // No access token at all — getUser() would be null, but the cached
+      // profile is still available for optimistic hydration.
+      expect(AuthService.getCachedUser()).toEqual(USER);
+    });
+
+    it('returns null when no profile is cached', () => {
+      expect(AuthService.getCachedUser()).toBeNull();
+    });
+
+    it('returns null for malformed cached JSON', () => {
+      localStorage.setItem('user', '{not json');
+      expect(AuthService.getCachedUser()).toBeNull();
+    });
+  });
+
+  describe('isAccessTokenValid', () => {
+    it('is false when there is no token', () => {
+      expect(AuthService.isAccessTokenValid()).toBe(false);
+    });
+
+    it('is false once the token is past its exp', () => {
+      localStorage.setItem('accessToken', makeToken({ userId: 7, exp: NOW - 60 }));
+      expect(AuthService.isAccessTokenValid()).toBe(false);
+    });
+
+    it('is true for an unexpired token', () => {
+      localStorage.setItem('accessToken', makeToken({ userId: 7, exp: NOW + 600 }));
+      expect(AuthService.isAccessTokenValid()).toBe(true);
+    });
+  });
+
+  describe('getUser', () => {
+    it('returns null when the access token is expired even if a profile is cached', () => {
+      localStorage.setItem('user', JSON.stringify(USER));
+      localStorage.setItem('accessToken', makeToken({ userId: 7, exp: NOW - 60 }));
+      expect(AuthService.getUser()).toBeNull();
+    });
+
+    it('prefers the cached profile for a valid token of the same user', () => {
+      localStorage.setItem('user', JSON.stringify(USER));
+      localStorage.setItem('accessToken', makeToken({ userId: 7, exp: NOW + 600 }));
+      expect(AuthService.getUser()).toEqual(USER);
+    });
+  });
+
+  describe('refreshToken de-duplication', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('coalesces concurrent refreshes into a single network call', async () => {
+      localStorage.setItem('refreshToken', 'r1');
+      let resolveFetch;
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = () =>
+              resolve({ ok: true, json: async () => ({ accessToken: 'new-access' }) });
+          })
+      );
+
+      // Two callers notice the expired token at the same time.
+      const p1 = AuthService.refreshToken();
+      const p2 = AuthService.refreshToken();
+
+      resolveFetch();
+      const [t1, t2] = await Promise.all([p1, p2]);
+
+      expect(t1).toBe('new-access');
+      expect(t2).toBe('new-access');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem('accessToken')).toBe('new-access');
+    });
+
+    it('allows a fresh refresh after the previous one settles', async () => {
+      localStorage.setItem('refreshToken', 'r1');
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ accessToken: 'access-x' }),
+      });
+
+      await AuthService.refreshToken();
+      await AuthService.refreshToken();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

On a **second visit** after the ~15-minute access token expires, profile data felt slow to load and the app briefly looked **logged out** before resolving.

The app was discarding the identity it already had and rebuilding it over the network behind a logged-out shell:

1. `AuthService.getUser()` returns `null` the instant the access token expires — even though the full profile is cached in `localStorage.user` and a valid 30-day refresh token exists. So `AuthProvider` initialized as logged-out.
2. The navbar flashed a **"Sign In"** CTA (`Navigation` renders the avatar only when `isAuthenticated && user`).
3. `ProtectedRoute` **blanked the page** (`return null` while `isRestoring`).
4. A **blocking** `POST /auth/refresh` (+ possible `GET /auth/me`) round-trip gated first render. Every coffee-break revisit paid this.

Cached data existed — we just ignored it and waited on the network behind a logged-out UI.

## Fix — optimistic hydration + background reconcile

We already persist the full profile from `/auth/me`, so paint it immediately and refresh silently:

- **`authService.js`** — added `getCachedUser()` (returns the stored profile *regardless* of token expiry) and `isAccessTokenValid()` (clean validity check). **De-duplicated `refreshToken()`** behind a single in-flight promise so the restore and the first protected API calls don't each stampede `/auth/refresh`.
- **`AuthContext.tsx`** — hydrates auth state from the cached profile when the access token is expired but a refresh token exists, so `isAuthenticated` is **true on first paint** (no flash, no blank). The token refresh now runs as a **non-blocking background reconcile**; `isRestoring` only blocks in the rare refresh-token-but-no-cached-profile case. A failed background refresh cleanly downgrades to logged-out.

Net effect: a returning user sees their avatar and content **instantly from cache**; the token swap happens invisibly in the background.

## Tests

- New `authService.test.js` — cache/token helpers + refresh de-dup (10 tests).
- New optimistic-hydration test in `AuthContext.test.tsx`.
- Updated the AuthService mocks in `App.test.tsx` and `AuthContext.test.tsx` for the new methods.
- Full suite: **704 passing**; production build succeeds.

## Docs

Added `CLAUDE.md` capturing the auth/session model and this root-cause writeup so future latency investigations start with context.

## Follow-ups (not in this PR)

- `Navigation.tsx` could consult `isRestoring` to suppress the "Sign In" CTA in the rare cold-start case.
- The 15-min access-token TTL drives frequent background refreshes; lengthening it / proactive refresh would cut churn (security tradeoff — needs owner sign-off).
- Next latency candidate: picks/scoreboard fetches in `picksService.js` (no client-side caching; each mount re-fetches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzkHCbD4uZWEmSVzSAVahC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzkHCbD4uZWEmSVzSAVahC)_