### PR TITLE
Picks-available banner + group-card notification dot (World Cup)

### DIFF
--- a/frontend/src/designsystem/components/Banner/Banner.test.tsx
+++ b/frontend/src/designsystem/components/Banner/Banner.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Banner from './Banner';
+
+describe('Banner', () => {
+  it('renders its message', () => {
+    render(<Banner variant="warning">You have 3 picks to make</Banner>);
+    expect(screen.getByText('You have 3 picks to make')).toBeInTheDocument();
+  });
+
+  it('applies the variant palette', () => {
+    render(<Banner variant="warning">heads up</Banner>);
+    expect(screen.getByRole('status')).toHaveClass('bg-warning-50');
+  });
+
+  it('renders a tappable action and fires its handler', () => {
+    const onClick = vi.fn();
+    render(
+      <Banner variant="warning" action={{ label: 'Make your picks', onClick }}>
+        You have picks to make
+      </Banner>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Make your picks' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the action button when none is given', () => {
+    render(<Banner>just info</Banner>);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/designsystem/components/Banner/Banner.tsx
+++ b/frontend/src/designsystem/components/Banner/Banner.tsx
@@ -1,0 +1,69 @@
+import {
+  InformationCircleIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
+
+export type BannerVariant = 'info' | 'success' | 'warning' | 'error';
+
+export interface BannerAction {
+  /** Link/button text, e.g. "Make your picks". */
+  label: string;
+  /** Click handler — typically a deeplink navigation. */
+  onClick: () => void;
+}
+
+export interface BannerProps {
+  /** Visual tone + leading icon. Defaults to `info`. */
+  variant?: BannerVariant;
+  /** Banner copy. */
+  children: React.ReactNode;
+  /** Optional trailing call-to-action rendered as a tappable link. */
+  action?: BannerAction;
+}
+
+// Subtle, persistent inline-alert palette (border + tinted surface), matching
+// the hand-rolled error block this component generalizes. Distinct from
+// InlineToast's solid, transient toast styling.
+const VARIANT_CLASSES: Record<BannerVariant, string> = {
+  info: 'bg-secondary-50 border-secondary-200 text-secondary-800 dark:bg-secondary-900/40 dark:border-secondary-700 dark:text-secondary-200',
+  success: 'bg-success-50 border-success-200 text-success-800 dark:bg-success-900/20 dark:border-success-800 dark:text-success-200',
+  warning: 'bg-warning-50 border-warning-200 text-warning-800 dark:bg-warning-900/20 dark:border-warning-800 dark:text-warning-200',
+  error: 'bg-error-50 border-error-200 text-error-700 dark:bg-error-900/20 dark:border-error-800 dark:text-error-300',
+};
+
+const VARIANT_ICON: Record<BannerVariant, React.ComponentType<{ className?: string }>> = {
+  info: InformationCircleIcon,
+  success: CheckCircleIcon,
+  warning: ExclamationTriangleIcon,
+  error: ExclamationCircleIcon,
+};
+
+/**
+ * A persistent, full-width inline alert with an icon, a message, and an optional
+ * tappable action. Unlike InlineToast (a transient, auto-dismissing, absolutely
+ * positioned popover), a Banner stays put in the document flow and is meant to
+ * span its container — e.g. a "you have picks to make" notice above a tab bar.
+ */
+export default function Banner({ variant = 'info', children, action }: BannerProps) {
+  const Icon = VARIANT_ICON[variant];
+  return (
+    <div
+      role="status"
+      className={`flex flex-col gap-xs rounded-base border p-md text-sm sm:flex-row sm:items-center sm:gap-sm ${VARIANT_CLASSES[variant]}`}
+    >
+      <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+      <span className="flex-1">{children}</span>
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="self-start whitespace-nowrap font-semibold underline underline-offset-2 hover:no-underline sm:self-auto"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/designsystem/components/Banner/index.ts
+++ b/frontend/src/designsystem/components/Banner/index.ts
@@ -1,0 +1,2 @@
+export { default, default as Banner } from './Banner';
+export type { BannerProps, BannerVariant, BannerAction } from './Banner';

--- a/frontend/src/designsystem/components/GroupCard/GroupCard.test.tsx
+++ b/frontend/src/designsystem/components/GroupCard/GroupCard.test.tsx
@@ -108,6 +108,18 @@ describe('GroupCard', () => {
     });
   });
 
+  describe('picks-available notification dot', () => {
+    it('shows the dot when hasPicksToMake is true', () => {
+      render(<GroupCard group={BASE_GROUP} hasPicksToMake />);
+      expect(screen.getByRole('status', { name: 'Picks available to make' })).toBeInTheDocument();
+    });
+
+    it('hides the dot by default', () => {
+      render(<GroupCard group={BASE_GROUP} />);
+      expect(screen.queryByRole('status', { name: 'Picks available to make' })).toBeNull();
+    });
+  });
+
   describe('member view', () => {
     it('renders Leave Group button for non-owner', () => {
       render(<GroupCard group={MEMBER_GROUP} />);

--- a/frontend/src/designsystem/components/GroupCard/GroupCard.tsx
+++ b/frontend/src/designsystem/components/GroupCard/GroupCard.tsx
@@ -1,6 +1,7 @@
 import Avatar from '../Avatar/Avatar';
 import Button from '../Button/Button';
 import Card from '../Card/Card';
+import NotificationDot from '../NotificationDot/NotificationDot';
 
 export interface GroupData {
   id: string;
@@ -29,6 +30,12 @@ export interface GroupCardProps {
   onLeave?: () => void;
   /** Called when the owner clicks "Delete". */
   onDelete?: () => void;
+  /**
+   * When true, shows a red notification dot (same affordance as the Chat tab's
+   * unread indicator) signalling the viewer has picks waiting to be made in this
+   * group. Computed by the groups list from the pool's open/unpicked matches.
+   */
+  hasPicksToMake?: boolean;
 }
 
 function formatDate(dateString: string): string {
@@ -48,9 +55,17 @@ export default function GroupCard({
   onEdit,
   onLeave,
   onDelete,
+  hasPicksToMake = false,
 }: GroupCardProps) {
   return (
-    <Card padding="lg" className="hover:shadow-md transition-shadow">
+    <Card padding="lg" className="relative hover:shadow-md transition-shadow">
+      {hasPicksToMake && (
+        <NotificationDot
+          size="md"
+          label="Picks available to make"
+          className="absolute right-3 top-3 ring-2 ring-neutral-0 dark:ring-secondary-800"
+        />
+      )}
       {/* Header & Badges: stack on mobile, row on desktop */}
       <div className="flex flex-col mb-4">
         <h3

--- a/frontend/src/designsystem/components/GroupsList/GroupsList.tsx
+++ b/frontend/src/designsystem/components/GroupsList/GroupsList.tsx
@@ -25,6 +25,11 @@ export interface GroupsListProps {
   onRefresh?: () => void;
   /** When false, hides the built-in header and subheader. */
   showHeader?: boolean;
+  /**
+   * Per-group "viewer has picks to make" flags, keyed by group identifier.
+   * A truthy entry surfaces the notification dot on that group's card.
+   */
+  needsPickByGroup?: Record<string, boolean>;
 }
 
 /**
@@ -44,6 +49,7 @@ export default function GroupsList({
   onDeleteGroup,
   onRefresh,
   showHeader = true,
+  needsPickByGroup = {},
 }: GroupsListProps) {
   function handleViewGroup(group: GroupData) {
     onViewGroup?.(group);
@@ -147,6 +153,7 @@ export default function GroupsList({
             <GroupCard
               key={group.id}
               group={group}
+              hasPicksToMake={!!needsPickByGroup[group.identifier]}
               onView={() => handleViewGroup(group)}
               onEdit={() => handleEditGroup(group)}
               onLeave={() => handleLeaveGroup(group)}

--- a/frontend/src/designsystem/components/NotificationDot/NotificationDot.test.tsx
+++ b/frontend/src/designsystem/components/NotificationDot/NotificationDot.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import NotificationDot from './NotificationDot';
+
+describe('NotificationDot', () => {
+  it('exposes its label to assistive tech', () => {
+    render(<NotificationDot label="Picks available to make" />);
+    expect(screen.getByRole('status', { name: 'Picks available to make' })).toBeInTheDocument();
+  });
+
+  it('defaults to the small size and the error color token', () => {
+    render(<NotificationDot label="Unread messages" />);
+    const dot = screen.getByRole('status');
+    expect(dot).toHaveClass('h-2', 'w-2', 'rounded-full', 'bg-error-500');
+  });
+
+  it('renders the medium size when asked', () => {
+    render(<NotificationDot label="Unread messages" size="md" />);
+    expect(screen.getByRole('status')).toHaveClass('h-2.5', 'w-2.5');
+  });
+
+  it('merges positioning classes and a test id', () => {
+    render(
+      <NotificationDot
+        label="Unread messages"
+        className="absolute -top-0.5 -right-1.5"
+        data-testid="chat-unread-indicator"
+      />,
+    );
+    const dot = screen.getByTestId('chat-unread-indicator');
+    expect(dot).toHaveClass('absolute', '-top-0.5', '-right-1.5', 'bg-error-500');
+  });
+});

--- a/frontend/src/designsystem/components/NotificationDot/NotificationDot.tsx
+++ b/frontend/src/designsystem/components/NotificationDot/NotificationDot.tsx
@@ -1,0 +1,48 @@
+export type NotificationDotSize = 'sm' | 'md';
+
+export interface NotificationDotProps {
+  /**
+   * Accessible label describing what the dot is flagging, e.g. "Unread
+   * messages" or "Picks available to make". Required — a bare dot is meaningless
+   * to a screen reader.
+   */
+  label: string;
+  /** Dot diameter. `sm` (8px) matches the inline tab indicator; `md` (10px) reads better on a card. */
+  size?: NotificationDotSize;
+  /**
+   * Positioning / ring overrides. The dot is `inline-block` by default; pass
+   * `absolute -top-0.5 -right-1.5` (etc.) to pin it to a positioned parent.
+   */
+  className?: string;
+  /** Optional test hook so existing tests can keep their selectors. */
+  'data-testid'?: string;
+}
+
+const SIZE_CLASSES: Record<NotificationDotSize, string> = {
+  sm: 'h-2 w-2',
+  md: 'h-2.5 w-2.5',
+};
+
+/**
+ * A small red status dot signalling "something needs your attention here" —
+ * unread chat, picks waiting to be made, etc. Purely presentational: the parent
+ * decides when it shows and where it sits (pass positioning via `className`).
+ *
+ * Extracted from the inline Chat-tab unread indicator so every "needs
+ * attention" affordance shares one definition and one color token.
+ */
+export default function NotificationDot({
+  label,
+  size = 'sm',
+  className = '',
+  'data-testid': testId,
+}: NotificationDotProps) {
+  return (
+    <span
+      role="status"
+      aria-label={label}
+      data-testid={testId}
+      className={`inline-block rounded-full bg-error-500 ${SIZE_CLASSES[size]} ${className}`.trim()}
+    />
+  );
+}

--- a/frontend/src/designsystem/components/NotificationDot/index.ts
+++ b/frontend/src/designsystem/components/NotificationDot/index.ts
@@ -1,0 +1,2 @@
+export { default, default as NotificationDot } from './NotificationDot';
+export type { NotificationDotProps, NotificationDotSize } from './NotificationDot';

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.test.tsx
@@ -31,6 +31,17 @@ describe('WorldCupGamesList', () => {
     expect(screen.queryByTestId('match-card-2')).toBeNull();
   });
 
+  it('opens on the initialView when given one (deeplink to "Needs pick")', () => {
+    // A tomorrow game would be hidden by the default Today view; opening on
+    // needs-pick (open + unpicked) surfaces it, proving initialView is honored.
+    const tomorrow = game({ id: 2, kickoff: '2026-06-13T20:00:00' });
+    render(
+      <WorldCupGamesList games={[tomorrow]} now={NOW} onPick={() => {}} initialView="needs-pick" />,
+    );
+    expect(screen.getByRole('button', { name: /Needs pick/i })).toHaveClass('bg-accent');
+    expect(screen.getByTestId('match-card-2')).toBeInTheDocument();
+  });
+
   it('filters games by World Cup group via the group dropdown', () => {
     const groupD = game({
       id: 1,

--- a/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/WorldCupGamesList.tsx
@@ -18,6 +18,9 @@ export interface WorldCupGamesListProps {
   now: Date;
   onPick: (gameId: number, result: MatchResult) => void;
   disabled?: boolean;           // read-only viewer (optional; pass through if convenient)
+  /** Which saved view the list opens on. Defaults to 'today'; a deeplink can
+   *  open straight on 'needs-pick' so the "what do I still owe?" chip is preselected. */
+  initialView?: SavedView;
 }
 
 const VIEWS: { key: SavedView; label: string }[] = [
@@ -62,8 +65,8 @@ function Chip({ label, count, active, onClick }: { label: string; count?: number
 const selectCls =
   'rounded-md border border-border bg-neutral-0 px-xs py-xxs text-sm text-content dark:bg-secondary-900';
 
-export default function WorldCupGamesList({ games, now, onPick, disabled }: WorldCupGamesListProps) {
-  const [view, setView] = useState<SavedView>('today');
+export default function WorldCupGamesList({ games, now, onPick, disabled, initialView = 'today' }: WorldCupGamesListProps) {
+  const [view, setView] = useState<SavedView>(initialView);
   const [query, setQuery] = useState('');
   const [filters, setFilters] = useState<Filters>(NO_FILTERS);
   const [sort, setSort] = useState<SortKey>('kickoff');

--- a/frontend/src/lib/wcNeedsPick.test.ts
+++ b/frontend/src/lib/wcNeedsPick.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { countNeedsPick } from './wcNeedsPick';
+import type { MatchPick, WorldCupMatch } from './types';
+
+// NOW sits after the group-stage opener but before the others below, so the
+// open/locked window is exercised, not just the pick state.
+const NOW = new Date('2026-06-12T18:00:00Z');
+
+const match = (over: Partial<WorldCupMatch> = {}): WorldCupMatch => ({
+  id: 1,
+  stage: 'group',
+  homeTeam: { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: 'mex.png' },
+  awayTeam: { id: '2', name: 'South Africa', abbreviation: 'RSA', logo: 'rsa.png' },
+  homeScore: 0,
+  awayScore: 0,
+  status: 'SCHEDULED',
+  isKnockout: false,
+  gameDate: '2026-06-20T17:00:00Z', // future → open
+  ...over,
+});
+
+const pick = (gameId: number, pickedResult: MatchPick['pickedResult'] = 'home'): MatchPick => ({
+  gameId,
+  pickedResult,
+});
+
+describe('countNeedsPick', () => {
+  it('counts open, unpicked, decided matches', () => {
+    const matches = [match({ id: 1 }), match({ id: 2 }), match({ id: 3 })];
+    expect(countNeedsPick(matches, [], NOW)).toBe(3);
+  });
+
+  it('excludes matches the viewer has already picked', () => {
+    const matches = [match({ id: 1 }), match({ id: 2 })];
+    expect(countNeedsPick(matches, [pick(1)], NOW)).toBe(1);
+  });
+
+  it('excludes matches that have already kicked off (locked)', () => {
+    const matches = [
+      match({ id: 1, gameDate: '2026-06-10T17:00:00Z' }), // past kickoff → locked
+      match({ id: 2, gameDate: '2026-06-20T17:00:00Z' }), // future → open
+    ];
+    expect(countNeedsPick(matches, [], NOW)).toBe(1);
+  });
+
+  it('excludes in-progress / final matches', () => {
+    const matches = [
+      match({ id: 1, status: 'IN_PROGRESS' }),
+      match({ id: 2, status: 'FINAL' }),
+      match({ id: 3 }),
+    ];
+    expect(countNeedsPick(matches, [], NOW)).toBe(1);
+  });
+
+  it('excludes undecided knockout placeholders even when open + unpicked', () => {
+    const matches = [
+      match({
+        id: 1,
+        stage: 'r16',
+        homeTeam: { id: '2A', name: 'Group A 2nd Place', abbreviation: '2A', logo: '' },
+      }),
+      match({ id: 2 }),
+    ];
+    expect(countNeedsPick(matches, [], NOW)).toBe(1);
+  });
+
+  it('handles an undefined picks payload', () => {
+    expect(countNeedsPick([match({ id: 1 })], undefined, NOW)).toBe(1);
+  });
+
+  it('returns 0 for an empty slate', () => {
+    expect(countNeedsPick([], [], NOW)).toBe(0);
+  });
+});

--- a/frontend/src/lib/wcNeedsPick.ts
+++ b/frontend/src/lib/wcNeedsPick.ts
@@ -1,0 +1,35 @@
+// Shared "how many picks does this viewer still owe?" count for World Cup pools.
+//
+// Funnels through the EXACT same pipeline the "Needs pick" filter chip uses —
+// toBrowseGames(matches, draft) + the pure needsPick(game, now) rule from
+// wcGamesView — so the leaderboard banner, the group-card dot, and the picks-tab
+// chip can never disagree about what counts. A pick is "needed" only when the
+// match is still open (pre-kickoff), unpicked by this viewer, and both teams are
+// decided (knockout placeholders aren't pickable). See wcGamesView.needsPick.
+
+import type { MatchPick, WorldCupMatch } from './types';
+import { toBrowseGames } from './worldCupBrowseAdapter';
+import { needsPick } from './wcGamesView';
+
+/** Build the gameId→result draft map the adapter expects from a picks payload. */
+function toDraft(picks: MatchPick[] | undefined): Record<number, MatchPick['pickedResult']> {
+  const draft: Record<number, MatchPick['pickedResult']> = {};
+  for (const p of picks ?? []) {
+    if (p && p.gameId != null && p.pickedResult) draft[p.gameId] = p.pickedResult;
+  }
+  return draft;
+}
+
+/**
+ * Count the matches this viewer still needs to pick, given the tournament's
+ * matches and the viewer's saved picks. `now` is injected so the open/locked
+ * window is testable.
+ */
+export function countNeedsPick(
+  matches: WorldCupMatch[],
+  picks: MatchPick[] | undefined,
+  now: Date,
+): number {
+  const draft = toDraft(picks);
+  return toBrowseGames(matches, draft).filter((g) => needsPick(g, now)).length;
+}

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -21,6 +21,7 @@ import { pollIntervalFor } from '../../lib/matchPolling';
 import SaveTargetsDropdown, { type SaveTarget } from '../../components/SaveTargetsDropdown';
 import PickPersonSelector, { type PickPersonOption } from '../../components/PickPersonSelector';
 import WorldCupGamesList from '../../designsystem/components/WorldCupBrowse/WorldCupGamesList';
+import type { SavedView } from '../../lib/wcGamesView';
 import { toBrowseGames } from '../../lib/worldCupBrowseAdapter';
 
 // The World Cup pick-making surface: the whole tournament as one stage-grouped
@@ -70,6 +71,8 @@ export interface WorldCupPicksTabProps {
   currentUserId?: string | number | null;
   /** Whether the caller is a group admin. Gates editing OTHER members' picks. */
   isAdmin?: boolean;
+  /** Saved view the embedded games list opens on (e.g. 'needs-pick' from a deeplink). */
+  initialView?: SavedView;
 }
 
 export default function WorldCupPicksTab({
@@ -77,6 +80,7 @@ export default function WorldCupPicksTab({
   members = [],
   currentUserId = null,
   isAdmin = false,
+  initialView,
 }: WorldCupPicksTabProps) {
   const groupId = identifier;
 
@@ -506,6 +510,7 @@ export default function WorldCupPicksTab({
             now={now}
             onPick={pickResult}
             disabled={submitting || readOnly}
+            initialView={initialView}
           />
         )}
       </div>

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -337,6 +337,12 @@ describe('GroupDetailsPage', () => {
       mockGetGroup.mockResolvedValue(worldCupGroup);
       mockGetMembers.mockResolvedValue(members);
       mockGetMessages.mockResolvedValue(messages);
+      // Defaults for the leaderboard banner's needs-pick probe (stages + my-picks),
+      // so the background fetch resolves deterministically; tests that care about
+      // the banner override these.
+      mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
+      mockGetAllWorldCupStages.mockResolvedValue(stagesResponse);
+      mockGetMyWorldCupPicks.mockResolvedValue({ picks: [] });
     });
 
     it('renders the TournamentLeaderboard on the Leaderboard tab for a world_cup_2026 pool', async () => {
@@ -455,6 +461,50 @@ describe('GroupDetailsPage', () => {
       fireEvent.click(screen.getByRole('tab', { name: /chat/i }));
       expect(screen.queryByRole('button', { name: 'Submit Picks' })).not.toBeInTheDocument();
       expect(screen.queryByText('0 picks selected')).not.toBeInTheDocument();
+    });
+
+    it('shows the picks-available banner on the Leaderboard tab when the viewer owes picks', async () => {
+      mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
+      mockGetAllWorldCupStages.mockResolvedValue(stagesResponse);
+      mockGetMyWorldCupPicks.mockResolvedValue({ picks: [] }); // nothing picked → 1 owed
+
+      renderPage();
+      await screen.findByRole('heading', { name: worldCupGroup.name });
+
+      // The one open, unpicked, decided match surfaces the banner with its count.
+      expect(await screen.findByText(/1 pick available to make/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /make your picks/i })).toBeInTheDocument();
+    });
+
+    it('hides the banner once every open match is picked', async () => {
+      mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
+      mockGetAllWorldCupStages.mockResolvedValue(stagesResponse);
+      mockGetMyWorldCupPicks.mockResolvedValue({ picks: [{ gameId: 10, pickedResult: 'home' }] });
+
+      renderPage();
+      await screen.findByRole('heading', { name: worldCupGroup.name });
+      await waitFor(() => expect(mockGetMyWorldCupPicks).toHaveBeenCalled());
+
+      expect(screen.queryByText(/available to make/i)).not.toBeInTheDocument();
+    });
+
+    it('banner CTA deeplinks to the Picks tab with the "Needs pick" chip pre-selected', async () => {
+      mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
+      mockGetAllWorldCupStages.mockResolvedValue(stagesResponse);
+      mockGetMyWorldCupPicks.mockResolvedValue({ picks: [] });
+      mockGetMyGroups.mockResolvedValue([
+        { id: 1, identifier: 'sunday-squad', name: 'World Cup Squad', poolType: 'world_cup_2026' },
+      ] as any);
+
+      renderPage();
+      await screen.findByRole('heading', { name: worldCupGroup.name });
+
+      fireEvent.click(await screen.findByRole('button', { name: /make your picks/i }));
+
+      // The Picks surface is now mounted (submit bar present)...
+      expect(await screen.findByRole('button', { name: 'Submit Picks' })).toBeInTheDocument();
+      // ...and the "Needs pick" view chip is the active one (accent styling).
+      expect(screen.getByRole('button', { name: /Needs pick/i })).toHaveClass('bg-accent');
     });
   });
 

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -3,9 +3,14 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { getGroup, getMembers, getMessages, getUnreadStatus, markMessagesRead } from '../lib/groupsService.js';
 import type { GroupDetail, GroupMember, GroupMessage } from '../lib/groupsService';
-import { getWorldCupLeaderboard } from '../lib/worldCupService.js';
+import { getWorldCupLeaderboard, getAllWorldCupStages, getMyWorldCupPicks } from '../lib/worldCupService.js';
 import { writeCache, wcCacheKeys } from '../lib/worldCupCache';
+import { countNeedsPick } from '../lib/wcNeedsPick';
+import type { SavedView } from '../lib/wcGamesView';
+import type { WorldCupMatch } from '../lib/types';
+import Banner from '../designsystem/components/Banner';
 import Button from '../designsystem/components/Button';
+import NotificationDot from '../designsystem/components/NotificationDot';
 import PageContainer from '../designsystem/components/PageContainer';
 import Spinner from '../designsystem/components/Spinner';
 import LeaderboardTab from './GroupDetails/LeaderboardTab';
@@ -62,15 +67,29 @@ function GroupNotFound({ message, onBack }: { message: string; onBack: () => voi
 
 export default function GroupDetailsPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const identifier = searchParams.get('group');
   const { user } = useAuth();
+
+  // Deeplink seeds (read once on mount): ?tab= picks the initial tab and ?view=
+  // pre-selects a saved view in the Picks tab — e.g. the leaderboard banner links
+  // to ?tab=picks&view=needs-pick so the "Needs pick" chip opens already chosen.
+  const tabParam = searchParams.get('tab');
+  const initialTab: TabKey = TABS.some((t) => t.key === tabParam) ? (tabParam as TabKey) : 'leaderboard';
+  const viewParam = searchParams.get('view');
 
   const [group, setGroup] = useState<GroupDetail | null>(null);
   const [members, setMembers] = useState<GroupMember[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<TabKey>('leaderboard');
+  const [activeTab, setActiveTab] = useState<TabKey>(initialTab);
+  // Which saved view the Picks tab opens on; set by the banner CTA / a deeplink.
+  const [picksInitialView, setPicksInitialView] = useState<SavedView | undefined>(
+    viewParam === 'needs-pick' ? 'needs-pick' : undefined,
+  );
+  // How many picks the viewer still owes in this (World Cup) pool. Drives the
+  // leaderboard warning banner; 0 keeps it hidden.
+  const [needsPickCount, setNeedsPickCount] = useState(0);
   // Drives the red dot on the Chat tab. Fetched independently of the mount fetch
   // (a failure here must not collapse the whole page into the Not Found UI), and
   // cleared the moment the user opens the chat.
@@ -157,6 +176,34 @@ export default function GroupDetailsPage() {
     };
   }, [identifier]);
 
+  // Compute the viewer's outstanding-pick count for the leaderboard banner.
+  // World Cup pools only, and only while the Leaderboard tab is showing (that's
+  // the only place the banner renders) — re-running when the user returns from
+  // the Picks tab keeps the count fresh after they pick. Best-effort and off the
+  // critical path: a failure just leaves the banner hidden. Reuses the SAME
+  // matches + picks endpoints (and `wc:stages` cache) the Picks tab feeds on.
+  useEffect(() => {
+    if (!identifier || group?.poolType !== 'world_cup_2026' || activeTab !== 'leaderboard') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [stagesResp, picksResp] = await Promise.all([
+          getAllWorldCupStages(),
+          getMyWorldCupPicks(identifier),
+        ]);
+        if (cancelled) return;
+        const matches: WorldCupMatch[] = Array.isArray(stagesResp?.games) ? stagesResp.games : [];
+        writeCache(wcCacheKeys.stages, matches);
+        setNeedsPickCount(countNeedsPick(matches, picksResp?.picks, new Date()));
+      } catch {
+        /* non-fatal: leave the banner hidden */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [identifier, group?.poolType, activeTab]);
+
   // No identifier in the query string: nothing to load, show the error UI early.
   if (!identifier) {
     return (
@@ -215,6 +262,17 @@ export default function GroupDetailsPage() {
     }
   }
 
+  // Banner CTA: jump to the Picks tab with the "Needs pick" chip pre-selected,
+  // and reflect it in the URL so the destination is a real, refresh-safe deeplink.
+  function goToNeedsPick() {
+    setPicksInitialView('needs-pick');
+    setActiveTab('picks');
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', 'picks');
+    next.set('view', 'needs-pick');
+    setSearchParams(next, { replace: true });
+  }
+
   // getGroup returns userRole (NOT isOwner); admin is the owning role.
   const isOwner = group.userRole === 'admin';
   // World Cup pools render the tournament-shaped tab variants. Absent/NFL pools
@@ -267,6 +325,15 @@ export default function GroupDetailsPage() {
           </div>
         </div>
 
+        {/* Picks-available warning — spans between the member count and the tab
+            bar, shown on the Leaderboard tab when the viewer still owes picks.
+            Tapping the CTA deeplinks to the Picks tab on the "Needs pick" chip. */}
+        {isWorldCup && activeTab === 'leaderboard' && needsPickCount > 0 && (
+          <Banner variant="warning" action={{ label: 'Make your picks', onClick: goToNeedsPick }}>
+            You have {needsPickCount} {needsPickCount === 1 ? 'pick' : 'picks'} available to make.
+          </Banner>
+        )}
+
         {/* Tab Navigation */}
         <div className="border-b border-secondary-200 dark:border-secondary-700">
           {/* pt-1 gives the Chat tab's unread dot room: overflow-x-auto forces
@@ -288,10 +355,10 @@ export default function GroupDetailsPage() {
               >
                 {tab.label}
                 {tab.key === 'chat' && hasUnreadChat && (
-                  <span
+                  <NotificationDot
+                    label="Unread messages"
                     data-testid="chat-unread-indicator"
-                    aria-label="Unread messages"
-                    className="absolute -top-0.5 -right-1.5 h-2 w-2 rounded-full bg-error-500"
+                    className="absolute -top-0.5 -right-1.5"
                   />
                 )}
               </button>
@@ -318,6 +385,7 @@ export default function GroupDetailsPage() {
               members={members}
               currentUserId={user?.id ?? null}
               isAdmin={isOwner}
+              initialView={picksInitialView}
             />
           ) : (
             <PicksTab identifier={identifier} members={members} />

--- a/frontend/src/pages/GroupsPage.tsx
+++ b/frontend/src/pages/GroupsPage.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getMyGroups, leaveGroup, deleteGroup } from '../lib/groupsService.js';
+import { getAllWorldCupStages, getMyWorldCupPicks } from '../lib/worldCupService.js';
+import { peekCache, writeCache, wcCacheKeys } from '../lib/worldCupCache';
+import { countNeedsPick } from '../lib/wcNeedsPick';
+import type { WorldCupMatch } from '../lib/types';
 import GroupsList from '../designsystem/components/GroupsList';
 import type { GroupData } from '../designsystem/components/GroupCard/GroupCard';
 import Button from '../designsystem/components/Button';
@@ -25,6 +29,9 @@ export default function GroupsPage() {
   const [groups, setGroups] = useState<GroupData[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Per-group "you have picks to make" flags (World Cup pools), keyed by
+  // identifier. Drives the notification dot on each card.
+  const [needsPickByGroup, setNeedsPickByGroup] = useState<Record<string, boolean>>({});
 
   // Search + filter selections from the GroupsSearchFilter bar. Applied to the
   // loaded groups to produce the visible subset; an empty filter set shows all.
@@ -60,6 +67,47 @@ export default function GroupsPage() {
       cancelled = true;
     };
   }, [refreshKey]);
+
+  // Compute the notification dot per World Cup group: reuse the SAME open/unpicked
+  // rule the picks-tab "Needs pick" chip uses (countNeedsPick). The tournament
+  // slate is fetched once and shared via the wc:stages cache; each group only
+  // needs its own lightweight my-picks read. Best-effort — failures leave a card
+  // without a dot rather than erroring the page.
+  useEffect(() => {
+    const wcGroups = groups.filter((g) => g.poolType === 'world_cup_2026');
+    if (wcGroups.length === 0) {
+      setNeedsPickByGroup({});
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        let matches = peekCache<WorldCupMatch[]>(wcCacheKeys.stages);
+        if (matches === undefined) {
+          const resp = await getAllWorldCupStages();
+          matches = Array.isArray(resp?.games) ? resp.games : [];
+          writeCache(wcCacheKeys.stages, matches);
+        }
+        const now = new Date();
+        const entries = await Promise.all(
+          wcGroups.map(async (g) => {
+            try {
+              const picksResp = await getMyWorldCupPicks(g.identifier);
+              return [g.identifier, countNeedsPick(matches as WorldCupMatch[], picksResp?.picks, now) > 0] as const;
+            } catch {
+              return [g.identifier, false] as const;
+            }
+          }),
+        );
+        if (!cancelled) setNeedsPickByGroup(Object.fromEntries(entries));
+      } catch {
+        if (!cancelled) setNeedsPickByGroup({});
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [groups]);
 
   async function handleLeaveGroup(group: GroupData) {
     try {
@@ -174,6 +222,7 @@ export default function GroupsPage() {
             ) : (
               <GroupsList
                 groups={visibleGroups}
+                needsPickByGroup={needsPickByGroup}
                 showHeader={false}
                 onCreateNew={() => navigate('/create-group')}
                 onJoinExisting={() => navigate('/join-group')}


### PR DESCRIPTION
## What & why

When a World Cup 2026 pool member still has picks they can make, the app now tells them in two places instead of staying silent:

1. **Warning banner** on the group's **Leaderboard** tab — spans the full width between the member count and the tab bar, e.g. *"You have 3 picks available to make."* with a **Make your picks** link.
2. **Notification dot** on that group's **card** in the groups list — the same red dot affordance as the Chat tab's unread indicator.

The banner's CTA **deeplinks** to the Picks tab with the **"Needs pick"** filter chip already selected, so the member lands exactly where they can act.

## How it reuses what's already there

Detection funnels through the existing, well-tested `needsPick(game, now)` rule via a tiny new `countNeedsPick` helper, using the same `toBrowseGames` adapter the "Needs pick" chip already uses — so the **banner, the dot, and the chip can never disagree** about what counts (open + unpicked + both teams decided). A pick is "needed" only while the match is still pre-kickoff.

**No backend changes** — it reuses `getAllWorldCupStages()` (already cached tournament-globally as `wc:stages`) + `getMyWorldCupPicks(groupId)`.

## New design-system primitives (per review feedback)

- **`NotificationDot`** — extracted as a DS component; the inline Chat-tab unread dot is **retrofitted** onto it so there's one definition/color token.
- **`Banner`** — a persistent, full-width inline alert with an optional tappable action (distinct from the transient, auto-dismissing `InlineToast`).
- **Deeplink support** — `GroupDetailsPage` now reads `?tab=` / `?view=` so the CTA is a real, refresh-safe link; `WorldCupGamesList` gained an `initialView` prop (defaults to `today`, unchanged).

## Scope

World Cup 2026 pools only (the NFL leaderboard has no cache/pick-detection wiring yet). Banner shows only on the Leaderboard tab; the card dot is a plain dot with no count, mirroring the Chat indicator.

## Tests

- `wcNeedsPick` counting rules (open/locked/picked/knockout-placeholder/empty).
- `NotificationDot` + `Banner` DS components.
- `WorldCupGamesList` honors `initialView`.
- `GroupCard` renders the dot on the flag.
- `GroupDetailsPage`: banner shows/hides on count, and the CTA deeplinks to the Picks tab with the "Needs pick" chip active.

Full frontend suite green (735 passed) and `pnpm build` clean. Screenshots of all three scenarios shared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)