### PR TITLE
World Cup: single-request stage slate + break the GroupDetailsPage waterfall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,64 @@ mocks or the providers throw "X is not a function" at mount.
   `frontend/src/lib/picksService.js` (no client-side caching; each page mount
   re-fetches).
 
+## Investigation: "extra beat" on World Cup group tabs (2026-06)
+
+**Symptom:** the Leaderboard and Picks tabs in a `world_cup_2026` group felt a
+beat slow each time you opened them — including switching away and back.
+
+**Root cause:** `GroupDetailsPage` conditionally renders only the active tab
+(`activeTab === 'leaderboard' && …`), so each tab **unmounts on every tab
+switch** and its data-owning child re-fetches from scratch behind a `Loading…`
+blank. There was no client-side cache, so re-entry never reused prior data. The
+Picks tab was the worst case: `WorldCupPicksTab` fans out to **seven** stage
+requests (`Promise.all(WORLD_CUP_STAGES.map(getStageMatches))`) on every mount,
+plus a my-picks hydrate and a my-groups fetch.
+
+Secondary contributor (not yet fixed): the page-shell `Promise.all([getGroup,
+getMembers, getMessages])` gates first render, and the leaderboard fetch can't
+even *start* until that resolves — a serial waterfall. `getMessages` is fetched
+eagerly on mount even though Chat isn't the default tab.
+
+**Fix (committed):** a tiny stale-while-revalidate cache,
+`frontend/src/lib/worldCupCache.ts` (`peekCache`/`writeCache`/
+`clearWorldCupCache` + `wcCacheKeys`). It's process-memory only, no TTL —
+freshness comes from always revalidating, not from expiry.
+
+- `WorldCupLeaderboardTab` and `WorldCupPicksTab` seed initial state
+  synchronously from `peekCache(...)`, so a warm cache paints the last-known
+  standings/match slate **instantly** on re-entry. The fetch still runs but only
+  shows the blocking spinner on a **cold** load (`peekCache(...) === undefined`);
+  a warm revalidate is silent. A failed revalidate keeps the stale data on
+  screen instead of replacing it with an error.
+- Stage matches are cached tournament-globally (`wc:stages`); the leaderboard is
+  cached per group (`wc:lb:<id>`). The Picks tab's live-poll silent refresh also
+  writes the cache so a mid-tournament tab switch re-seeds from the latest
+  scores, not a stale pre-kickoff slate.
+
+**Mental model (same as the auth fix):** cached data paints immediately; the
+network only *reconciles*. The cold-vs-warm distinction is the whole trick — gate
+the spinner on `peekCache(key) === undefined`, never unconditionally.
+
+**Test seam:** the cache is module-global and **persists across test cases**.
+Component tests that seed from it must `clearWorldCupCache()` in `beforeEach`
+(see `WorldCupLeaderboardTab.test.tsx` / `WorldCupPicksTab.test.tsx`) or a prior
+render's data leaks into the next — most visibly breaking the "shows the loading
+state" cases (a warm cache means no spinner). The cache module is imported
+*real* (unmocked) in those tests, alongside the mocked `worldCupService.js`.
+
+### Open follow-ups (not yet done)
+
+- Collapse the seven-stage fan-out into one backend endpoint
+  (`/api/games/world-cup-2026/stages` or `?stage=all`) so even a cold Picks load
+  is a single round-trip. The backend already DB-caches per stage
+  (`api.js` → `GameService.getWorldCupStage`), so this is mostly a route + a
+  `getAllWorldCupStages()` service wrapper.
+- Break the `GroupDetailsPage` waterfall: kick off the leaderboard fetch in
+  parallel with the shell instead of after it, and lazy-load `getMessages` when
+  the Chat tab opens rather than eagerly on mount.
+- The NFL `PicksTab`/scoreboard via `picksService.js` has the same
+  re-fetch-on-mount shape; the same cache pattern applies.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,18 +130,54 @@ render's data leaks into the next — most visibly breaking the "shows the loadi
 state" cases (a warm cache means no spinner). The cache module is imported
 *real* (unmocked) in those tests, alongside the mocked `worldCupService.js`.
 
+### Follow-ups: cold-load round-trips + the shell waterfall (2026-06, done)
+
+Both done in the pass that followed the SWR cache.
+
+**1. Single-request stage slate.** The Picks tab's seven-stage fan-out is now one
+round-trip. `GameService.getAllWorldCupStages(forceRefresh)`
+(`backend/src/services/GameService.js`) `Promise.all`s the seven
+`getWorldCupStage` reads server-side and flattens them in calendar order
+(`WORLD_CUP_STAGE_ORDER`); the per-stage DB cache + live-refresh rules are
+unchanged. Exposed at `GET /api/games/world-cup-2026/stages`
+(`backend/src/routes/api.js`, registered before the NFL `/:year/...` param route
+like the other literal world-cup routes) returning the same
+`{ games, count, cached }` shape with the grafted `winnerTeamId`. Frontend:
+`getAllWorldCupStages()` in `worldCupService.js`; `WorldCupPicksTab` calls it in
+place of `Promise.all(WORLD_CUP_STAGES.map(getStageMatches))` in BOTH the initial
+fetch and the live-poll `refreshMatchesSilently`. `getStageMatches` is still
+exported (single-stage callers/tests), but no component fans out anymore.
+
+**2. Broke the `GroupDetailsPage` waterfall.** Two changes:
+- The shell `Promise.all` is now just `[getGroup, getMembers]` — `getMessages`
+  was dropped from the critical path and is **lazy-loaded the first time the Chat
+  tab opens** (`ensureMessagesLoaded`, guarded so it fetches once; the tab shows
+  a spinner until `messagesLoaded`). Chat history no longer delays first paint.
+- For `world_cup_2026` pools the page **prefetches the leaderboard in parallel**
+  with the shell: as soon as `getGroup` resolves and the pool type is known, it
+  fires `getWorldCupLeaderboard` and `writeCache`s it under
+  `wcCacheKeys.leaderboard(id)`. The default Leaderboard tab seeds from that
+  cache and paints instantly instead of starting its fetch only after the shell
+  resolves. (The tab still revalidates on mount — one extra background call, by
+  SWR design.)
+
+**Test-seam notes:**
+- `WorldCupPicksTab.test.tsx`, `WorldCupPicksPage.test.tsx`, and
+  `GroupDetailsPage.test.tsx` now mock `getAllWorldCupStages` (a single resolved
+  `{ games }`) instead of per-stage `getStageMatches`.
+- `GroupDetailsPage.test.tsx` imports the **real** cache and calls
+  `clearWorldCupCache()` in `beforeEach` (the leaderboard prefetch + the embedded
+  WC tabs both touch it); chat assertions are now `await findByText(...)` because
+  messages lazy-load; and `getMessages` must NOT be called on mount.
+- Backend: `tests/api-worldcup-route.test.js` covers the `/stages` route (flattened
+  multi-stage payload + grafted knockout `winnerTeamId`).
+
 ### Open follow-ups (not yet done)
 
-- Collapse the seven-stage fan-out into one backend endpoint
-  (`/api/games/world-cup-2026/stages` or `?stage=all`) so even a cold Picks load
-  is a single round-trip. The backend already DB-caches per stage
-  (`api.js` → `GameService.getWorldCupStage`), so this is mostly a route + a
-  `getAllWorldCupStages()` service wrapper.
-- Break the `GroupDetailsPage` waterfall: kick off the leaderboard fetch in
-  parallel with the shell instead of after it, and lazy-load `getMessages` when
-  the Chat tab opens rather than eagerly on mount.
 - The NFL `PicksTab`/scoreboard via `picksService.js` has the same
-  re-fetch-on-mount shape; the same cache pattern applies.
+  re-fetch-on-mount shape; the SWR cache pattern (and the parallel-prefetch trick)
+  applies there too. The NFL `LeaderboardTab` has no cache yet, so the
+  parallel-prefetch optimization is currently World-Cup-only.
 
 ## Commands
 

--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -55,6 +55,33 @@ router.get('/games/world-cup-2026/stage/:stage', async (req, res) => {
   }
 });
 
+// Whole-tournament slate in ONE request. The Picks tab previously fanned out to
+// seven /stage/:stage calls on every mount; this collapses them server-side so a
+// cold Picks load is a single round-trip. Registered before /games/:year/... for
+// the same reason as the stage route (literal world-cup-2026 prefix must win).
+router.get('/games/world-cup-2026/stages', async (req, res) => {
+  try {
+    const forceRefresh = (req.query.refresh === 'true') || (req.query.force === 'true') || (req.query.force === '1');
+
+    const games = await GameService.getAllWorldCupStages(forceRefresh);
+
+    res.json({
+      // Same per-game shape as the single-stage handler, including the grafted
+      // winnerTeamId (not part of Game.toJSON()) so knockout advancing-team
+      // signals survive in the flattened payload.
+      games: games.map(g => {
+        const json = (typeof g.toJSON === 'function' ? g.toJSON() : { ...g });
+        json.winnerTeamId = g.winnerTeamId ?? null;
+        return json;
+      }),
+      count: games.length,
+      cached: !forceRefresh
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // On-demand, resilient, no-schema per-match detail for the World Cup detail panel.
 // Registered before /games/:year/:seasonType/:week for the same reason as the stage
 // route: world-cup-2026/event/:espnId is a literal-prefixed 4-segment path the NFL

--- a/backend/src/services/GameService.js
+++ b/backend/src/services/GameService.js
@@ -263,6 +263,25 @@ export class GameService {
     }
   }
 
+  // The seven World Cup stages, in calendar order. Kept here next to the fetch
+  // so the single-request "all stages" endpoint and any future sweep share one
+  // source of truth.
+  static WORLD_CUP_STAGE_ORDER = ['group', 'r32', 'r16', 'qf', 'sf', 'third', 'final'];
+
+  // One-shot fetch of every stage, flattened in calendar order. Lets the client
+  // pull the whole tournament slate in a SINGLE round-trip instead of fanning out
+  // to seven /stage/:stage requests on every Picks-tab mount. Each stage still
+  // routes through getWorldCupStage, so the per-stage DB cache + live-refresh
+  // rules are unchanged; this only collapses the fan-out to the network edge.
+  static async getAllWorldCupStages(forceRefresh = false) {
+    const perStage = await Promise.all(
+      GameService.WORLD_CUP_STAGE_ORDER.map((stage) =>
+        GameService.getWorldCupStage(stage, forceRefresh),
+      ),
+    );
+    return perStage.flat();
+  }
+
   // Read the homeAway side ESPN flags as the result. ESPN sets
   // competitors[].winner === true on the advancing team — notably on PK
   // shootouts, where the 90' scoreline is level and is the only signal of who

--- a/backend/tests/api-worldcup-route.test.js
+++ b/backend/tests/api-worldcup-route.test.js
@@ -93,6 +93,72 @@ describe('GET /api/games/world-cup-2026/stage/:stage', () => {
   });
 });
 
+describe('GET /api/games/world-cup-2026/stages', () => {
+  let server;
+  let baseURL;
+
+  before(async () => {
+    const app = express();
+    app.use('/api', apiRouter);
+    await new Promise((resolve) => {
+      server = app.listen(0, () => {
+        baseURL = `http://localhost:${server.address().port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    process.env.USE_MOCK_ESPN = 'true';
+    MockESPNService.configure();
+    mock.method(Game, 'findByLeagueStage', async () => []);
+    mock.method(Game, 'findByESPNIds', async () => new Map());
+    mock.method(Game.prototype, 'save', async function save() {
+      this.id = this.id || 1;
+      return this;
+    });
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    MockESPNService.reset();
+    delete process.env.USE_MOCK_ESPN;
+  });
+
+  test('returns every stage flattened into one { games, count, cached } payload', async () => {
+    const response = await fetch(`${baseURL}/api/games/world-cup-2026/stages`);
+    assert.strictEqual(response.status, 200);
+    const data = await response.json();
+
+    assert.ok(Array.isArray(data.games), 'games should be an array');
+    assert.strictEqual(data.count, data.games.length, 'count should match games length');
+    assert.strictEqual(data.cached, true, 'no refresh requested means cached');
+
+    // The flattened slate spans multiple stages — not just the group round — so a
+    // single request stands in for the old seven-call fan-out.
+    const stages = new Set(data.games.map((g) => g.stage));
+    assert.ok(stages.has('group'), 'flattened slate includes the group stage');
+    assert.ok(stages.size > 1, 'flattened slate spans more than one stage');
+    assert.ok('winnerTeamId' in data.games[0], 'winnerTeamId must be present in the payload');
+  });
+
+  test('carries the resolved knockout winnerTeamId through the combined route', async () => {
+    const response = await fetch(`${baseURL}/api/games/world-cup-2026/stages`);
+    assert.strictEqual(response.status, 200);
+    const data = await response.json();
+
+    const reg = data.games.find(
+      (g) => g.homeTeam?.abbreviation === 'ENG' && g.awayTeam?.abbreviation === 'GER'
+    );
+    assert.ok(reg, 'flattened slate should include the ENG vs GER knockout fixture');
+    assert.strictEqual(reg.winnerTeamId, WORLD_CUP_2026_TEAMS.ENG.id, 'advancing team surfaces in JSON');
+  });
+});
+
 describe('GET /api/games/world-cup-2026/event/:espnId', () => {
   let server;
   let baseURL;

--- a/frontend/src/lib/worldCupCache.test.ts
+++ b/frontend/src/lib/worldCupCache.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { peekCache, writeCache, clearWorldCupCache, wcCacheKeys } from './worldCupCache';
+
+describe('worldCupCache', () => {
+  beforeEach(() => clearWorldCupCache());
+
+  it('returns undefined for a key that was never written', () => {
+    expect(peekCache('wc:lb:never')).toBeUndefined();
+  });
+
+  it('round-trips a written value', () => {
+    writeCache('wc:lb:g1', [{ rank: 1 }]);
+    expect(peekCache('wc:lb:g1')).toEqual([{ rank: 1 }]);
+  });
+
+  it('overwrites a prior value for the same key', () => {
+    writeCache(wcCacheKeys.stages, [1, 2]);
+    writeCache(wcCacheKeys.stages, [3]);
+    expect(peekCache(wcCacheKeys.stages)).toEqual([3]);
+  });
+
+  it('clearWorldCupCache drops everything', () => {
+    writeCache(wcCacheKeys.stages, [1]);
+    writeCache(wcCacheKeys.leaderboard('g1'), [2]);
+    clearWorldCupCache();
+    expect(peekCache(wcCacheKeys.stages)).toBeUndefined();
+    expect(peekCache(wcCacheKeys.leaderboard('g1'))).toBeUndefined();
+  });
+
+  it('keys leaderboards per group', () => {
+    expect(wcCacheKeys.leaderboard('a')).not.toBe(wcCacheKeys.leaderboard('b'));
+  });
+});

--- a/frontend/src/lib/worldCupCache.ts
+++ b/frontend/src/lib/worldCupCache.ts
@@ -1,0 +1,39 @@
+// In-memory stale-while-revalidate store for the World Cup group views.
+//
+// The Leaderboard and Picks tabs each own their fetch and unmount on every tab
+// switch (GroupDetailsPage conditionally renders the active tab), so without a
+// cache, re-entering a tab — or revisiting the group — re-runs the fetch behind
+// a "Loading…" blank every time. The Picks tab is the worst offender: it fans
+// out to SEVEN stage requests on each mount.
+//
+// This store lets a tab paint its last-known data immediately and revalidate in
+// the background, so the "extra beat" only ever shows on the very first load.
+// It's process-memory only (no persistence) and deliberately tiny — freshness is
+// handled by always revalidating, not by TTLs.
+
+type Entry<T> = { value: T; ts: number };
+
+const store = new Map<string, Entry<unknown>>();
+
+/** Last cached value for `key`, or `undefined` if nothing has been cached yet. */
+export function peekCache<T>(key: string): T | undefined {
+  const entry = store.get(key);
+  return entry ? (entry.value as T) : undefined;
+}
+
+/** Cache `value` under `key`, stamping it with the current time. */
+export function writeCache<T>(key: string, value: T): void {
+  store.set(key, { value, ts: Date.now() });
+}
+
+/** Drop everything. Tests call this in `beforeEach` so cases don't bleed cache. */
+export function clearWorldCupCache(): void {
+  store.clear();
+}
+
+/** Stable cache keys. Stage matches are tournament-global; the leaderboard is
+ *  per group. */
+export const wcCacheKeys = {
+  stages: 'wc:stages',
+  leaderboard: (groupId: string) => `wc:lb:${groupId}`,
+} as const;

--- a/frontend/src/lib/worldCupService.d.ts
+++ b/frontend/src/lib/worldCupService.d.ts
@@ -29,6 +29,13 @@ export interface LeaderboardResponse {
 export function getStageMatches(stage: WorldCupStage): Promise<StageMatchesResponse>;
 
 /**
+ * Fetch every tournament stage in a SINGLE request — the games are flattened
+ * across all stages in calendar order. Replaces the client-side seven-stage
+ * fan-out so a cold Picks-tab load is one round-trip.
+ */
+export function getAllWorldCupStages(): Promise<StageMatchesResponse>;
+
+/**
  * Persist a member's World Cup picks for a group. Each pick names a game and the
  * picked result (home/away/draw). Resolves to the parsed response body.
  */

--- a/frontend/src/lib/worldCupService.js
+++ b/frontend/src/lib/worldCupService.js
@@ -31,6 +31,19 @@ export async function getStageMatches(stage) {
   return res.json();
 }
 
+// Whole-tournament slate in ONE request. Replaces the client-side seven-stage
+// fan-out (Promise.all over getStageMatches) so a cold Picks-tab load is a single
+// round-trip. Returns the same { games, count, cached } shape as getStageMatches,
+// with games already flattened across every stage in calendar order.
+export async function getAllWorldCupStages() {
+  const res = await authFetch(`${apiBase()}/api/games/world-cup-2026/stages`);
+  if (!res.ok) {
+    const data = await res.json().catch(()=>({}));
+    throw new Error(data.error || 'Failed to load matches');
+  }
+  return res.json();
+}
+
 export async function submitWorldCupPicks(groupId, picks) {
   const res = await authFetch(`${apiBase()}/api/picks/group/${groupId}/world-cup`, { method: 'POST', body: JSON.stringify({ picks }) });
   if (!res.ok) {

--- a/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../../lib/worldCupService.js', () => ({
 }));
 
 import { getWorldCupLeaderboard } from '../../lib/worldCupService.js';
+// Real (unmocked) cache module — the tab seeds initial state from it, so it must
+// be cleared between cases or a prior render's rows leak into the next.
+import { clearWorldCupCache } from '../../lib/worldCupCache';
 const mockGetWorldCupLeaderboard = vi.mocked(getWorldCupLeaderboard);
 
 const identifier = 'wc-group';
@@ -41,7 +44,10 @@ const rows: TournamentLeaderboardRow[] = [
 ];
 
 describe('WorldCupLeaderboardTab', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearWorldCupCache();
+  });
 
   it('fetches and renders the tournament leaderboard table', async () => {
     mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: rows });
@@ -88,5 +94,43 @@ describe('WorldCupLeaderboardTab', () => {
     await waitFor(() => {
       expect(screen.queryByRole('table')).not.toBeInTheDocument();
     });
+  });
+
+  // Stale-while-revalidate: a second mount (e.g. switching back to the tab) must
+  // paint the cached standings synchronously — no "Loading…" blank — while a
+  // background refresh runs.
+  it('paints cached standings instantly on a re-mount without a loading flash', async () => {
+    mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: rows });
+
+    // First mount warms the cache.
+    const first = render(<WorldCupLeaderboardTab identifier={identifier} />);
+    await screen.findByRole('table');
+    first.unmount();
+
+    // Second mount: rows are present immediately and the spinner never shows.
+    render(<WorldCupLeaderboardTab identifier={identifier} />);
+    expect(screen.queryByText('Loading leaderboard…')).not.toBeInTheDocument();
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('keeps showing cached standings when a background revalidate fails', async () => {
+    mockGetWorldCupLeaderboard.mockResolvedValueOnce({ leaderboard: rows });
+
+    const first = render(<WorldCupLeaderboardTab identifier={identifier} />);
+    await screen.findByRole('table');
+    first.unmount();
+
+    // The revalidate on re-mount rejects, but the cached table must stay put and
+    // no error message replaces it.
+    mockGetWorldCupLeaderboard.mockRejectedValueOnce(new Error('flaky network'));
+    render(<WorldCupLeaderboardTab identifier={identifier} />);
+
+    await waitFor(() => {
+      expect(mockGetWorldCupLeaderboard).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByText('flaky network')).not.toBeInTheDocument();
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('Alice')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupLeaderboardTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import TournamentLeaderboard from '../../designsystem/components/TournamentLeaderboard';
 import type { TournamentLeaderboardRow } from '../../lib/types';
 import { getWorldCupLeaderboard } from '../../lib/worldCupService.js';
+import { peekCache, writeCache, wcCacheKeys } from '../../lib/worldCupCache';
 
 export interface WorldCupLeaderboardTabProps {
   /** Group identifier; the leaderboard fetch keys off the same `?group=` value. */
@@ -12,23 +13,39 @@ export interface WorldCupLeaderboardTabProps {
 // so the page shell stays agnostic to pool type. Renders the tournament-shaped
 // TournamentLeaderboard with the four tiebreaker columns; rows arrive already
 // ordered by the backend comparator and are never re-sorted here.
+//
+// Stale-while-revalidate: the tab unmounts on every tab switch, so the rows are
+// cached per group and seeded synchronously on mount. A warm cache paints the
+// last-known standings instantly and refreshes silently in the background; only
+// a cold (first-ever) load shows the "Loading…" blank.
 export default function WorldCupLeaderboardTab({ identifier }: WorldCupLeaderboardTabProps) {
-  const [rows, setRows] = useState<TournamentLeaderboardRow[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cacheKey = wcCacheKeys.leaderboard(identifier);
+  const cached = peekCache<TournamentLeaderboardRow[]>(cacheKey);
+  const [rows, setRows] = useState<TournamentLeaderboardRow[]>(cached ?? []);
+  const [loading, setLoading] = useState(cached === undefined);
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
-    setLoading(true);
+    // Only block with the spinner on a cold load; a warm cache revalidates
+    // silently so the standings never flash empty on a tab switch.
+    const isCold = peekCache(cacheKey) === undefined;
+    if (isCold) setLoading(true);
     setError(null);
     try {
       const resp = await getWorldCupLeaderboard(identifier);
-      setRows(Array.isArray(resp?.leaderboard) ? resp.leaderboard : []);
+      const next = Array.isArray(resp?.leaderboard) ? resp.leaderboard : [];
+      writeCache(cacheKey, next);
+      setRows(next);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load leaderboard');
+      // Keep showing the cached standings on a failed revalidate; only surface
+      // the error when there was nothing to fall back to.
+      if (peekCache(cacheKey) === undefined) {
+        setError(err instanceof Error ? err.message : 'Failed to load leaderboard');
+      }
     } finally {
       setLoading(false);
     }
-  }, [identifier]);
+  }, [identifier, cacheKey]);
 
   useEffect(() => {
     load();

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -23,6 +23,9 @@ import {
   submitUserWorldCupPicks,
 } from '../../lib/worldCupService.js';
 import { getMyGroups } from '../../lib/groupsService.js';
+// Real (unmocked) cache module — the tab seeds its match slate from it, so clear
+// it between cases or a prior render's matches leak into the next.
+import { clearWorldCupCache } from '../../lib/worldCupCache';
 const mockGetStageMatches = vi.mocked(getStageMatches);
 const mockSubmitPicks = vi.mocked(submitWorldCupPicks);
 const mockGetMyWorldCupPicks = vi.mocked(getMyWorldCupPicks);
@@ -106,6 +109,7 @@ function pickButton(homeName: string, label: string): HTMLElement {
 describe('WorldCupPicksTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearWorldCupCache();
     mockGetStageMatches.mockImplementation(stageResponder([groupMatch, r16Match]));
     // Default: source group is the user's only WC group. Tests exercising the
     // dropdown re-mock with multiple groups.
@@ -153,6 +157,29 @@ describe('WorldCupPicksTab', () => {
     renderTab();
     expect(await screen.findByText('Loading matches…')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit Picks' })).not.toBeInTheDocument();
+  });
+
+  // Stale-while-revalidate: re-entering the Picks tab must paint the cached
+  // match slate immediately — no "Loading matches…" blank behind the seven-stage
+  // fan-out — while a background revalidate runs.
+  it('paints the cached match slate instantly on a re-mount without a loading flash', async () => {
+    // First mount warms the stage cache.
+    const first = renderTab();
+    await screen.findByText((_c, n) => n?.textContent?.startsWith('Mexico vs ') ?? false, {
+      selector: 'span',
+    });
+    first.unmount();
+
+    // Second mount: a never-resolving fetch would normally pin the loading state,
+    // but the cached slate paints first so "Loading matches…" never appears.
+    mockGetStageMatches.mockReturnValue(new Promise<never>(() => {}));
+    renderTab();
+    expect(screen.queryByText('Loading matches…')).not.toBeInTheDocument();
+    expect(
+      screen.getByText((_c, n) => n?.textContent?.startsWith('Mexico vs ') ?? false, {
+        selector: 'span',
+      }),
+    ).toBeInTheDocument();
   });
 
   it('fetches every tournament stage and renders matches in the flat browse list', async () => {

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import WorldCupPicksTab from './WorldCupPicksTab';
-import type { WorldCupMatch, WorldCupStage } from '../../lib/types';
+import type { WorldCupMatch } from '../../lib/types';
 
 vi.mock('../../lib/worldCupService.js', () => ({
-  getStageMatches: vi.fn(),
+  getAllWorldCupStages: vi.fn(),
   submitWorldCupPicks: vi.fn(),
   getMyWorldCupPicks: vi.fn(),
   getUserWorldCupPicks: vi.fn(),
@@ -16,7 +16,7 @@ vi.mock('../../lib/groupsService.js', () => ({
 }));
 
 import {
-  getStageMatches,
+  getAllWorldCupStages,
   submitWorldCupPicks,
   getMyWorldCupPicks,
   getUserWorldCupPicks,
@@ -26,7 +26,7 @@ import { getMyGroups } from '../../lib/groupsService.js';
 // Real (unmocked) cache module — the tab seeds its match slate from it, so clear
 // it between cases or a prior render's matches leak into the next.
 import { clearWorldCupCache } from '../../lib/worldCupCache';
-const mockGetStageMatches = vi.mocked(getStageMatches);
+const mockGetAllWorldCupStages = vi.mocked(getAllWorldCupStages);
 const mockSubmitPicks = vi.mocked(submitWorldCupPicks);
 const mockGetMyWorldCupPicks = vi.mocked(getMyWorldCupPicks);
 const mockGetUserWorldCupPicks = vi.mocked(getUserWorldCupPicks);
@@ -65,13 +65,10 @@ function match(overrides: Partial<WorldCupMatch>): WorldCupMatch {
 const groupMatch = match({ id: 10, stage: 'group', homeTeam: mex, awayTeam: usa });
 const r16Match = match({ id: 20, stage: 'r16', isKnockout: true, homeTeam: can, awayTeam: arg });
 
-// Route every stage fetch to its matching subset so the tab flattens a known
-// two-match tournament (one group, one knockout).
-function stageResponder(matches: WorldCupMatch[]) {
-  return (stage: WorldCupStage) => {
-    const games = matches.filter((m) => m.stage === stage);
-    return Promise.resolve({ games, count: games.length, cached: false });
-  };
+// The single /stages endpoint returns every match flattened in one payload, so
+// the tab renders a known two-match tournament (one group, one knockout).
+function stagesResponse(matches: WorldCupMatch[]) {
+  return { games: matches, count: matches.length, cached: false };
 }
 
 function renderTab(identifier = 'la-crew') {
@@ -110,7 +107,7 @@ describe('WorldCupPicksTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearWorldCupCache();
-    mockGetStageMatches.mockImplementation(stageResponder([groupMatch, r16Match]));
+    mockGetAllWorldCupStages.mockResolvedValue(stagesResponse([groupMatch, r16Match]));
     // Default: source group is the user's only WC group. Tests exercising the
     // dropdown re-mock with multiple groups.
     mockGetMyGroups.mockResolvedValue([
@@ -153,7 +150,7 @@ describe('WorldCupPicksTab', () => {
   it('shows the loading indicator while a stage fetch is in flight', async () => {
     // A never-resolving promise pins the tab in its loading state — and the
     // sticky submit bar must not render before any matches exist.
-    mockGetStageMatches.mockReturnValue(new Promise<never>(() => {}));
+    mockGetAllWorldCupStages.mockReturnValue(new Promise<never>(() => {}));
     renderTab();
     expect(await screen.findByText('Loading matches…')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit Picks' })).not.toBeInTheDocument();
@@ -172,7 +169,7 @@ describe('WorldCupPicksTab', () => {
 
     // Second mount: a never-resolving fetch would normally pin the loading state,
     // but the cached slate paints first so "Loading matches…" never appears.
-    mockGetStageMatches.mockReturnValue(new Promise<never>(() => {}));
+    mockGetAllWorldCupStages.mockReturnValue(new Promise<never>(() => {}));
     renderTab();
     expect(screen.queryByText('Loading matches…')).not.toBeInTheDocument();
     expect(
@@ -182,12 +179,13 @@ describe('WorldCupPicksTab', () => {
     ).toBeInTheDocument();
   });
 
-  it('fetches every tournament stage and renders matches in the flat browse list', async () => {
+  it('fetches the whole tournament in one request and renders matches in the flat browse list', async () => {
     renderTab();
     await screen.findByText((_c, n) => n?.textContent?.startsWith('Mexico vs ') ?? false, {
       selector: 'span',
     });
-    expect(mockGetStageMatches).toHaveBeenCalledTimes(7);
+    // One round-trip for the whole slate — no seven-stage fan-out.
+    expect(mockGetAllWorldCupStages).toHaveBeenCalledTimes(1);
 
     // Both matchups render in the flat list (no per-stage <h2> sections anymore).
     expect(cardFor('Mexico')).toBeInTheDocument();
@@ -201,15 +199,15 @@ describe('WorldCupPicksTab', () => {
     expect(pickButton('Mexico', 'USA')).toBeInTheDocument();
   });
 
-  it('shows an error state with a retry when a stage fetch fails', async () => {
-    mockGetStageMatches.mockRejectedValue(new Error('boom'));
+  it('shows an error state with a retry when the stages fetch fails', async () => {
+    mockGetAllWorldCupStages.mockRejectedValue(new Error('boom'));
     renderTab();
     expect(await screen.findByText(/Failed to fetch matches/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
   });
 
-  it('shows the empty state when no stage returns matches', async () => {
-    mockGetStageMatches.mockResolvedValue({ games: [], count: 0, cached: false });
+  it('shows the empty state when the tournament returns no matches', async () => {
+    mockGetAllWorldCupStages.mockResolvedValue({ games: [], count: 0, cached: false });
     renderTab();
     expect(await screen.findByText('No matches found for this tournament.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit Picks' })).not.toBeInTheDocument();

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -4,13 +4,12 @@ import EmptyState from '../../designsystem/components/EmptyState';
 import InlineToast from '../../designsystem/components/InlineToast';
 import type { ToastVariant } from '../../designsystem/components/InlineToast/InlineToast';
 import {
-  WORLD_CUP_STAGES,
   type MatchPick,
   type MatchPickResult,
   type WorldCupMatch,
 } from '../../lib/types';
 import {
-  getStageMatches,
+  getAllWorldCupStages,
   submitWorldCupPicks,
   getMyWorldCupPicks,
   getUserWorldCupPicks,
@@ -145,10 +144,10 @@ export default function WorldCupPicksTab({
     if (isCold) setFetchState((s) => ({ ...s, loading: true, error: '' }));
     (async () => {
       try {
-        // Fetch every stage in parallel and flatten into one list; the browse list handles ordering/grouping.
-        const responses = await Promise.all(WORLD_CUP_STAGES.map((stage) => getStageMatches(stage)));
+        // One request for the whole tournament; the browse list handles ordering/grouping.
+        const resp = await getAllWorldCupStages();
         if (cancelled) return;
-        const matches = responses.flatMap((r) => (Array.isArray(r?.games) ? r.games : []));
+        const matches = Array.isArray(resp?.games) ? resp.games : [];
         writeCache(wcCacheKeys.stages, matches);
         setFetchState({ loading: false, error: '', matches });
       } catch (err) {
@@ -179,8 +178,8 @@ export default function WorldCupPicksTab({
   // events into the rows (and their timelines) while a match is live.
   const refreshMatchesSilently = useCallback(async () => {
     try {
-      const responses = await Promise.all(WORLD_CUP_STAGES.map((stage) => getStageMatches(stage)));
-      const matches = responses.flatMap((r) => (Array.isArray(r?.games) ? r.games : []));
+      const resp = await getAllWorldCupStages();
+      const matches = Array.isArray(resp?.games) ? resp.games : [];
       // Keep the cache current so a tab switch mid-tournament re-seeds from the
       // latest scores/statuses, not a stale pre-kickoff slate.
       writeCache(wcCacheKeys.stages, matches);

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -17,6 +17,7 @@ import {
   submitUserWorldCupPicks,
 } from '../../lib/worldCupService.js';
 import { getMyGroups } from '../../lib/groupsService.js';
+import { peekCache, writeCache, wcCacheKeys } from '../../lib/worldCupCache';
 import { pollIntervalFor } from '../../lib/matchPolling';
 import SaveTargetsDropdown, { type SaveTarget } from '../../components/SaveTargetsDropdown';
 import PickPersonSelector, { type PickPersonOption } from '../../components/PickPersonSelector';
@@ -115,10 +116,16 @@ export default function WorldCupPicksTab({
     : personOptions.find((m) => m.id === selectedUserId)?.name ?? 'this member';
   const selectedFirstName = selectedName.split(' ')[0];
 
+  // Seed the match slate from cache so re-entering the Picks tab (or revisiting
+  // the group) paints the tournament instantly instead of blanking behind the
+  // seven-stage fetch. The stage schedule is tournament-global, so the cache key
+  // isn't group-scoped; live scores/statuses are reconciled by the fetch below
+  // and the background poll.
+  const cachedStages = peekCache<WorldCupMatch[]>(wcCacheKeys.stages);
   const [fetchState, setFetchState] = useState<FetchState>({
     loading: false,
     error: '',
-    matches: [],
+    matches: cachedStages ?? [],
   });
   const [draft, setDraft] = useState<DraftMap>({});
   const [submitting, setSubmitting] = useState(false);
@@ -132,20 +139,29 @@ export default function WorldCupPicksTab({
 
   useEffect(() => {
     let cancelled = false;
-    setFetchState((s) => ({ ...s, loading: true, error: '' }));
+    // Only show the blocking "Loading matches…" state on a cold load. With a warm
+    // cache the slate is already on screen, so this fetch just revalidates it.
+    const isCold = peekCache(wcCacheKeys.stages) === undefined;
+    if (isCold) setFetchState((s) => ({ ...s, loading: true, error: '' }));
     (async () => {
       try {
         // Fetch every stage in parallel and flatten into one list; the browse list handles ordering/grouping.
         const responses = await Promise.all(WORLD_CUP_STAGES.map((stage) => getStageMatches(stage)));
         if (cancelled) return;
         const matches = responses.flatMap((r) => (Array.isArray(r?.games) ? r.games : []));
+        writeCache(wcCacheKeys.stages, matches);
         setFetchState({ loading: false, error: '', matches });
       } catch (err) {
         if (cancelled) return;
+        // Keep the cached slate on a failed revalidate; only surface the error
+        // when there was nothing to show.
         setFetchState((s) => ({
           ...s,
           loading: false,
-          error: `Failed to fetch matches: ${err instanceof Error ? err.message : 'unknown error'}`,
+          error:
+            peekCache(wcCacheKeys.stages) === undefined
+              ? `Failed to fetch matches: ${err instanceof Error ? err.message : 'unknown error'}`
+              : s.error,
         }));
       }
     })();
@@ -165,6 +181,9 @@ export default function WorldCupPicksTab({
     try {
       const responses = await Promise.all(WORLD_CUP_STAGES.map((stage) => getStageMatches(stage)));
       const matches = responses.flatMap((r) => (Array.isArray(r?.games) ? r.games : []));
+      // Keep the cache current so a tab switch mid-tournament re-seeds from the
+      // latest scores/statuses, not a stale pre-kickoff slate.
+      writeCache(wcCacheKeys.stages, matches);
       setFetchState((s) => ({ ...s, matches }));
     } catch {
       // Keep the existing slate; the next tick retries.

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -7,7 +7,10 @@ import type {
   GroupMember,
   GroupMessage,
 } from '../lib/groupsService';
-import type { WorldCupMatch, WorldCupStage } from '../lib/types';
+import type { WorldCupMatch } from '../lib/types';
+// Real (unmocked) cache module: the page now prefetches the WC leaderboard into
+// it, and the WC tabs seed from it, so clear it per case to stop cross-test leaks.
+import { clearWorldCupCache, peekCache, wcCacheKeys } from '../lib/worldCupCache';
 
 // Mock the groups service so the three mount fetches are controllable per test
 // without touching the network or auth tokens.
@@ -38,7 +41,7 @@ vi.mock('../lib/picksService.js', () => ({
 // control every fetch without a network call; the real components render.
 vi.mock('../lib/worldCupService.js', () => ({
   getWorldCupLeaderboard: vi.fn(),
-  getStageMatches: vi.fn(),
+  getAllWorldCupStages: vi.fn(),
   submitWorldCupPicks: vi.fn(),
   getMyWorldCupPicks: vi.fn(),
 }));
@@ -75,7 +78,7 @@ import {
 import { getClosestWeek, getPickSeasons, getScoreboard } from '../lib/picksService.js';
 import {
   getWorldCupLeaderboard,
-  getStageMatches,
+  getAllWorldCupStages,
   getMyWorldCupPicks,
 } from '../lib/worldCupService.js';
 const mockGetGroup = vi.mocked(getGroup);
@@ -88,7 +91,7 @@ const mockGetClosestWeek = vi.mocked(getClosestWeek);
 const mockGetPickSeasons = vi.mocked(getPickSeasons);
 const mockGetScoreboard = vi.mocked(getScoreboard);
 const mockGetWorldCupLeaderboard = vi.mocked(getWorldCupLeaderboard);
-const mockGetStageMatches = vi.mocked(getStageMatches);
+const mockGetAllWorldCupStages = vi.mocked(getAllWorldCupStages);
 const mockGetMyWorldCupPicks = vi.mocked(getMyWorldCupPicks);
 
 const ownerGroup: GroupDetail = {
@@ -144,6 +147,7 @@ function renderPage(query = '?group=sunday-squad') {
 describe('GroupDetailsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearWorldCupCache();
     // Hold the picks fetch open so the picks tab stays in its loading state for
     // the tab-switching assertions (this suite covers navigation, not picks data).
     mockGetClosestWeek.mockReturnValue(new Promise(() => {}));
@@ -168,10 +172,32 @@ describe('GroupDetailsPage', () => {
     expect(
       await screen.findByRole('heading', { name: ownerGroup.name })
     ).toBeInTheDocument();
-    // All three mount fetches run with the query-string identifier.
+    // The shell fetch is now just group + members; messages are lazy-loaded when
+    // the Chat tab opens, so getMessages must NOT fire on mount.
     expect(mockGetGroup).toHaveBeenCalledWith('sunday-squad');
     expect(mockGetMembers).toHaveBeenCalledWith('sunday-squad');
-    expect(mockGetMessages).toHaveBeenCalledWith('sunday-squad');
+    expect(mockGetMessages).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch chat messages until the Chat tab is opened', async () => {
+    mockGetGroup.mockResolvedValue(ownerGroup);
+    mockGetMembers.mockResolvedValue(members);
+    mockGetMessages.mockResolvedValue(messages);
+
+    renderPage();
+    await screen.findByRole('heading', { name: ownerGroup.name });
+
+    // Sitting on the default Leaderboard tab, chat history stays unfetched.
+    expect(mockGetMessages).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
+    await screen.findByText('Welcome!');
+    expect(mockGetMessages).toHaveBeenCalledTimes(1);
+
+    // Re-opening Chat reuses the already-loaded history — no refetch.
+    fireEvent.click(screen.getByRole('tab', { name: /leaderboard/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
+    expect(mockGetMessages).toHaveBeenCalledTimes(1);
   });
 
   it('shows the Owner badge for an admin and switches between tab bodies', async () => {
@@ -192,8 +218,10 @@ describe('GroupDetailsPage', () => {
     expect(screen.getByText('Loading picks…')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
-    // ChatTab renders the seeded messages passed from the page mount.
-    expect(screen.getByText('Welcome!')).toBeInTheDocument();
+    // ChatTab now lazy-loads its history on first open, so the message appears
+    // after the fetch resolves rather than synchronously.
+    expect(await screen.findByText('Welcome!')).toBeInTheDocument();
+    expect(mockGetMessages).toHaveBeenCalledWith('sunday-squad');
 
     fireEvent.click(screen.getByRole('tab', { name: /settings/i }));
     // SettingsTab leads with the Members roster section.
@@ -303,10 +331,7 @@ describe('GroupDetailsPage', () => {
       // pickable whenever CI runs.
       gameDate: (() => { const d = new Date(); d.setHours(23, 59, 59, 999); return d.toISOString(); })(),
     };
-    const stageResponder = (stage: WorldCupStage) => {
-      const games = stage === 'group' ? [wcMatch] : [];
-      return Promise.resolve({ games, count: games.length, cached: false });
-    };
+    const stagesResponse = { games: [wcMatch], count: 1, cached: false };
 
     beforeEach(() => {
       mockGetGroup.mockResolvedValue(worldCupGroup);
@@ -347,9 +372,36 @@ describe('GroupDetailsPage', () => {
       expect(within(screen.getByRole('table')).getByText('Alice')).toBeInTheDocument();
     });
 
+    it('prefetches the World Cup leaderboard into the cache during the shell load', async () => {
+      const lbRows = [
+        {
+          userId: 1,
+          name: 'Alice',
+          pictureUrl: null,
+          rank: 1,
+          tied: false,
+          points: 12,
+          wins_correct: 4,
+          losses: 1,
+          draws_correct: 2,
+          draws_incorrect: 1,
+        },
+      ];
+      mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: lbRows });
+
+      renderPage();
+      await screen.findByRole('heading', { name: worldCupGroup.name });
+
+      // The parallel prefetch warms the per-group cache so the Leaderboard tab
+      // paints from it instead of waterfalling its own fetch after the shell.
+      await waitFor(() =>
+        expect(peekCache(wcCacheKeys.leaderboard('sunday-squad'))).toEqual(lbRows),
+      );
+    });
+
     it('embeds the World Cup pick-making surface on the Picks tab', async () => {
       mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
-      mockGetStageMatches.mockImplementation(stageResponder);
+      mockGetAllWorldCupStages.mockResolvedValue(stagesResponse);
       mockGetMyWorldCupPicks.mockResolvedValue({ picks: [] });
       mockGetMyGroups.mockResolvedValue([
         { id: 1, identifier: 'sunday-squad', name: 'World Cup Squad', poolType: 'world_cup_2026' },
@@ -379,7 +431,7 @@ describe('GroupDetailsPage', () => {
 
     it('shows the save bar on the Picks tab and removes it when switching away', async () => {
       mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
-      mockGetStageMatches.mockImplementation(stageResponder);
+      mockGetAllWorldCupStages.mockResolvedValue(stagesResponse);
       mockGetMyWorldCupPicks.mockResolvedValue({ picks: [] });
       mockGetMyGroups.mockResolvedValue([
         { id: 1, identifier: 'sunday-squad', name: 'World Cup Squad', poolType: 'world_cup_2026' },
@@ -455,8 +507,8 @@ describe('GroupDetailsPage', () => {
 
       fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
 
-      // Chat content renders, the dot disappears, and the read marker persists.
-      expect(screen.getByText('Welcome!')).toBeInTheDocument();
+      // Chat content lazy-loads, the dot disappears, and the read marker persists.
+      expect(await screen.findByText('Welcome!')).toBeInTheDocument();
       expect(screen.queryByTestId('chat-unread-indicator')).not.toBeInTheDocument();
       expect(mockMarkMessagesRead).toHaveBeenCalledWith('sunday-squad');
     });
@@ -470,7 +522,7 @@ describe('GroupDetailsPage', () => {
 
       fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
 
-      expect(screen.getByText('Welcome!')).toBeInTheDocument();
+      expect(await screen.findByText('Welcome!')).toBeInTheDocument();
       expect(mockMarkMessagesRead).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -3,6 +3,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { getGroup, getMembers, getMessages, getUnreadStatus, markMessagesRead } from '../lib/groupsService.js';
 import type { GroupDetail, GroupMember, GroupMessage } from '../lib/groupsService';
+import { getWorldCupLeaderboard } from '../lib/worldCupService.js';
+import { writeCache, wcCacheKeys } from '../lib/worldCupCache';
 import Button from '../designsystem/components/Button';
 import PageContainer from '../designsystem/components/PageContainer';
 import Spinner from '../designsystem/components/Spinner';
@@ -66,7 +68,6 @@ export default function GroupDetailsPage() {
 
   const [group, setGroup] = useState<GroupDetail | null>(null);
   const [members, setMembers] = useState<GroupMember[]>([]);
-  const [messages, setMessages] = useState<GroupMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabKey>('leaderboard');
@@ -74,6 +75,12 @@ export default function GroupDetailsPage() {
   // (a failure here must not collapse the whole page into the Not Found UI), and
   // cleared the moment the user opens the chat.
   const [hasUnreadChat, setHasUnreadChat] = useState(false);
+  // Chat messages are lazy-loaded the first time the Chat tab opens (see
+  // ensureMessagesLoaded) rather than eagerly on mount — Chat isn't the default
+  // tab, so fetching its history up front only delayed the leaderboard.
+  const [messages, setMessages] = useState<GroupMessage[]>([]);
+  const [messagesLoaded, setMessagesLoaded] = useState(false);
+  const [messagesLoading, setMessagesLoading] = useState(false);
 
   useEffect(() => {
     if (!identifier) return;
@@ -86,17 +93,34 @@ export default function GroupDetailsPage() {
       setLoading(true);
       setError(null);
       try {
-        // Promise.all so a failure in ANY branch surfaces ONE error UI, never
-        // three. Mirrors the GroupsPage/EditGroupPage cancelled-guard pattern.
-        const [groupResp, membersResp, messagesResp] = await Promise.all([
-          getGroup(id),
-          getMembers(id),
-          getMessages(id),
-        ]);
+        const groupPromise = getGroup(id);
+
+        // Break the waterfall: the moment we know this is a World Cup pool, warm
+        // the leaderboard cache IN PARALLEL with the rest of the shell. The
+        // default Leaderboard tab seeds from that cache, so it paints the instant
+        // it mounts instead of starting its own fetch only after the shell
+        // resolves. Best-effort — a failure just falls back to a cold tab fetch.
+        groupPromise
+          .then((g) => {
+            if (g?.poolType === 'world_cup_2026') {
+              getWorldCupLeaderboard(id)
+                .then((resp) =>
+                  writeCache(
+                    wcCacheKeys.leaderboard(id),
+                    Array.isArray(resp?.leaderboard) ? resp.leaderboard : [],
+                  ),
+                )
+                .catch(() => {});
+            }
+          })
+          .catch(() => {});
+
+        // Promise.all so a failure in either branch surfaces ONE error UI, never
+        // two. getMessages is no longer here — Chat loads on demand.
+        const [groupResp, membersResp] = await Promise.all([groupPromise, getMembers(id)]);
         if (!cancelled) {
           setGroup(groupResp);
           setMembers(membersResp);
-          setMessages(messagesResp);
         }
       } catch (err) {
         if (!cancelled) {
@@ -162,14 +186,32 @@ export default function GroupDetailsPage() {
     );
   }
 
-  // Switch tabs; opening Chat clears the unread dot and marks the chat read
-  // server-side (fire-and-forget — the local clear is what the user sees, and a
-  // failed write just means the dot reappears on the next visit).
+  // Lazy-load the chat history the first time Chat is opened. A failed fetch
+  // soft-falls to an empty thread (the user can still post) rather than blocking
+  // the tab — chat history is non-critical to the rest of the page.
+  function ensureMessagesLoaded() {
+    if (messagesLoaded || messagesLoading || !identifier) return;
+    setMessagesLoading(true);
+    getMessages(identifier)
+      .then((msgs) => setMessages(msgs))
+      .catch(() => setMessages([]))
+      .finally(() => {
+        setMessagesLoaded(true);
+        setMessagesLoading(false);
+      });
+  }
+
+  // Switch tabs; opening Chat lazy-loads its history, clears the unread dot, and
+  // marks the chat read server-side (fire-and-forget — the local clear is what
+  // the user sees, and a failed write just means the dot reappears next visit).
   function handleSelectTab(key: TabKey) {
     setActiveTab(key);
-    if (key === 'chat' && hasUnreadChat && identifier) {
-      setHasUnreadChat(false);
-      markMessagesRead(identifier).catch(() => {});
+    if (key === 'chat') {
+      ensureMessagesLoaded();
+      if (hasUnreadChat && identifier) {
+        setHasUnreadChat(false);
+        markMessagesRead(identifier).catch(() => {});
+      }
     }
   }
 
@@ -280,9 +322,14 @@ export default function GroupDetailsPage() {
           ) : (
             <PicksTab identifier={identifier} members={members} />
           ))}
-        {activeTab === 'chat' && (
-          <ChatTab identifier={identifier} initialMessages={messages} />
-        )}
+        {activeTab === 'chat' &&
+          (messagesLoaded ? (
+            <ChatTab identifier={identifier} initialMessages={messages} />
+          ) : (
+            <div className="flex justify-center py-12">
+              <Spinner size="md" label="Loading chat..." />
+            </div>
+          ))}
         {activeTab === 'settings' && (
           <SettingsTab
             group={group}

--- a/frontend/src/pages/WorldCupPicksPage.test.tsx
+++ b/frontend/src/pages/WorldCupPicksPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import WorldCupPicksPage from './WorldCupPicksPage';
-import type { WorldCupMatch, WorldCupStage } from '../lib/types';
+import type { WorldCupMatch } from '../lib/types';
 
 // The page is a thin shell around WorldCupPicksTab (which owns the stage list,
 // draft state, and sticky submit bar — see WorldCupPicksTab.test.tsx for that
@@ -10,7 +10,7 @@ import type { WorldCupMatch, WorldCupStage } from '../lib/types';
 // and the heading + embedded surface when a group is present.
 
 vi.mock('../lib/worldCupService.js', () => ({
-  getStageMatches: vi.fn(),
+  getAllWorldCupStages: vi.fn(),
   submitWorldCupPicks: vi.fn(),
   getMyWorldCupPicks: vi.fn(),
 }));
@@ -18,9 +18,9 @@ vi.mock('../lib/groupsService.js', () => ({
   getMyGroups: vi.fn(),
 }));
 
-import { getStageMatches, getMyWorldCupPicks } from '../lib/worldCupService.js';
+import { getAllWorldCupStages, getMyWorldCupPicks } from '../lib/worldCupService.js';
 import { getMyGroups } from '../lib/groupsService.js';
-const mockGetStageMatches = vi.mocked(getStageMatches);
+const mockGetAllWorldCupStages = vi.mocked(getAllWorldCupStages);
 const mockGetMyWorldCupPicks = vi.mocked(getMyWorldCupPicks);
 const mockGetMyGroups = vi.mocked(getMyGroups);
 
@@ -52,10 +52,7 @@ function renderPage(route = '/world-cup?group=la-crew') {
 describe('WorldCupPicksPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetStageMatches.mockImplementation((stage: WorldCupStage) => {
-      const games = stage === 'group' ? [groupMatch] : [];
-      return Promise.resolve({ games, count: games.length, cached: false });
-    });
+    mockGetAllWorldCupStages.mockResolvedValue({ games: [groupMatch], count: 1, cached: false });
     mockGetMyGroups.mockResolvedValue([
       { id: 1, identifier: 'la-crew', name: 'LA Crew', poolType: 'world_cup_2026' },
     ] as any);
@@ -67,7 +64,7 @@ describe('WorldCupPicksPage', () => {
     expect(screen.getByText('Group Not Found')).toBeInTheDocument();
     expect(screen.queryByText('World Cup 2026 Picks')).not.toBeInTheDocument();
     // The picks surface never mounts, so no stage fetch fires.
-    expect(mockGetStageMatches).not.toHaveBeenCalled();
+    expect(mockGetAllWorldCupStages).not.toHaveBeenCalled();
   });
 
   it('renders the page heading with the embedded picks surface for a group', async () => {
@@ -85,6 +82,6 @@ describe('WorldCupPicksPage', () => {
       }),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Submit Picks' })).toBeInTheDocument();
-    expect(mockGetStageMatches).toHaveBeenCalledTimes(7);
+    expect(mockGetAllWorldCupStages).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/tests/e2e/world-cup-live-clock.spec.ts
+++ b/frontend/tests/e2e/world-cup-live-clock.spec.ts
@@ -37,42 +37,38 @@ test('world cup picks page shows the live minute mark on the card and in the det
     route.fulfill({ json: { venue: null, stats: [], lineups: null } }),
   )
 
-  // Stub the per-stage endpoint. Only the group stage returns the live match;
-  // every other stage returns an empty list so the match renders exactly once.
-  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
-    const isGroup = route.request().url().includes('/stage/group')
-    const games = isGroup
-      ? [
-          {
-            id: 301,
-            espnId: '760603',
-            stage: 'group',
-            isKnockout: false,
-            status: 'IN_PROGRESS',
-            homeScore: 1,
-            awayScore: 0,
-            // Kicked off ~70 minutes ago; the Live view filters purely on status.
-            gameDate: new Date(Date.now() - 70 * 60 * 1000).toISOString(),
-            winnerTeamId: null,
-            // ESPN live-match progress fields, parsed by the backend and persisted.
-            displayClock: "63'",
-            statusDetail: '2nd Half',
-            period: 2,
-            homeTeam: {
-              id: '1',
-              name: 'Argentina',
-              abbreviation: 'ARG',
-              logo: 'https://example.test/arg.png',
-            },
-            awayTeam: {
-              id: '2',
-              name: 'France',
-              abbreviation: 'FRA',
-              logo: 'https://example.test/fra.png',
-            },
-          },
-        ]
-      : []
+  // Stub the whole-tournament endpoint (GET .../stages) with the single live match.
+  await page.route('**/api/games/world-cup-2026/stages', async (route) => {
+    const games = [
+      {
+        id: 301,
+        espnId: '760603',
+        stage: 'group',
+        isKnockout: false,
+        status: 'IN_PROGRESS',
+        homeScore: 1,
+        awayScore: 0,
+        // Kicked off ~70 minutes ago; the Live view filters purely on status.
+        gameDate: new Date(Date.now() - 70 * 60 * 1000).toISOString(),
+        winnerTeamId: null,
+        // ESPN live-match progress fields, parsed by the backend and persisted.
+        displayClock: "63'",
+        statusDetail: '2nd Half',
+        period: 2,
+        homeTeam: {
+          id: '1',
+          name: 'Argentina',
+          abbreviation: 'ARG',
+          logo: 'https://example.test/arg.png',
+        },
+        awayTeam: {
+          id: '2',
+          name: 'France',
+          abbreviation: 'FRA',
+          logo: 'https://example.test/fra.png',
+        },
+      },
+    ]
     await route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/frontend/tests/e2e/world-cup-needs-pick-knockout.spec.ts
+++ b/frontend/tests/e2e/world-cup-needs-pick-knockout.spec.ts
@@ -38,10 +38,12 @@ async function seed(page: import('@playwright/test').Page) {
     const payload = { userId: 1, email: 'ada@example.com', name: 'Ada Lovelace', pictureUrl: null, exp: 9999999999 }
     localStorage.setItem('accessToken', `header.${btoa(JSON.stringify(payload))}.sig`)
   })
-  // Catch-all so nothing escapes to a real backend; the stage stub wins (registered last).
+  // Catch-all so nothing escapes to a real backend; the stages stub wins (registered last).
   await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
-  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
-    const games = route.request().url().includes('/stage/r32') ? [decidedGame, undecidedGame] : []
+  // The tab now pulls the whole tournament in one request (GET .../stages), so the
+  // stub returns the full flat slate rather than per-stage subsets.
+  await page.route('**/api/games/world-cup-2026/stages', async (route) => {
+    const games = [decidedGame, undecidedGame]
     await route.fulfill({ json: { games, count: games.length, cached: false } })
   })
   await page.goto('/world-cup?group=test-group')

--- a/frontend/tests/e2e/world-cup-picks-person-selector.spec.ts
+++ b/frontend/tests/e2e/world-cup-picks-person-selector.spec.ts
@@ -66,26 +66,23 @@ async function stubGroup(page: Page, userRole: 'admin' | 'member') {
   })
 }
 
-// One group-stage match; every other stage is empty so it renders exactly once.
+// One group-stage match, served via the single whole-tournament endpoint.
 async function stubStages(page: Page) {
-  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
-    const isGroup = route.request().url().includes('/stage/group')
-    const games = isGroup
-      ? [
-          {
-            id: 101,
-            stage: 'group',
-            isKnockout: false,
-            status: 'SCHEDULED',
-            homeScore: 0,
-            awayScore: 0,
-            gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-            winnerTeamId: null,
-            homeTeam: { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: 'https://example.test/mex.png' },
-            awayTeam: { id: '2', name: 'Canada', abbreviation: 'CAN', logo: 'https://example.test/can.png' },
-          },
-        ]
-      : []
+  await page.route('**/api/games/world-cup-2026/stages', async (route) => {
+    const games = [
+      {
+        id: 101,
+        stage: 'group',
+        isKnockout: false,
+        status: 'SCHEDULED',
+        homeScore: 0,
+        awayScore: 0,
+        gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        winnerTeamId: null,
+        homeTeam: { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: 'https://example.test/mex.png' },
+        awayTeam: { id: '2', name: 'Canada', abbreviation: 'CAN', logo: 'https://example.test/can.png' },
+      },
+    ]
     await route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/frontend/tests/e2e/world-cup-picks-renders.spec.ts
+++ b/frontend/tests/e2e/world-cup-picks-renders.spec.ts
@@ -1,14 +1,12 @@
 import { test, expect } from '@playwright/test'
 
-// WorldCupPicksPage sits behind ProtectedRoute and renders a stage-grouped match
-// list. It fetches every WORLD_CUP_STAGES entry in parallel via
-// worldCupService.getStageMatches -> GET ${apiBaseUrl}/api/games/world-cup-2026/stage/<stage>.
+// WorldCupPicksPage sits behind ProtectedRoute and renders a flat match list. It
+// pulls the whole tournament in one request via
+// worldCupService.getAllWorldCupStages -> GET ${apiBaseUrl}/api/games/world-cup-2026/stages.
 // We seed a valid, far-future JWT-shaped accessToken in localStorage (same
 // pattern as profile-page-shows-user.spec.ts) so AuthProvider treats us as
-// authenticated and ProtectedRoute lets /world-cup through, then stub the stage
-// endpoint: only the group-stage request returns the synthetic match (the other
-// six stages return an empty list) so the single match renders once with no
-// duplicate React keys.
+// authenticated and ProtectedRoute lets /world-cup through, then stub the stages
+// endpoint with the synthetic match slate.
 //
 // Route coverage: the live App route is '/world-cup' (see App.tsx), which is
 // what we navigate below. check-page-spec-coverage.mjs, however, derives the
@@ -37,64 +35,56 @@ test('world cup picks page renders the stage match list with pick buttons', asyn
   // precedence — the specific stage stub below must win over this catch-all.
   await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
 
-  // Stub the per-stage endpoint. The page fetches all seven stages; the group
-  // request returns the playable match, the r32 request returns a knockout
-  // fixture whose away slot is still ESPN's TBD placeholder, and every other
-  // stage returns an empty list so each match renders exactly once.
-  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
-    const url = route.request().url()
-    let games: object[] = []
-    if (url.includes('/stage/group')) {
-      games = [
-        {
-          id: 101,
-          stage: 'group',
-          isKnockout: false,
-          status: 'SCHEDULED',
-          homeScore: 0,
-          awayScore: 0,
-          gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-          winnerTeamId: null,
-          homeTeam: {
-            id: '1',
-            name: 'Mexico',
-            abbreviation: 'MEX',
-            logo: 'https://example.test/mex.png',
-          },
-          awayTeam: {
-            id: '2',
-            name: 'Canada',
-            abbreviation: 'CAN',
-            logo: 'https://example.test/can.png',
-          },
+  // Stub the whole-tournament endpoint (GET .../stages). It returns the full flat
+  // slate in one request: the playable group match plus an r32 knockout fixture
+  // whose away slot is still ESPN's TBD placeholder.
+  await page.route('**/api/games/world-cup-2026/stages', async (route) => {
+    const games = [
+      {
+        id: 101,
+        stage: 'group',
+        isKnockout: false,
+        status: 'SCHEDULED',
+        homeScore: 0,
+        awayScore: 0,
+        gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        winnerTeamId: null,
+        homeTeam: {
+          id: '1',
+          name: 'Mexico',
+          abbreviation: 'MEX',
+          logo: 'https://example.test/mex.png',
         },
-      ]
-    } else if (url.includes('/stage/r32')) {
-      games = [
-        {
-          id: 201,
-          stage: 'r32',
-          isKnockout: true,
-          status: 'SCHEDULED',
-          homeScore: 0,
-          awayScore: 0,
-          gameDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
-          winnerTeamId: null,
-          homeTeam: {
-            id: '3',
-            name: 'France',
-            abbreviation: 'FRA',
-            logo: 'https://example.test/fra.png',
-          },
-          awayTeam: {
-            id: 'tbd-1',
-            name: 'TBD',
-            abbreviation: 'TBD',
-            logo: '',
-          },
+        awayTeam: {
+          id: '2',
+          name: 'Canada',
+          abbreviation: 'CAN',
+          logo: 'https://example.test/can.png',
         },
-      ]
-    }
+      },
+      {
+        id: 201,
+        stage: 'r32',
+        isKnockout: true,
+        status: 'SCHEDULED',
+        homeScore: 0,
+        awayScore: 0,
+        gameDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        winnerTeamId: null,
+        homeTeam: {
+          id: '3',
+          name: 'France',
+          abbreviation: 'FRA',
+          logo: 'https://example.test/fra.png',
+        },
+        awayTeam: {
+          id: 'tbd-1',
+          name: 'TBD',
+          abbreviation: 'TBD',
+          logo: '',
+        },
+      },
+    ]
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -197,36 +187,33 @@ test('makes world cup picks inline on the group detail Picks tab', async ({ page
     })
   })
 
-  // Same per-stage stub as the page-level test: the group stage returns one match,
-  // every other stage returns an empty list so the match renders exactly once.
-  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
-    const isGroup = route.request().url().includes('/stage/group')
-    const games = isGroup
-      ? [
-          {
-            id: 101,
-            stage: 'group',
-            isKnockout: false,
-            status: 'SCHEDULED',
-            homeScore: 0,
-            awayScore: 0,
-            gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-            winnerTeamId: null,
-            homeTeam: {
-              id: '1',
-              name: 'Mexico',
-              abbreviation: 'MEX',
-              logo: 'https://example.test/mex.png',
-            },
-            awayTeam: {
-              id: '2',
-              name: 'Canada',
-              abbreviation: 'CAN',
-              logo: 'https://example.test/can.png',
-            },
-          },
-        ]
-      : []
+  // Same single-request stub as the page-level test: the whole-tournament endpoint
+  // returns the one group match.
+  await page.route('**/api/games/world-cup-2026/stages', async (route) => {
+    const games = [
+      {
+        id: 101,
+        stage: 'group',
+        isKnockout: false,
+        status: 'SCHEDULED',
+        homeScore: 0,
+        awayScore: 0,
+        gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        winnerTeamId: null,
+        homeTeam: {
+          id: '1',
+          name: 'Mexico',
+          abbreviation: 'MEX',
+          logo: 'https://example.test/mex.png',
+        },
+        awayTeam: {
+          id: '2',
+          name: 'Canada',
+          abbreviation: 'CAN',
+          logo: 'https://example.test/can.png',
+        },
+      },
+    ]
     await route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/frontend/tests/e2e/world-cup-sticky-filters.spec.ts
+++ b/frontend/tests/e2e/world-cup-sticky-filters.spec.ts
@@ -41,9 +41,9 @@ async function seed(page: import('@playwright/test').Page) {
     localStorage.setItem('accessToken', `header.${btoa(JSON.stringify(payload))}.sig`)
   })
   await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
-  await page.route('**/api/games/world-cup-2026/stage/**', async (route) => {
-    const list = route.request().url().includes('/stage/group') ? games : []
-    await route.fulfill({ json: { games: list, count: list.length, cached: false } })
+  // One request for the whole tournament (GET .../stages) → return the full slate.
+  await page.route('**/api/games/world-cup-2026/stages', async (route) => {
+    await route.fulfill({ json: { games, count: games.length, cached: false } })
   })
   await page.goto('/world-cup?group=test-group')
   await expect(page.getByRole('heading', { name: 'World Cup 2026 Picks' })).toBeVisible()


### PR DESCRIPTION
Follow-ups to the World Cup tab caching work, targeting the remaining **cold-load** latency on the Leaderboard and Picks tabs.

> [!NOTE]
> **Heads up:** the SWR cache commit (`worldCupCache.ts` + the two tabs seeding from it) was pushed to the PR #137 branch *after* that PR merged, so it never actually landed on `main`. This PR includes it (first commit, cherry-picked) so the cache + these two follow-ups land together. If you've since merged it another way, the cherry-pick will no-op on rebase.

## 1. Collapse the seven-stage fan-out into one round-trip

The Picks tab fetched **seven** `/stage/:stage` endpoints on every cold mount. Now it's a single request.

- **Backend:** `GameService.getAllWorldCupStages(forceRefresh)` `Promise.all`s the seven `getWorldCupStage` reads server-side and flattens them in calendar order — the per-stage DB cache and live-refresh rules are unchanged. Exposed at `GET /api/games/world-cup-2026/stages` (same `{ games, count, cached }` shape, with the grafted knockout `winnerTeamId`), registered before the NFL `/:year/...` param route like the other literal world-cup routes.
- **Frontend:** `getAllWorldCupStages()` replaces `Promise.all(WORLD_CUP_STAGES.map(getStageMatches))` in `WorldCupPicksTab` for both the initial fetch and the live-poll silent refresh. `getStageMatches` stays exported for single-stage callers.

## 2. Break the `GroupDetailsPage` shell waterfall

The page used to gate first render on `Promise.all([getGroup, getMembers, getMessages])`, and the leaderboard fetch couldn't start until that resolved.

- **Lazy chat:** the blocking fetch is now just `[getGroup, getMembers]`. `getMessages` is dropped from the critical path and lazy-loaded the first time the Chat tab opens (`ensureMessagesLoaded`, fetch-once, spinner until loaded). Chat history no longer delays first paint.
- **Parallel leaderboard prefetch:** for `world_cup_2026` pools, the moment `getGroup` resolves and the pool type is known, the page fires `getWorldCupLeaderboard` and writes it into the SWR cache. The default Leaderboard tab seeds from that cache and paints **instantly** instead of waterfalling its fetch after the shell. (The tab still revalidates on mount — one extra background call, by SWR design.)

## Tests
- **Backend:** `tests/api-worldcup-route.test.js` covers the new `/stages` route (flattened multi-stage payload + knockout `winnerTeamId`).
- **Frontend:** the WC page/tab tests now mock `getAllWorldCupStages`; `GroupDetailsPage.test.tsx` covers lazy chat-message loading (no `getMessages` on mount, fetch-once on open) and the parallel leaderboard prefetch warming the cache.
- Full frontend suite **714 passing**, build clean. Backend route tests green — the only backend failures (`db-init`, `routes`) are pre-existing and environment-only (no Postgres in CI sandbox); they fail identically with these changes stashed.

## Net effect
A cold Picks load goes from **7 requests → 1**, and the World Cup Leaderboard (the default tab) paints from a cache warmed in parallel with the page shell rather than after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzkHCbD4uZWEmSVzSAVahC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzkHCbD4uZWEmSVzSAVahC)_