### PR TITLE
feat: "knockout stage picks only" sub-setting for World Cup 2026 groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,37 @@ exported (single-stage callers/tests), but no component fans out anymore.
   applies there too. The NFL `LeaderboardTab` has no cache yet, so the
   parallel-prefetch optimization is currently World-Cup-only.
 
+## Feature: "knockout stage picks only" WC groups (2026-06)
+
+A `world_cup_2026` sub-setting, chosen at group creation and **immutable** (like
+`pool_type`). When on, the group only allows picks on knockout-stage games; the
+group stage (`stage = 'group'`) is hidden in the UI and rejected server-side.
+Scoring/leaderboard are unchanged — they already sum per-match over whatever picks
+exist.
+
+- **Column:** `groups.knockout_only BOOLEAN NOT NULL DEFAULT false`. Added the same
+  way as `pool_type`: in `schema.sql` (CREATE + idempotent `DO $$` ALTER) and in
+  `backend/scripts/addWorldCupColumns.js`. **Deploy note:** prod runs with
+  `INIT_DB` unset, so the column does NOT appear on a normal deploy — land it with
+  one `INIT_DB=true` deploy *or* `node backend/scripts/addWorldCupColumns.js`. The
+  `DEFAULT false` backfills existing rows, so it's non-destructive.
+- **Model:** `Group` carries `knockoutOnly` (camelCase) through the constructor,
+  `create()`, `findByIdentifier()`, `getUserGroups()`. Left out of `update()`'s
+  `allowedFields` on purpose (immutable).
+- **Backend enforcement:** `POST /api/groups` rejects `knockoutOnly` when
+  `poolType !== 'world_cup_2026'` (400). Both WC pick routes in `worldCupPicks.js`
+  (self + admin-override) read `stage` back from the games row and reject any
+  group-stage pick via `groupStagePickViolations()` (400 `{ error, gameIds }`).
+- **Frontend:** `CreateGroupForm` shows the checkbox only for a WC pool (cleared
+  on switch to NFL). `WorldCupPicksTab` takes a `knockoutOnly` prop
+  (`GroupDetailsPage` passes `group.knockoutOnly`) and also derives it from its own
+  `getMyGroups` fetch as a fallback for the standalone `/world-cup` page; it filters
+  `stage === 'group'` matches out of `visibleMatches` before render/count.
+- **Test seams:** several exact-payload assertions
+  (`CreateGroupForm.test.tsx`, `CreateGroupPage.test.tsx`) now include
+  `knockoutOnly`. WC-pick-route tests stub `Group.findByIdentifier` to return
+  `{ ..., knockoutOnly: true }` and add `stage` to the `FROM games` row mock.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,12 +187,18 @@ group stage (`stage = 'group'`) is hidden in the UI and rejected server-side.
 Scoring/leaderboard are unchanged — they already sum per-match over whatever picks
 exist.
 
-- **Column:** `groups.knockout_only BOOLEAN NOT NULL DEFAULT false`. Added the same
-  way as `pool_type`: in `schema.sql` (CREATE + idempotent `DO $$` ALTER) and in
-  `backend/scripts/addWorldCupColumns.js`. **Deploy note:** prod runs with
-  `INIT_DB` unset, so the column does NOT appear on a normal deploy — land it with
-  one `INIT_DB=true` deploy *or* `node backend/scripts/addWorldCupColumns.js`. The
-  `DEFAULT false` backfills existing rows, so it's non-destructive.
+- **Column:** `groups.knockout_only BOOLEAN NOT NULL DEFAULT false`. Defined in
+  `schema.sql` (CREATE + idempotent `DO $$` ALTER) and `backend/scripts/addWorldCupColumns.js`.
+- **Deploy (automatic, self-healing):** prod runs with `INIT_DB` unset, so neither
+  `schema.sql` nor the migration script runs on a normal deploy — and `create()`'s
+  INSERT names `knockout_only`, so a missing column would 500 *every* new group.
+  `Group.ensureKnockoutOnlyColumn()` closes this the same way `ensureChatReadsSchema`
+  / `GroupInvite.ensureLinkInviteSchema` do: `create()` calls it first, it adds the
+  column (`ADD COLUMN IF NOT EXISTS`) on the first group creation after deploy, then
+  a static `Group._knockoutOnlyColumnEnsured` latch makes every later create a
+  zero-query no-op ("back to normal"). Reads already tolerate a missing column
+  (`SELECT g.*` → undefined → false). `INIT_DB=true` and the migration script remain
+  as explicit/ops alternatives but are no longer required.
 - **Model:** `Group` carries `knockoutOnly` (camelCase) through the constructor,
   `create()`, `findByIdentifier()`, `getUserGroups()`. Left out of `update()`'s
   `allowedFields` on purpose (immutable).

--- a/backend/scripts/addWorldCupColumns.js
+++ b/backend/scripts/addWorldCupColumns.js
@@ -80,6 +80,20 @@ async function addWorldCupColumns() {
     `);
     console.log('   ✅ groups.pool_type ensured');
 
+    // 4c. groups.knockout_only — world_cup_2026 sub-setting. When true, members may
+    //     only pick knockout-stage games; group-stage picks are rejected. Default
+    //     false so every existing group (NFL and World Cup alike) is unaffected.
+    //     NOT declared NOT NULL via the ADD here because adding a NOT NULL column
+    //     to a populated table requires the DEFAULT to backfill atomically; the
+    //     DEFAULT false does exactly that, and the backfill below + the schema.sql
+    //     CREATE keep the column NOT NULL on a fresh init.
+    console.log('\n4c. Adding groups.knockout_only (boolean default false)...');
+    await pool.query(`
+      ALTER TABLE groups
+      ADD COLUMN IF NOT EXISTS knockout_only BOOLEAN NOT NULL DEFAULT false
+    `);
+    console.log('   ✅ groups.knockout_only ensured');
+
     // 4b. games.winner_team_id — the resolved advancing-team id for soccer
     //     knockout matches. Persisted because ESPN's competitor.winner flag (the
     //     only signal on a PK shootout) isn't recoverable from a cached row's
@@ -102,7 +116,7 @@ async function addWorldCupColumns() {
       FROM information_schema.columns
       WHERE (table_name = 'games' AND column_name IN ('league', 'stage', 'winner_team_id'))
          OR (table_name = 'user_picks' AND column_name = 'picked_result')
-         OR (table_name = 'groups' AND column_name = 'pool_type')
+         OR (table_name = 'groups' AND column_name IN ('pool_type', 'knockout_only'))
       ORDER BY table_name, column_name
     `);
     verify.rows.forEach(col => {

--- a/backend/scripts/addWorldCupColumns.js
+++ b/backend/scripts/addWorldCupColumns.js
@@ -81,13 +81,11 @@ async function addWorldCupColumns() {
     console.log('   ✅ groups.pool_type ensured');
 
     // 4c. groups.knockout_only — world_cup_2026 sub-setting. When true, members may
-    //     only pick knockout-stage games; group-stage picks are rejected. Default
-    //     false so every existing group (NFL and World Cup alike) is unaffected.
-    //     NOT declared NOT NULL via the ADD here because adding a NOT NULL column
-    //     to a populated table requires the DEFAULT to backfill atomically; the
-    //     DEFAULT false does exactly that, and the backfill below + the schema.sql
-    //     CREATE keep the column NOT NULL on a fresh init.
-    console.log('\n4c. Adding groups.knockout_only (boolean default false)...');
+    //     only pick knockout-stage games; group-stage picks are rejected. Added as
+    //     NOT NULL DEFAULT false: Postgres backfills every existing row with false
+    //     atomically as part of the ADD, so the column is non-null from the start
+    //     and every existing group (NFL and World Cup alike) is unaffected.
+    console.log('\n4c. Adding groups.knockout_only (boolean NOT NULL default false)...');
     await pool.query(`
       ALTER TABLE groups
       ADD COLUMN IF NOT EXISTS knockout_only BOOLEAN NOT NULL DEFAULT false

--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS groups (
   is_public BOOLEAN DEFAULT true,
   max_members INTEGER DEFAULT 20 CHECK (max_members <= 40 AND max_members >= 2),
   pool_type VARCHAR(20) NOT NULL DEFAULT 'nfl_weekly' CHECK (pool_type IN ('nfl_weekly','world_cup_2026')), -- pick-pool variant
+  knockout_only BOOLEAN NOT NULL DEFAULT false, -- world_cup_2026 sub-setting: members may only pick knockout-stage games (no group stage)
   avatar_url VARCHAR(500),
   created_by INTEGER REFERENCES users(id) ON DELETE CASCADE,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -251,6 +252,12 @@ BEGIN
   ) THEN
     ALTER TABLE groups ADD COLUMN pool_type VARCHAR(20) NOT NULL DEFAULT 'nfl_weekly'
       CHECK (pool_type IN ('nfl_weekly','world_cup_2026'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'groups' AND column_name = 'knockout_only'
+  ) THEN
+    ALTER TABLE groups ADD COLUMN knockout_only BOOLEAN NOT NULL DEFAULT false;
   END IF;
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -2,6 +2,12 @@ import pool from '../config/database.js';
 import crypto from 'crypto';
 
 export class Group {
+  // Self-heal latch for the knockout_only column (see ensureKnockoutOnlyColumn).
+  // Once the column is confirmed present in this process, every later create()
+  // skips even the catalog lookup — so the migration cost is paid at most once per
+  // warm lambda and then "goes back to normal" (zero extra queries).
+  static _knockoutOnlyColumnEnsured = false;
+
   constructor(data) {
     this.id = data.id;
     this.name = data.name;
@@ -27,9 +33,46 @@ export class Group {
     this.knockoutOnly = data.knockoutOnly ?? false;
   }
 
+  // Ensure the groups.knockout_only column exists. Production resilience: prod
+  // runs with INIT_DB unset, so schema.sql is NOT synced on deploy — mirror the
+  // ensureChatReadsSchema / GroupInvite.ensureLinkInviteSchema self-heal so the
+  // column lands automatically on the first group creation after a deploy, with no
+  // manual migration or INIT_DB toggle. This matters specifically for create():
+  // its INSERT names knockout_only, so a missing column would 500 EVERY new group
+  // (NFL included). Reads already tolerate a missing column (SELECT g.* yields
+  // undefined -> false), so only this write path needs the gate. Idempotent: a
+  // single indexed catalog lookup that early-returns once latched, and the ALTER
+  // itself is ADD COLUMN IF NOT EXISTS (safe under concurrent cold starts).
+  static async ensureKnockoutOnlyColumn() {
+    if (this._knockoutOnlyColumnEnsured) return; // warm-instance fast path: no query
+    try {
+      const check = await pool.query(
+        `SELECT 1 FROM information_schema.columns WHERE table_name = 'groups' AND column_name = 'knockout_only'`
+      );
+      if (check.rows.length === 0) {
+        console.log('[groups] Missing knockout_only column – adding');
+        await pool.query(
+          `ALTER TABLE groups ADD COLUMN IF NOT EXISTS knockout_only BOOLEAN NOT NULL DEFAULT false`
+        );
+        console.log('[groups] knockout_only column added');
+      }
+      // Latch only after a confirmed present/added column, so the next create
+      // settles into the zero-query fast path.
+      this._knockoutOnlyColumnEnsured = true;
+    } catch (e) {
+      // Do NOT latch on failure — a transient error must let the next create retry
+      // rather than permanently believing the column is present.
+      console.warn('[groups] Failed to ensure knockout_only column (may already exist):', e.message);
+    }
+  }
+
   // Create new group
   static async create(groupData, creatorId) {
     const { name, identifier, description, isPublic, maxMembers, avatarUrl, poolType, knockoutOnly } = groupData;
+
+    // Self-heal the knockout_only column before the INSERT references it. No-op
+    // once the column exists (latched), so this is free on the steady-state path.
+    await Group.ensureKnockoutOnlyColumn();
     
     // Ensure identifier is unique and URL-friendly
     // Clean identifier: lowercase, replace invalid chars with dash, collapse dashes, trim dashes

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -21,11 +21,15 @@ export class Group {
     // frontend's GroupDetailsPage can branch on group.poolType — without it
     // every WC group rendered the NFL PicksTab.
     this.poolType = data.poolType;
+    // World Cup 2026 sub-setting: when true, members may only pick knockout-stage
+    // games (no group stage). Defaults to false so NFL pools and ordinary WC pools
+    // are unaffected. The WC picks routes read this to reject group-stage picks.
+    this.knockoutOnly = data.knockoutOnly ?? false;
   }
 
   // Create new group
   static async create(groupData, creatorId) {
-    const { name, identifier, description, isPublic, maxMembers, avatarUrl, poolType } = groupData;
+    const { name, identifier, description, isPublic, maxMembers, avatarUrl, poolType, knockoutOnly } = groupData;
     
     // Ensure identifier is unique and URL-friendly
     // Clean identifier: lowercase, replace invalid chars with dash, collapse dashes, trim dashes
@@ -43,12 +47,12 @@ export class Group {
       // (see addWorldCupColumns.js migration), so omitting it preserves the
       // pre-WC behavior for NFL callers. Pass through when set.
       const groupQuery = `
-        INSERT INTO groups (name, identifier, description, is_public, max_members, avatar_url, created_by, pool_type)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, 'nfl_weekly'))
+        INSERT INTO groups (name, identifier, description, is_public, max_members, avatar_url, created_by, pool_type, knockout_only)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, 'nfl_weekly'), COALESCE($9, false))
         RETURNING *
       `;
       const groupResult = await client.query(groupQuery, [
-        name, cleanIdentifier, description, isPublic, maxMembers, avatarUrl, creatorId, poolType || null
+        name, cleanIdentifier, description, isPublic, maxMembers, avatarUrl, creatorId, poolType || null, knockoutOnly ?? null
       ]);
       
       const group = groupResult.rows[0];
@@ -74,7 +78,9 @@ export class Group {
         createdAt: group.created_at,
         updatedAt: group.updated_at,
         memberCount: 1,
-        userRole: 'admin'
+        userRole: 'admin',
+        poolType: group.pool_type,
+        knockoutOnly: group.knockout_only,
       });
     } catch (error) {
       await client.query('ROLLBACK');
@@ -122,6 +128,7 @@ export class Group {
       memberCount: parseInt(row.member_count),
       userRole: row.user_role,
       poolType: row.pool_type,
+      knockoutOnly: row.knockout_only,
     });
   }
 
@@ -158,6 +165,7 @@ export class Group {
       memberCount: parseInt(row.member_count),
       userRole: row.user_role,
       poolType: row.pool_type,
+      knockoutOnly: row.knockout_only,
     }));
   }
 

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -8,7 +8,7 @@ const router = express.Router();
 // Create a new group
 router.post('/', authenticateToken, async (req, res) => {
   try {
-    const { name, identifier, description, isPublic = true, maxMembers = 40, avatarUrl, poolType, knockoutOnly = false } = req.body;
+    const { name, identifier, description, isPublic = true, maxMembers = 40, avatarUrl, poolType, knockoutOnly } = req.body;
 
     if (!name || !identifier) {
       return res.status(400).json({ error: 'Name and identifier are required' });
@@ -24,9 +24,17 @@ router.post('/', authenticateToken, async (req, res) => {
       return res.status(400).json({ error: 'Invalid poolType' });
     }
 
+    // knockoutOnly is an optional boolean. Reject anything that isn't a real
+    // boolean (or absent) rather than coercing — a stray string like "false"
+    // would otherwise read as truthy and silently flip the setting on.
+    if (knockoutOnly !== undefined && typeof knockoutOnly !== 'boolean') {
+      return res.status(400).json({ error: 'knockoutOnly must be a boolean' });
+    }
+    const isKnockoutOnly = knockoutOnly === true;
+
     // knockoutOnly is a World Cup 2026 sub-setting; it is meaningless for an NFL
     // pool and would silently mislead, so reject the combination outright.
-    if (knockoutOnly && poolType !== 'world_cup_2026') {
+    if (isKnockoutOnly && poolType !== 'world_cup_2026') {
       return res.status(400).json({ error: 'knockoutOnly is only valid for world_cup_2026 pools' });
     }
 
@@ -38,7 +46,7 @@ router.post('/', authenticateToken, async (req, res) => {
       maxMembers,
       avatarUrl,
       poolType,
-      knockoutOnly: Boolean(knockoutOnly),
+      knockoutOnly: isKnockoutOnly,
     }, req.user.id);
     
     res.status(201).json(group);

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -8,7 +8,7 @@ const router = express.Router();
 // Create a new group
 router.post('/', authenticateToken, async (req, res) => {
   try {
-    const { name, identifier, description, isPublic = true, maxMembers = 40, avatarUrl, poolType } = req.body;
+    const { name, identifier, description, isPublic = true, maxMembers = 40, avatarUrl, poolType, knockoutOnly = false } = req.body;
 
     if (!name || !identifier) {
       return res.status(400).json({ error: 'Name and identifier are required' });
@@ -24,6 +24,12 @@ router.post('/', authenticateToken, async (req, res) => {
       return res.status(400).json({ error: 'Invalid poolType' });
     }
 
+    // knockoutOnly is a World Cup 2026 sub-setting; it is meaningless for an NFL
+    // pool and would silently mislead, so reject the combination outright.
+    if (knockoutOnly && poolType !== 'world_cup_2026') {
+      return res.status(400).json({ error: 'knockoutOnly is only valid for world_cup_2026 pools' });
+    }
+
     const group = await Group.create({
       name,
       identifier,
@@ -32,6 +38,7 @@ router.post('/', authenticateToken, async (req, res) => {
       maxMembers,
       avatarUrl,
       poolType,
+      knockoutOnly: Boolean(knockoutOnly),
     }, req.user.id);
     
     res.status(201).json(group);

--- a/backend/src/routes/worldCupPicks.js
+++ b/backend/src/routes/worldCupPicks.js
@@ -16,6 +16,19 @@ async function ensureMembership(groupIdentifier, userId) {
   return group;
 }
 
+// Knockout-only enforcement. In a world_cup_2026 group created with
+// knockout_only=true, members may pick only knockout-stage games; the group stage
+// is off-limits. The frontend hides group-stage games for these pools, so a
+// group-stage gameId arriving here is anomalous — reject the whole batch with the
+// offending ids rather than silently dropping them. Returns the offending ids
+// (empty when the group is unrestricted or every pick is a knockout game).
+function groupStagePickViolations(group, picks, gameById) {
+  if (!group.knockoutOnly) return [];
+  return picks
+    .filter((p) => gameById.get(p.gameId)?.stage === 'group')
+    .map((p) => p.gameId);
+}
+
 /**
  * Submit World Cup picks for the authenticated user in a group.
  *
@@ -58,7 +71,7 @@ router.post('/group/:groupId/world-cup', authenticateToken, async (req, res) => 
     // slot columns (season/season_type/week) the upsert requires.
     const gameIds = picks.map(p => p.gameId);
     const { rows: gameRows } = await pool.query(
-      `SELECT id, season, season_type, week, game_date FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
+      `SELECT id, season, season_type, week, game_date, stage FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
       [gameIds]
     );
     const gameById = new Map(gameRows.map(g => [g.id, g]));
@@ -67,6 +80,12 @@ router.post('/group/:groupId/world-cup', authenticateToken, async (req, res) => 
       if (!gameById.has(p.gameId)) {
         return res.status(400).json({ error: 'Invalid gameId', gameId: p.gameId });
       }
+    }
+
+    // Knockout-only groups reject any group-stage pick outright (see helper).
+    const groupStageIds = groupStagePickViolations(group, picks, gameById);
+    if (groupStageIds.length > 0) {
+      return res.status(400).json({ error: 'Group-stage picks are not allowed in this group', gameIds: groupStageIds });
     }
 
     // Lock picks at kickoff. game_date (the scheduled start) is the authoritative,
@@ -335,7 +354,7 @@ router.post('/group/:groupId/world-cup/user/:userId', authenticateToken, async (
     // are upserted under targetUserId rather than the caller.
     const gameIds = picks.map((p) => p.gameId);
     const { rows: gameRows } = await pool.query(
-      `SELECT id, season, season_type, week, game_date FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
+      `SELECT id, season, season_type, week, game_date, stage FROM games WHERE id = ANY($1::int[]) AND league = 'world_cup'`,
       [gameIds]
     );
     const gameById = new Map(gameRows.map((g) => [g.id, g]));
@@ -343,6 +362,12 @@ router.post('/group/:groupId/world-cup/user/:userId', authenticateToken, async (
       if (!gameById.has(p.gameId)) {
         return res.status(400).json({ error: 'Invalid gameId', gameId: p.gameId });
       }
+    }
+
+    // Knockout-only groups reject any group-stage pick, even from an admin override.
+    const groupStageIds = groupStagePickViolations(group, picks, gameById);
+    if (groupStageIds.length > 0) {
+      return res.status(400).json({ error: 'Group-stage picks are not allowed in this group', gameIds: groupStageIds });
     }
 
     // Kickoff lock applies to admin overrides too: a started match's pick is

--- a/backend/tests/groups-create-route.test.js
+++ b/backend/tests/groups-create-route.test.js
@@ -97,4 +97,20 @@ describe('Groups create route — knockoutOnly', () => {
     assert.strictEqual(res.status, 400);
     assert.strictEqual(create.mock.callCount(), 0);
   });
+
+  test('rejects a non-boolean knockoutOnly without coercing a truthy string', async () => {
+    // A stray string like "false" must not read as truthy and silently enable the
+    // setting — the route rejects any non-boolean outright.
+    const create = mock.method(Group, 'create', async (data) => ({ id: 9, ...data }));
+    const res = await post({
+      name: 'Stringy',
+      identifier: 'stringy',
+      poolType: 'world_cup_2026',
+      knockoutOnly: 'false',
+    });
+    assert.strictEqual(res.status, 400);
+    const data = await res.json();
+    assert.match(data.error, /knockoutOnly must be a boolean/);
+    assert.strictEqual(create.mock.callCount(), 0);
+  });
 });

--- a/backend/tests/groups-create-route.test.js
+++ b/backend/tests/groups-create-route.test.js
@@ -1,0 +1,100 @@
+import { test, describe, before, after, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import groupsRouter from '../src/routes/groups.js';
+import { AuthService } from '../src/services/AuthService.js';
+import { User } from '../src/models/User.js';
+import { Group } from '../src/models/Group.js';
+
+// Mounts the groups router on a throwaway app at /api/groups and stubs auth
+// (AuthService.verifyAccessToken + User.findById) plus Group.create so the create
+// route's validation/plumbing is exercised without a live Postgres. Focused on the
+// World Cup `knockoutOnly` sub-setting added alongside pool_type.
+
+const AUTH_HEADER = { Authorization: 'Bearer test-token' };
+
+describe('Groups create route — knockoutOnly', () => {
+  let server;
+  let baseURL;
+
+  before(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/groups', groupsRouter);
+    await new Promise((resolve) => {
+      server = app.listen(0, () => {
+        baseURL = `http://localhost:${server.address().port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    mock.method(AuthService, 'verifyAccessToken', () => ({ userId: 1 }));
+    mock.method(User, 'findById', async () => ({ id: 1, name: 'Tester', email: 't@x.io' }));
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  function post(body) {
+    return fetch(`${baseURL}/api/groups`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test('passes knockoutOnly through to Group.create for a world_cup_2026 pool', async () => {
+    let seen = null;
+    mock.method(Group, 'create', async (data) => {
+      seen = data;
+      return { id: 5, ...data };
+    });
+
+    const res = await post({
+      name: 'Knockout Crew',
+      identifier: 'knockout-crew',
+      poolType: 'world_cup_2026',
+      knockoutOnly: true,
+    });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(seen.knockoutOnly, true, 'create receives knockoutOnly=true');
+    assert.strictEqual(seen.poolType, 'world_cup_2026');
+  });
+
+  test('defaults knockoutOnly to false when omitted', async () => {
+    let seen = null;
+    mock.method(Group, 'create', async (data) => {
+      seen = data;
+      return { id: 6, ...data };
+    });
+
+    const res = await post({ name: 'Plain WC', identifier: 'plain-wc', poolType: 'world_cup_2026' });
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(seen.knockoutOnly, false);
+  });
+
+  test('rejects knockoutOnly on a non-world-cup pool with 400 (no create)', async () => {
+    const create = mock.method(Group, 'create', async (data) => ({ id: 7, ...data }));
+
+    const res = await post({ name: 'NFL Group', identifier: 'nfl-group', poolType: 'nfl_weekly', knockoutOnly: true });
+    assert.strictEqual(res.status, 400);
+    const data = await res.json();
+    assert.match(data.error, /knockoutOnly is only valid for world_cup_2026/);
+    assert.strictEqual(create.mock.callCount(), 0, 'an invalid combination must never create a group');
+  });
+
+  test('rejects knockoutOnly when poolType is omitted (defaults to NFL)', async () => {
+    const create = mock.method(Group, 'create', async (data) => ({ id: 8, ...data }));
+    const res = await post({ name: 'No Pool', identifier: 'no-pool', knockoutOnly: true });
+    assert.strictEqual(res.status, 400);
+    assert.strictEqual(create.mock.callCount(), 0);
+  });
+});

--- a/backend/tests/groups-ensure-column.test.js
+++ b/backend/tests/groups-ensure-column.test.js
@@ -1,0 +1,81 @@
+import { test, describe, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert';
+import { Group } from '../src/models/Group.js';
+import pool from '../src/config/database.js';
+
+// The groups.knockout_only column self-heals on the first group creation after a
+// deploy (prod runs with INIT_DB unset, so schema.sql is not synced). These tests
+// drive Group.ensureKnockoutOnlyColumn directly with a stubbed pool so no live
+// Postgres is needed. The static `_knockoutOnlyColumnEnsured` latch is reset before
+// each case because it persists for the lifetime of the process.
+
+describe('Group.ensureKnockoutOnlyColumn (self-heal)', () => {
+  beforeEach(() => {
+    Group._knockoutOnlyColumnEnsured = false;
+  });
+  afterEach(() => {
+    mock.restoreAll();
+    Group._knockoutOnlyColumnEnsured = false;
+  });
+
+  test('adds the column with an idempotent ALTER when it is missing', async () => {
+    const sqls = [];
+    mock.method(pool, 'query', async (sql) => {
+      sqls.push(sql);
+      if (/information_schema\.columns/.test(sql)) return { rows: [] }; // column missing
+      if (/ALTER TABLE groups/.test(sql)) return { rows: [] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    await Group.ensureKnockoutOnlyColumn();
+
+    assert.ok(
+      sqls.some((s) => /ALTER TABLE groups ADD COLUMN IF NOT EXISTS knockout_only BOOLEAN NOT NULL DEFAULT false/.test(s)),
+      'issues the idempotent ALTER when the column is absent',
+    );
+    assert.strictEqual(Group._knockoutOnlyColumnEnsured, true, 'latches after adding');
+  });
+
+  test('does NOT alter when the column already exists', async () => {
+    const sqls = [];
+    mock.method(pool, 'query', async (sql) => {
+      sqls.push(sql);
+      if (/information_schema\.columns/.test(sql)) return { rows: [{ '?column?': 1 }] }; // present
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    await Group.ensureKnockoutOnlyColumn();
+
+    assert.ok(!sqls.some((s) => /ALTER TABLE/.test(s)), 'no ALTER issued when the column is present');
+    assert.strictEqual(Group._knockoutOnlyColumnEnsured, true);
+  });
+
+  test('latches so a warm instance skips the catalog check on later calls', async () => {
+    let queryCount = 0;
+    mock.method(pool, 'query', async (sql) => {
+      queryCount++;
+      if (/information_schema\.columns/.test(sql)) return { rows: [{ '?column?': 1 }] };
+      return { rows: [] };
+    });
+
+    await Group.ensureKnockoutOnlyColumn();
+    await Group.ensureKnockoutOnlyColumn();
+    await Group.ensureKnockoutOnlyColumn();
+
+    assert.strictEqual(queryCount, 1, 'only the first call hits the DB; the rest are the zero-query fast path');
+  });
+
+  test('does NOT latch on failure, so the next call retries', async () => {
+    let queryCount = 0;
+    mock.method(pool, 'query', async () => {
+      queryCount++;
+      throw new Error('transient DB error');
+    });
+
+    await Group.ensureKnockoutOnlyColumn(); // swallows the error
+    await Group.ensureKnockoutOnlyColumn(); // must try again
+
+    assert.strictEqual(queryCount, 2, 'a transient failure does not permanently latch');
+    assert.strictEqual(Group._knockoutOnlyColumnEnsured, false);
+  });
+});

--- a/backend/tests/worldcup-picks-route.test.js
+++ b/backend/tests/worldcup-picks-route.test.js
@@ -160,6 +160,80 @@ describe('World Cup picks router', () => {
       const data = await res.json();
       assert.match(data.error, /Invalid gameId/);
     });
+
+    test('rejects a group-stage pick in a knockout-only group (400, no persistence)', async () => {
+      // knockoutOnly group: the group stage is off-limits. A group-stage gameId
+      // must be rejected with the offending ids, and nothing may persist.
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member', knockoutOnly: true }));
+      mock.method(pool, 'query', async (sql) => {
+        if (/FROM games/.test(sql)) {
+          return { rows: [
+            { id: 101, season: 2026, season_type: 1, week: 1, stage: 'group', game_date: new Date(Date.now() + 86400000).toISOString() },
+            { id: 201, season: 2026, season_type: 3, week: 1, stage: 'r16', game_date: new Date(Date.now() + 86400000).toISOString() },
+          ] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      });
+      const upsert = mock.method(UserPick, 'bulkUpsertWorldCupPicks', async () => []);
+
+      const res = await fetch(`${baseURL}/api/picks/group/wc-pool/world-cup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+        body: JSON.stringify({ picks: [
+          { gameId: 101, pickedResult: 'home' }, // group stage -> forbidden
+          { gameId: 201, pickedResult: 'home' }, // knockout -> would be fine on its own
+        ] }),
+      });
+      assert.strictEqual(res.status, 400);
+      const data = await res.json();
+      assert.match(data.error, /Group-stage picks are not allowed/);
+      assert.deepStrictEqual(data.gameIds, [101], 'reports the offending group-stage id');
+      assert.strictEqual(upsert.mock.callCount(), 0, 'a forbidden batch must never persist');
+    });
+
+    test('allows a knockout-stage pick in a knockout-only group', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member', knockoutOnly: true }));
+      mock.method(pool, 'query', async (sql) => {
+        if (/FROM games/.test(sql)) {
+          return { rows: [
+            { id: 201, season: 2026, season_type: 3, week: 1, stage: 'r16', game_date: new Date(Date.now() + 86400000).toISOString() },
+          ] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      });
+      const upsert = mock.method(UserPick, 'bulkUpsertWorldCupPicks', async ({ picks }) =>
+        picks.map((p) => ({ gameId: p.gameId, pickedResult: p.pickedResult }))
+      );
+      const res = await fetch(`${baseURL}/api/picks/group/wc-pool/world-cup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+        body: JSON.stringify({ picks: [{ gameId: 201, pickedResult: 'home' }] }),
+      });
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(upsert.mock.callCount(), 1);
+    });
+
+    test('still allows group-stage picks in an ordinary (non-knockout-only) WC group', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member', knockoutOnly: false }));
+      mock.method(pool, 'query', async (sql) => {
+        if (/FROM games/.test(sql)) {
+          return { rows: [
+            { id: 101, season: 2026, season_type: 1, week: 1, stage: 'group', game_date: new Date(Date.now() + 86400000).toISOString() },
+          ] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      });
+      const upsert = mock.method(UserPick, 'bulkUpsertWorldCupPicks', async ({ picks }) =>
+        picks.map((p) => ({ gameId: p.gameId, pickedResult: p.pickedResult }))
+      );
+      const res = await fetch(`${baseURL}/api/picks/group/wc-pool/world-cup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+        body: JSON.stringify({ picks: [{ gameId: 101, pickedResult: 'home' }] }),
+      });
+      assert.strictEqual(res.status, 200);
+      assert.strictEqual(upsert.mock.callCount(), 1, 'group-stage picks save normally when not knockout-only');
+    });
   });
 
   describe('GET /group/:groupId/world-cup/leaderboard', () => {
@@ -422,6 +496,32 @@ describe('World Cup picks router', () => {
       assert.strictEqual(res.status, 400);
       const data = await res.json();
       assert.match(data.error, /Invalid gameId/);
+    });
+
+    test('rejects an admin override of a group-stage pick in a knockout-only group', async () => {
+      // The knockout-only rule binds even an admin: a started/group-stage game is
+      // off-limits for everyone, so the override is rejected before any persistence.
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'admin', knockoutOnly: true }));
+      mock.method(pool, 'query', async (sql) => {
+        if (/FROM group_memberships/.test(sql)) return { rows: [{ '?column?': 1 }] };
+        if (/FROM games/.test(sql)) {
+          return { rows: [
+            { id: 101, season: 2026, season_type: 1, week: 1, stage: 'group', game_date: new Date(Date.now() + 86400000).toISOString() },
+          ] };
+        }
+        throw new Error(`unexpected query: ${sql}`);
+      });
+      const upsert = mock.method(UserPick, 'bulkUpsertWorldCupPicks', async () => []);
+      const res = await fetch(`${baseURL}/api/picks/group/wc-pool/world-cup/user/2`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+        body: JSON.stringify({ picks: [{ gameId: 101, pickedResult: 'home' }] }),
+      });
+      assert.strictEqual(res.status, 400);
+      const data = await res.json();
+      assert.match(data.error, /Group-stage picks are not allowed/);
+      assert.deepStrictEqual(data.gameIds, [101]);
+      assert.strictEqual(upsert.mock.callCount(), 0);
     });
   });
 

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
@@ -223,6 +223,7 @@ describe('CreateGroupForm', () => {
         identifier: 'my-group',
         description: 'A cool group',
         poolType: 'nfl_weekly',
+        knockoutOnly: false,
       });
     });
 
@@ -283,6 +284,73 @@ describe('CreateGroupForm', () => {
       });
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({ poolType: 'world_cup_2026' })
+      );
+    });
+  });
+
+  describe('knockout-only setting (World Cup sub-setting)', () => {
+    const knockoutLabel = /Knockout stage picks only/;
+
+    it('is hidden for an NFL pool', () => {
+      renderForm();
+      expect(screen.queryByLabelText(knockoutLabel)).not.toBeInTheDocument();
+    });
+
+    it('appears only after switching the pool type to World Cup', () => {
+      renderForm();
+      expect(screen.queryByLabelText(knockoutLabel)).not.toBeInTheDocument();
+      fireEvent.change(screen.getByLabelText(/Pool Type/), {
+        target: { value: 'world_cup_2026' },
+      });
+      expect(screen.getByLabelText(knockoutLabel)).toBeInTheDocument();
+    });
+
+    it('shows the toggle (unchecked) when initialValues select World Cup', () => {
+      renderForm({ initialValues: { poolType: 'world_cup_2026' } });
+      const checkbox = screen.getByLabelText(knockoutLabel) as HTMLInputElement;
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox.checked).toBe(false);
+    });
+
+    it('honors initialValues.knockoutOnly', () => {
+      renderForm({ initialValues: { poolType: 'world_cup_2026', knockoutOnly: true } });
+      expect((screen.getByLabelText(knockoutLabel) as HTMLInputElement).checked).toBe(true);
+    });
+
+    it('submits knockoutOnly=true when checked for a World Cup pool', async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderForm({ onSubmit });
+      fireEvent.change(screen.getByLabelText(/Group Name/), { target: { value: 'KO Crew' } });
+      fireEvent.change(screen.getByLabelText(/Pool Type/), {
+        target: { value: 'world_cup_2026' },
+      });
+      fireEvent.click(screen.getByLabelText(knockoutLabel));
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+      });
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ poolType: 'world_cup_2026', knockoutOnly: true }),
+      );
+    });
+
+    it('clears knockoutOnly when switching back to NFL after checking it', async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderForm({ onSubmit });
+      fireEvent.change(screen.getByLabelText(/Group Name/), { target: { value: 'Switcher' } });
+      fireEvent.change(screen.getByLabelText(/Pool Type/), {
+        target: { value: 'world_cup_2026' },
+      });
+      fireEvent.click(screen.getByLabelText(knockoutLabel));
+      // Switch back to NFL — the toggle disappears and must not travel with the pool.
+      fireEvent.change(screen.getByLabelText(/Pool Type/), {
+        target: { value: 'nfl_weekly' },
+      });
+      expect(screen.queryByLabelText(knockoutLabel)).not.toBeInTheDocument();
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+      });
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ poolType: 'nfl_weekly', knockoutOnly: false }),
       );
     });
   });

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
@@ -10,6 +10,11 @@ export interface CreateGroupFormValues {
   identifier: string;
   description: string;
   poolType: PoolType;
+  /**
+   * World Cup 2026 sub-setting. When true, the group only allows picks on
+   * knockout-stage games. Always false unless poolType is 'world_cup_2026'.
+   */
+  knockoutOnly: boolean;
 }
 
 export interface CreateGroupFormProps {
@@ -67,6 +72,10 @@ export default function CreateGroupForm({
   const [identifier, setIdentifier] = useState(initialValues?.identifier ?? '');
   const [description, setDescription] = useState(initialValues?.description ?? '');
   const [poolType, setPoolType] = useState<PoolType>(initialValues?.poolType ?? 'nfl_weekly');
+  const [knockoutOnly, setKnockoutOnly] = useState<boolean>(initialValues?.knockoutOnly ?? false);
+  // The knockout-only setting is meaningful only for World Cup pools, so it lives
+  // behind the pool-type choice and rides along on it.
+  const isWorldCup = poolType === 'world_cup_2026';
   const [identifierManuallyEdited, setIdentifierManuallyEdited] = useState(
     !!initialValues?.identifier
   );
@@ -121,7 +130,9 @@ export default function CreateGroupForm({
 
     setLoading(true);
     try {
-      await onSubmit({ name, identifier, description, poolType });
+      // knockoutOnly only travels with a World Cup pool; force it off otherwise
+      // so a stale toggle from a since-changed pool type can never leak through.
+      await onSubmit({ name, identifier, description, poolType, knockoutOnly: isWorldCup && knockoutOnly });
       setToast({ open: true, message: 'Group created!', variant: 'success' });
     } catch (err) {
       setToast({
@@ -198,7 +209,13 @@ export default function CreateGroupForm({
           <select
             id="pool-type"
             value={poolType}
-            onChange={(e) => setPoolType(e.target.value as PoolType)}
+            onChange={(e) => {
+              const next = e.target.value as PoolType;
+              setPoolType(next);
+              // Leaving World Cup clears the sub-setting so it never travels with
+              // an NFL pool (the server rejects that combination anyway).
+              if (next !== 'world_cup_2026') setKnockoutOnly(false);
+            }}
             disabled={loading}
             className="block w-full rounded-md border border-secondary-300 px-3 py-2 text-secondary-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:bg-secondary-100 disabled:text-secondary-500 dark:bg-secondary-900 dark:border-secondary-600 dark:text-secondary-100"
           >
@@ -206,6 +223,33 @@ export default function CreateGroupForm({
             <option value="world_cup_2026">World Cup 2026</option>
           </select>
         </div>
+
+        {/* World Cup 2026 sub-setting. Only shown for a World Cup pool — it has no
+            meaning for NFL. When on, the group's Picks tab hides group-stage games
+            and the server rejects any group-stage pick. */}
+        {isWorldCup && (
+          <div className="rounded-md border border-secondary-200 bg-secondary-50 p-3 dark:border-secondary-700 dark:bg-secondary-900/40">
+            <label htmlFor="knockout-only" className="flex items-start gap-3 cursor-pointer">
+              <input
+                id="knockout-only"
+                type="checkbox"
+                checked={knockoutOnly}
+                onChange={(e) => setKnockoutOnly(e.target.checked)}
+                disabled={loading}
+                className="mt-0.5 h-4 w-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500 disabled:opacity-50"
+              />
+              <span className="text-sm">
+                <span className="block font-medium text-secondary-900 dark:text-secondary-100">
+                  Knockout stage picks only
+                </span>
+                <span className="block text-secondary-500 dark:text-secondary-400">
+                  Members can only pick knockout games (Round of 32 onward). Group-stage
+                  games are excluded. This can&apos;t be changed after the group is created.
+                </span>
+              </span>
+            </label>
+          </div>
+        )}
 
         <div className="flex space-x-3 pt-4">
           <div className="relative inline-toast-anchor">

--- a/frontend/src/designsystem/components/GroupCard/GroupCard.tsx
+++ b/frontend/src/designsystem/components/GroupCard/GroupCard.tsx
@@ -17,6 +17,9 @@ export interface GroupData {
   // predating #86. Forwarded by groupsService.getMyGroups so callers can
   // partition by pool type.
   poolType?: 'nfl_weekly' | 'world_cup_2026' | null;
+  // World Cup 2026 sub-setting forwarded by getMyGroups so the picks surface can
+  // hide group-stage games even without a loaded group object (standalone page).
+  knockoutOnly?: boolean;
 }
 
 export interface GroupCardProps {

--- a/frontend/src/lib/groupsService.d.ts
+++ b/frontend/src/lib/groupsService.d.ts
@@ -22,6 +22,8 @@ export interface GroupDetail {
   userRole?: string;
   createdAt?: string;
   poolType?: PoolType;
+  // World Cup 2026 sub-setting: group allows only knockout-stage picks.
+  knockoutOnly?: boolean;
 }
 
 export interface GroupMember {
@@ -51,6 +53,7 @@ export function createGroup(payload: {
   identifier: string;
   description?: string;
   poolType?: PoolType;
+  knockoutOnly?: boolean;
 }): Promise<void>;
 export function getGroup(identifier: string): Promise<GroupDetail>;
 export function getMembers(identifier: string): Promise<GroupMember[]>;

--- a/frontend/src/lib/groupsService.js
+++ b/frontend/src/lib/groupsService.js
@@ -52,7 +52,10 @@ export async function getMyGroups() {
   createdByPictureUrl: g.createdByPictureUrl || null,
   // Forwarded so the picks pages can fan a single submit out to every group
   // of the same poolType ('save to all my World Cup groups' / NFL groups).
-  poolType: g.poolType || null
+  poolType: g.poolType || null,
+  // World Cup knockout-only sub-setting; lets the picks tab hide group-stage
+  // games even on the standalone /world-cup surface (no group object loaded).
+  knockoutOnly: Boolean(g.knockoutOnly)
   }));
 }
 
@@ -66,6 +69,9 @@ export async function createGroup(payload) {
   };
   // Only forward poolType when provided so existing NFL group creation is unchanged.
   if (payload.poolType) body.poolType = payload.poolType;
+  // knockoutOnly is a World Cup sub-setting; only forward it when truthy so NFL
+  // group creation is byte-for-byte unchanged (the server rejects it for NFL).
+  if (payload.knockoutOnly) body.knockoutOnly = true;
   const res = await authFetch(`${apiBase()}`, {
     method: 'POST',
     body: JSON.stringify(body)
@@ -89,7 +95,13 @@ export async function getGroup(identifier) {
   if (!res.ok) throw new Error('Failed to load group');
   const data = await res.json();
   // Map the backend snake_case pool_type onto a camelCase poolType property.
-  return { ...data, ...(data.pool_type != null ? { poolType: data.pool_type } : {}) };
+  // The Group model serializes camelCase (poolType/knockoutOnly), but tolerate a
+  // raw snake_case row too (some callers/tests stub the bare DB shape).
+  return {
+    ...data,
+    ...(data.pool_type != null ? { poolType: data.pool_type } : {}),
+    ...(data.knockout_only != null ? { knockoutOnly: data.knockout_only } : {}),
+  };
 }
 
 export async function getMembers(identifier) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -17,6 +17,13 @@ export interface Group {
   createdAt: string;
   createdByName?: string | null;
   createdByPictureUrl?: string | null;
+  poolType?: PoolType | null;
+  /**
+   * World Cup 2026 sub-setting: when true the group only allows picks on
+   * knockout-stage games (group-stage games are hidden and rejected server-side).
+   * Always false/absent for NFL pools.
+   */
+  knockoutOnly?: boolean;
 }
 
 export interface GroupMember {

--- a/frontend/src/pages/CreateGroupPage.test.tsx
+++ b/frontend/src/pages/CreateGroupPage.test.tsx
@@ -57,6 +57,7 @@ describe('CreateGroupPage', () => {
       identifier: 'my-group',
       description: '',
       poolType: 'nfl_weekly',
+      knockoutOnly: false,
     });
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/groups');
@@ -83,7 +84,32 @@ describe('CreateGroupPage', () => {
       identifier: 'my-group',
       description: '',
       poolType: 'world_cup_2026',
+      knockoutOnly: false,
     });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/groups');
+    });
+  });
+
+  it('forwards the knockout-only World Cup sub-setting to createGroup', async () => {
+    mockCreateGroup.mockResolvedValue(undefined);
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText(/Group Name/), {
+      target: { value: 'My Group' },
+    });
+    fireEvent.change(screen.getByLabelText('Pool Type'), {
+      target: { value: 'world_cup_2026' },
+    });
+    fireEvent.click(screen.getByLabelText(/Knockout stage picks only/));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+    });
+
+    expect(mockCreateGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ poolType: 'world_cup_2026', knockoutOnly: true }),
+    );
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/groups');
     });

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -186,6 +186,30 @@ describe('WorldCupPicksTab', () => {
       expect(cardFor('Canada')).toBeInTheDocument();
     });
 
+    it('never counts or submits a hydrated group-stage pick in a knockout-only group', async () => {
+      // Saved picks include a stale group-stage selection (id 10) alongside a
+      // knockout one (id 20). The group-stage pick is invisible here, so it must
+      // not be counted in the submit bar nor sent to the server.
+      mockGetMyWorldCupPicks.mockResolvedValue({
+        picks: [
+          { gameId: 10, pickedResult: 'home' }, // group stage — must be ignored
+          { gameId: 20, pickedResult: 'home' }, // knockout — counts
+        ],
+      });
+      mockSubmitPicks.mockResolvedValue({});
+      render(<WorldCupPicksTab identifier="la-crew" knockoutOnly />);
+      await screen.findByText((_c, n) => n?.textContent?.startsWith('Canada vs ') ?? false, {
+        selector: 'span',
+      });
+      // Only the knockout pick is counted — not the hidden group-stage one.
+      expect(await screen.findByText('1 pick selected')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Submit Picks' }));
+      await waitFor(() =>
+        expect(mockSubmitPicks).toHaveBeenCalledWith('la-crew', [{ gameId: 20, pickedResult: 'home' }]),
+      );
+    });
+
     it('keeps group-stage games visible when knockoutOnly is false', async () => {
       render(<WorldCupPicksTab identifier="la-crew" knockoutOnly={false} />);
       await screen.findByText((_c, n) => n?.textContent?.startsWith('Mexico vs ') ?? false, {

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.test.tsx
@@ -147,6 +147,56 @@ describe('WorldCupPicksTab', () => {
     fireEvent.click(screen.getByRole('radio', { name }));
   }
 
+  // A knockout-only group hides every group-stage game so members can only pick
+  // knockout matches. The fixtures above are one group game (Mexico) + one
+  // knockout game (Canada), so the group game must vanish and the knockout stay.
+  describe('knockout-only group', () => {
+    function queryHome(homeName: string) {
+      return screen.queryByText(
+        (_c, n) => n?.textContent?.startsWith(homeName + ' vs ') ?? false,
+        { selector: 'span' },
+      );
+    }
+
+    it('hides group-stage games when the knockoutOnly prop is set', async () => {
+      render(<WorldCupPicksTab identifier="la-crew" knockoutOnly />);
+      // The knockout match (Canada vs Argentina) still renders…
+      await screen.findByText((_c, n) => n?.textContent?.startsWith('Canada vs ') ?? false, {
+        selector: 'span',
+      });
+      showAllGames();
+      expect(cardFor('Canada')).toBeInTheDocument();
+      // …but the group-stage match (Mexico vs USA) is filtered out entirely.
+      expect(queryHome('Mexico')).not.toBeInTheDocument();
+      // The group-stage scoring bullet is omitted, since it can't be picked here.
+      expect(screen.queryByText(/Group stage:/)).not.toBeInTheDocument();
+    });
+
+    it('derives knockout-only from getMyGroups when no prop is passed (standalone page)', async () => {
+      mockGetMyGroups.mockResolvedValue([
+        { id: 1, identifier: 'la-crew', name: 'LA Crew', poolType: 'world_cup_2026', knockoutOnly: true },
+      ] as any);
+      renderTab(); // standalone surface: no knockoutOnly prop
+      await screen.findByText((_c, n) => n?.textContent?.startsWith('Canada vs ') ?? false, {
+        selector: 'span',
+      });
+      showAllGames();
+      // Once getMyGroups resolves, the derived flag hides the group-stage game.
+      await waitFor(() => expect(queryHome('Mexico')).not.toBeInTheDocument());
+      expect(cardFor('Canada')).toBeInTheDocument();
+    });
+
+    it('keeps group-stage games visible when knockoutOnly is false', async () => {
+      render(<WorldCupPicksTab identifier="la-crew" knockoutOnly={false} />);
+      await screen.findByText((_c, n) => n?.textContent?.startsWith('Mexico vs ') ?? false, {
+        selector: 'span',
+      });
+      showAllGames();
+      expect(cardFor('Mexico')).toBeInTheDocument();
+      expect(cardFor('Canada')).toBeInTheDocument();
+    });
+  });
+
   it('shows the loading indicator while a stage fetch is in flight', async () => {
     // A never-resolving promise pins the tab in its loading state — and the
     // sticky submit bar must not render before any matches exist.

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -308,13 +308,24 @@ export default function WorldCupPicksTab({
   const now = useMemo(() => new Date(), []); // one stable "now" per mount for the list's date logic
   // "today" filtering can drift on a session left open past midnight; acceptable (server enforces locks).
 
+  // Submittable picks come from the VISIBLE matches only. In a knockout-only group
+  // this excludes any group-stage draft entry — guarding the window on the
+  // standalone page where `derivedKnockoutOnly` resolves a tick after mount and a
+  // group-stage game could be briefly pickable. Hidden games can't be submitted or
+  // counted, so the server's group-stage rejection is never even reached.
+  const visibleIds = useMemo(
+    () => new Set(visibleMatches.map((m) => m.id)),
+    [visibleMatches],
+  );
   const picks: MatchPick[] = useMemo(
     () =>
-      Object.entries(draft).map(([gameId, pickedResult]) => ({
-        gameId: Number(gameId),
-        pickedResult,
-      })),
-    [draft],
+      Object.entries(draft)
+        .filter(([gameId]) => visibleIds.has(Number(gameId)))
+        .map(([gameId, pickedResult]) => ({
+          gameId: Number(gameId),
+          pickedResult,
+        })),
+    [draft, visibleIds],
   );
 
   // Read-only viewers can never submit; everyone else needs a group + ≥1 pick.

--- a/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
+++ b/frontend/src/pages/GroupDetails/WorldCupPicksTab.tsx
@@ -71,6 +71,13 @@ export interface WorldCupPicksTabProps {
   currentUserId?: string | number | null;
   /** Whether the caller is a group admin. Gates editing OTHER members' picks. */
   isAdmin?: boolean;
+  /**
+   * Knockout-only group: hide group-stage games entirely so members can only pick
+   * knockout matches. Passed by GroupDetailsPage (which has the loaded group) for
+   * instant correctness on first paint; the standalone /world-cup page omits it,
+   * so the tab also derives it from its own getMyGroups fetch as a fallback.
+   */
+  knockoutOnly?: boolean;
   /** Saved view the embedded games list opens on (e.g. 'needs-pick' from a deeplink). */
   initialView?: SavedView;
 }
@@ -80,6 +87,7 @@ export default function WorldCupPicksTab({
   members = [],
   currentUserId = null,
   isAdmin = false,
+  knockoutOnly,
   initialView,
 }: WorldCupPicksTabProps) {
   const groupId = identifier;
@@ -276,9 +284,26 @@ export default function WorldCupPicksTab({
   // Derive the flat browse-list games from the fetched matches + the current
   // draft. The list itself owns view/filter/sort state; we just feed it data and
   // route picks back through pickResult.
+  // Fallback knockout-only flag derived from the getMyGroups fetch (below), for
+  // the standalone /world-cup page where no group object — and thus no prop — is
+  // passed. The explicit prop (from GroupDetailsPage) always wins so first paint
+  // is correct.
+  const [derivedKnockoutOnly, setDerivedKnockoutOnly] = useState(false);
+  const effectiveKnockoutOnly = knockoutOnly ?? derivedKnockoutOnly;
+
+  // In a knockout-only group the group stage is off-limits, so drop those matches
+  // before anything renders or counts them. Everything downstream (browse list,
+  // empty state, submit bar) keys off this filtered view.
+  const visibleMatches = useMemo(
+    () =>
+      effectiveKnockoutOnly
+        ? fetchState.matches.filter((m) => m.stage !== 'group')
+        : fetchState.matches,
+    [fetchState.matches, effectiveKnockoutOnly],
+  );
   const browseGames = useMemo(
-    () => toBrowseGames(fetchState.matches, draft),
-    [fetchState.matches, draft],
+    () => toBrowseGames(visibleMatches, draft),
+    [visibleMatches, draft],
   );
   const now = useMemo(() => new Date(), []); // one stable "now" per mount for the list's date logic
   // "today" filtering can drift on a session left open past midnight; acceptable (server enforces locks).
@@ -319,6 +344,10 @@ export default function WorldCupPicksTab({
     getMyGroups()
       .then((groups) => {
         if (cancelled) return;
+        // Derive this group's knockout-only flag from the roster fetch (used only
+        // when no explicit prop is supplied — e.g. the standalone /world-cup page).
+        const self = groups.find((g) => g.identifier === groupId);
+        if (self) setDerivedKnockoutOnly(Boolean(self.knockoutOnly));
         const wc: SaveTarget[] = groups
           .filter((g) => g.poolType === 'world_cup_2026')
           .map((g) => ({ identifier: g.identifier, name: g.name }));
@@ -478,11 +507,15 @@ export default function WorldCupPicksTab({
           the sum across every match you pick.
         </p>
         <ul className="mt-xs list-disc space-y-xxs pl-lg">
-          <li>
-            <span className="font-medium text-secondary-900 dark:text-neutral-0">Group stage:</span>{' '}
-            winning team = 3 pts · a team that draws = 1 · pick &ldquo;Draw&rdquo; = 2 if it draws (1
-            if a team wins) · losing team = 0.
-          </li>
+          {/* This is a knockout-only group, so the group-stage scoring line is
+              omitted — those games can't be picked here. */}
+          {!effectiveKnockoutOnly && (
+            <li>
+              <span className="font-medium text-secondary-900 dark:text-neutral-0">Group stage:</span>{' '}
+              winning team = 3 pts · a team that draws = 1 · pick &ldquo;Draw&rdquo; = 2 if it draws (1
+              if a team wins) · losing team = 0.
+            </li>
+          )}
           <li>
             <span className="font-medium text-secondary-900 dark:text-neutral-0">Knockout:</span>{' '}
             the team that advances = 3 pts, everyone else = 0. Penalties still count as advancing, so
@@ -502,8 +535,15 @@ export default function WorldCupPicksTab({
               Try Again
             </Button>
           </div>
-        ) : fetchState.matches.length === 0 ? (
-          <EmptyState title="No matches yet" description="No matches found for this tournament." />
+        ) : visibleMatches.length === 0 ? (
+          <EmptyState
+            title="No matches yet"
+            description={
+              effectiveKnockoutOnly
+                ? 'No knockout matches are available yet. They appear once the bracket is set.'
+                : 'No matches found for this tournament.'
+            }
+          />
         ) : (
           <WorldCupGamesList
             games={browseGames}
@@ -516,7 +556,7 @@ export default function WorldCupPicksTab({
       </div>
 
       {/* Spacer so the sticky bar never covers the last match row. */}
-      {fetchState.matches.length > 0 && <div className="h-20" aria-hidden="true" />}
+      {visibleMatches.length > 0 && <div className="h-20" aria-hidden="true" />}
 
       {/* Sticky submit bar — pinned to the bottom of the viewport so the user
           can submit from anywhere in the stage list without scrolling to the
@@ -528,7 +568,7 @@ export default function WorldCupPicksTab({
           two bars cross while scrolling, but below the match detail panel
           (z-40) — so the filter bar reads as tethered to the content sliding
           under it while this bar floats cleanly on top. */}
-      {fetchState.matches.length > 0 && (
+      {visibleMatches.length > 0 && (
         <div className="sticky bottom-0 z-20 -mx-sm sm:-mx-lg mt-lg border-t border-border bg-neutral-0/95 px-sm sm:px-lg py-sm shadow-[0_-2px_8px_-2px_rgba(0,0,0,0.06)] backdrop-blur dark:bg-secondary-900/95">
           <div className="mx-auto flex max-w-4xl flex-col gap-sm sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-col gap-xxs sm:flex-row sm:items-center sm:gap-md">

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -385,6 +385,7 @@ export default function GroupDetailsPage() {
               members={members}
               currentUserId={user?.id ?? null}
               isAdmin={isOwner}
+              knockoutOnly={group?.knockoutOnly ?? false}
               initialView={picksInitialView}
             />
           ) : (

--- a/frontend/tests/e2e/world-cup-knockout-only-group.spec.ts
+++ b/frontend/tests/e2e/world-cup-knockout-only-group.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test'
+
+// A world_cup_2026 group created with the "knockout stage picks only" setting
+// must let members pick ONLY knockout games — the group stage is hidden entirely
+// on the Picks tab, and the server rejects any group-stage pick. This e2e drives
+// the in-group Picks tab and asserts the group-stage fixture never renders while
+// the knockout fixture does, then makes + submits a knockout pick end-to-end.
+//
+// The knockout-only flag rides on the group object: getGroup returns
+// knockout_only=true (snake_case from the backend row), which GroupDetailsPage
+// forwards to the embedded WorldCupPicksTab. (/world-cup-picks is the
+// filename-derived route the coverage check matches.)
+test('knockout-only group hides group-stage games on the Picks tab', async ({ page }) => {
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Catch-all safety net first (lowest precedence). Any unstubbed API call
+  // resolves to an empty object so the test never reaches a real backend.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  // Saved-picks hydrate returns none; the POST records the submitted body.
+  let submittedBody: { picks?: { gameId: number; pickedResult: string }[] } | null = null
+  await page.route('**/api/picks/group/**/world-cup/me', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ picks: [] }) }),
+  )
+  await page.route('**/api/picks/group/ko-group/world-cup', async (route) => {
+    submittedBody = route.request().postDataJSON()
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ picks: submittedBody?.picks ?? [] }),
+    })
+  })
+
+  // my-groups feeds the tab's fan-out dropdown + the derived knockout-only
+  // fallback; return the group as an array so getMyGroups resolves cleanly.
+  await page.route('**/api/groups/my-groups', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: '1', identifier: 'ko-group', name: 'Knockout Squad', userRole: 'member', poolType: 'world_cup_2026', knockoutOnly: true },
+      ]),
+    }),
+  )
+
+  // Group detail mount fans out to getGroup / getMembers / getMessages under
+  // /api/groups/<identifier>. getGroup must return pool_type='world_cup_2026' to
+  // flip the tabs to the tournament variant AND knockout_only=true to enable the
+  // setting; members/messages return empty arrays.
+  await page.route('**/api/groups/**', async (route) => {
+    const url = route.request().url()
+    if (url.includes('/my-groups')) return route.fallback() // handled above
+    if (url.includes('/members') || url.includes('/messages')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        name: 'Knockout Squad',
+        identifier: 'ko-group',
+        memberCount: 1,
+        userRole: 'member',
+        pool_type: 'world_cup_2026',
+        knockout_only: true,
+      }),
+    })
+  })
+
+  // The whole-tournament endpoint returns one group-stage game (must be hidden)
+  // and one knockout game (must remain pickable).
+  await page.route('**/api/games/world-cup-2026/stages', async (route) => {
+    const games = [
+      {
+        id: 101,
+        stage: 'group',
+        isKnockout: false,
+        status: 'SCHEDULED',
+        homeScore: 0,
+        awayScore: 0,
+        gameDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        winnerTeamId: null,
+        homeTeam: { id: '1', name: 'Mexico', abbreviation: 'MEX', logo: 'https://example.test/mex.png' },
+        awayTeam: { id: '2', name: 'Canada', abbreviation: 'CAN', logo: 'https://example.test/can.png' },
+      },
+      {
+        id: 201,
+        stage: 'r32',
+        isKnockout: true,
+        status: 'SCHEDULED',
+        homeScore: 0,
+        awayScore: 0,
+        gameDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        winnerTeamId: null,
+        homeTeam: { id: '3', name: 'France', abbreviation: 'FRA', logo: 'https://example.test/fra.png' },
+        awayTeam: { id: '4', name: 'Brazil', abbreviation: 'BRA', logo: 'https://example.test/bra.png' },
+      },
+    ]
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, count: games.length, cached: false }),
+    })
+  })
+
+  await page.goto('/group-details?group=ko-group')
+
+  await expect(page.getByRole('heading', { name: 'Knockout Squad' })).toBeVisible()
+
+  // Enter the Picks tab; switch to the "All" view so date filters don't hide the
+  // future-dated knockout fixture.
+  await page.getByRole('tab', { name: 'Picks' }).click()
+  await page.getByRole('button', { name: 'All' }).click()
+
+  // The knockout game renders and is pickable…
+  const knockoutCard = page.getByTestId('match-card-201')
+  await expect(knockoutCard).toBeVisible()
+  await expect(knockoutCard.getByRole('button', { name: 'FRA' })).toBeVisible()
+  await expect(knockoutCard.getByRole('button', { name: 'BRA' })).toBeVisible()
+  // A knockout can't draw — no Draw option.
+  await expect(knockoutCard.getByRole('button', { name: 'Draw' })).toHaveCount(0)
+
+  // …but the group-stage game is hidden entirely — no card, and the group-stage
+  // scoring line is gone from the rules box.
+  await expect(page.getByTestId('match-card-101')).toHaveCount(0)
+  await expect(page.getByText(/Group stage:/)).toHaveCount(0)
+
+  // Picking the knockout game and submitting posts only that pick to the group's
+  // world-cup endpoint.
+  await knockoutCard.getByRole('button', { name: 'FRA' }).click()
+  await expect(page.getByText('1 pick selected')).toBeVisible()
+  await page.getByRole('button', { name: 'Submit Picks' }).click()
+  await expect(page.getByText('Picks saved')).toBeVisible()
+  expect(submittedBody).toEqual({ picks: [{ gameId: 201, pickedResult: 'home' }] })
+})


### PR DESCRIPTION
## Summary

Adds a **"Knockout stage picks only"** sub-setting to World Cup 2026 group creation. When enabled, members of that group can pick **only knockout-stage games** (Round of 32 → Final) — the group stage is hidden on the Picks tab and rejected server-side. The setting is chosen at creation and is **immutable** afterward (same lifecycle as `pool_type`).

Scoring and the leaderboard need no changes: they already sum per-match over whatever picks exist, so a knockout-only group simply has no group-stage picks to score.

> ⚠️ As called out in the request, coarse all-or-nothing knockout scoring is tie-prone; a tiebreaker wrinkle is intended as a separate follow-up.

## Data model

- New column `groups.knockout_only BOOLEAN NOT NULL DEFAULT false`, added exactly like `pool_type`: in `schema.sql` (CREATE + idempotent `DO $$` ALTER) and in `backend/scripts/addWorldCupColumns.js`.
- `Group` model carries `knockoutOnly` through the constructor, `create()`, `findByIdentifier()`, and `getUserGroups()`. Deliberately left out of `update()`'s `allowedFields` (immutable).

## Enforcement

- **`POST /api/groups`** rejects `knockoutOnly` with 400 unless `poolType === 'world_cup_2026'`.
- **Both** World Cup pick routes (`POST …/world-cup` and the admin-override `…/world-cup/user/:userId`) read each game's `stage` back from the DB and reject any group-stage pick in a knockout-only group with `400 { error, gameIds }` — nothing persists.

## Frontend

- `CreateGroupForm` shows the checkbox only when Pool Type is World Cup 2026 (cleared when switching back to NFL); the value flows through `groupsService.createGroup`.
- `WorldCupPicksTab` filters out `stage === 'group'` games via a `knockoutOnly` prop (`GroupDetailsPage` passes `group.knockoutOnly`), with a `getMyGroups`-derived fallback so the standalone `/world-cup` deep-link surface also hides the group stage. The group-stage scoring line is hidden too.

## Tests

- **Backend:** new `groups-create-route.test.js` (create validation) + new cases in `worldcup-picks-route.test.js` (group-stage pick rejected in both routes; knockout picks and ordinary WC groups unaffected).
- **Frontend unit:** `CreateGroupForm` toggle visibility/value/reset; `WorldCupPicksTab` hides group-stage games (via prop and via derived flag).
- **E2E:** `world-cup-knockout-only-group.spec.ts` — in-group Picks tab shows the knockout game, hides the group-stage game, and submits a knockout pick.

Verification (this branch):
- Backend: `node --test tests/*.test.js` → 270 pass (the 4 failures are pre-existing DB-dependent integration tests, identical on `main`).
- Frontend: full `vitest run` → 745 pass; `pnpm build` clean; the 3 relevant e2e specs pass.

## Deploy note

Prod runs with `INIT_DB` unset, so the new column will **not** appear on a normal deploy. Land it with **one `INIT_DB=true` deploy** or by running `node backend/scripts/addWorldCupColumns.js` against prod. `DEFAULT false` backfills existing rows, so it's non-destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)