### PR TITLE
fix: WC needs-pick count for knockout-only groups + refresh resolved knockout matchups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,46 @@ exist.
   `knockoutOnly`. WC-pick-route tests stub `Group.findByIdentifier` to return
   `{ ..., knockoutOnly: true }` and add `stage` to the `FROM games` row mock.
 
+## Fixes: WC needs-pick banner + stale knockout matchups (2026-06)
+
+Two independent bugs surfaced by a knockout-only group; fixed together.
+
+**1. Banner/dot over-counts in a knockout-only group.** The leaderboard banner
+(`GroupDetailsPage`) and the groups-list dot (`GroupsPage`) both call
+`countNeedsPick(matches, picks, now)` ([wcNeedsPick.ts](frontend/src/lib/wcNeedsPick.ts)),
+which counted the *unfiltered* slate — so a knockout-only group counted the
+remaining pickable **group-stage** games it can't actually pick (banner said 13,
+Picks tab said 1). Both screens already share the same `needsPick`/`teamsDecided`
+predicate; the only divergence was the missing stage filter. Fix: `countNeedsPick`
+takes an optional `knockoutOnly` arg that drops `stage === 'group'` before counting;
+both call sites pass the group's flag (`group?.knockoutOnly` / `g.knockoutOnly`).
+Ongoing pools pass `false` → unchanged.
+
+**2. Resolved knockout matchups served stale (placeholders).** Two compounding
+backend causes, both pre-existing:
+- `Game.isDifferentFrom()` ([Game.js](backend/src/models/Game.js)) compared
+  date/status/score/period/clock/statusDetail/eventCount but **not team identity**,
+  so when ESPN swaps a bracket placeholder ("Third Place Group B/E/F/I/J", abbr
+  `3RD`, `isActive:false`) for the resolved team (Bosnia/`BIH`/`isActive:true`) with
+  no other field changing, the cache update gate never fired. Fix: also diff a
+  team-identity fingerprint over **stable** fields only — `id | abbreviation |
+  isActive` — for home and away. Volatile fields (record/form/logo/odds) are
+  deliberately excluded so NFL/group-stage rows never churn.
+- `GameService.isStageCacheFresh()` served future SCHEDULED games from the DB for up
+  to 24h without consulting ESPN, so even with the diff fix nothing re-fetched.
+  Fix: a **proactive, throttled** trigger — a knockout stage still holding
+  placeholder participants (`hasUnresolvedKnockoutParticipants` /
+  `isPlaceholderTeam`, mirroring the frontend `teamDecided` rule) re-checks ESPN at
+  most once per `PLACEHOLDER_REFRESH_THROTTLE_MS` (5 min), tracked per stage in the
+  in-process `_lastStageFetchAt` map (set in `getWorldCupStage` whenever ESPN is
+  fetched). `isStageCacheFresh` now takes `(cachedSet, stage, now)`; the old
+  2-arg/`stage=null` calls skip the placeholder branch (group stage never has
+  placeholders anyway). Bounds ESPN to traffic-independent ~1 call/stage/5min.
+
+Both fixes apply to ongoing AND knockout-only World Cup groups (the stale-matchup
+fix is at the cache layer, shared by all WC pools). `?refresh=true` / `?force=1` on
+the stage routes still force-bypass the cache.
+
 ## Commands
 
 ```bash

--- a/backend/src/models/Game.js
+++ b/backend/src/models/Game.js
@@ -247,6 +247,16 @@ static parseMatchEvents(competition, homeComp, awayComp) {
     // parse — even to an empty [] — reads as a change and gets persisted, which
     // is what backfills the events column for pre-existing rows.
     const eventCount = (g) => (Array.isArray(g.events) ? g.events.length : -1);
+    // Team-identity fingerprint over STABLE fields only: id, abbreviation, and the
+    // ESPN isActive flag. This is what lets a soccer knockout matchup refresh when
+    // its bracket slot resolves — ESPN swaps a placeholder ("Third Place Group
+    // B/E/F/I/J", abbr "3RD", isActive:false) for the real team ("Bosnia", "BIH",
+    // isActive:true) WITHOUT changing date/status/score, so none of the fields
+    // below would catch it. Deliberately excludes volatile fields (record, form,
+    // logo, odds) so NFL/group-stage rows — whose identity never changes — don't
+    // churn the cache on every refresh.
+    const teamIdentity = (t) =>
+      t ? `${t.id ?? ''}|${t.abbreviation ?? ''}|${t.isActive === false ? '0' : '1'}` : '';
     return (
       this.gameDate.getTime() !== otherGame.gameDate.getTime() ||
   this.status !== otherGame.status ||
@@ -255,6 +265,8 @@ static parseMatchEvents(competition, homeComp, awayComp) {
   this.period !== otherGame.period ||
   this.displayClock !== otherGame.displayClock ||
   this.statusDetail !== otherGame.statusDetail ||
+  teamIdentity(this.homeTeam) !== teamIdentity(otherGame.homeTeam) ||
+  teamIdentity(this.awayTeam) !== teamIdentity(otherGame.awayTeam) ||
   eventCount(this) !== eventCount(otherGame)
     );
   }

--- a/backend/src/services/GameService.js
+++ b/backend/src/services/GameService.js
@@ -158,13 +158,59 @@ export class GameService {
   // group stage is the only World Cup phase where a 'draw' is a terminal result.
   static KNOCKOUT_STAGES = new Set(['r32', 'r16', 'qf', 'sf', 'third', 'final']);
 
+  // Bracket-placeholder detection, mirroring the frontend's teamDecided rule
+  // (wcGamesView.ts). A knockout slot is unresolved until the bracket decides it;
+  // ESPN seeds it with isActive:false, a digit-bearing abbreviation (3RD, 1G, 2K),
+  // and a qualification-path name ("Third Place Group …", "Group G Winner").
+  static PLACEHOLDER_NAME = /\b(winner|runner-?up|loser|place|group|tbd)\b|\//i;
+
+  static isPlaceholderTeam(t) {
+    if (!t) return true;
+    if (t.isActive === false) return true;
+    if (typeof t.abbreviation === 'string' && /\d/.test(t.abbreviation)) return true;
+    if (typeof t.name === 'string' && GameService.PLACEHOLDER_NAME.test(t.name)) return true;
+    return false;
+  }
+
+  // Does this knockout-stage slate still hold an unresolved matchup? Only knockout
+  // stages can (the group stage always has two real teams), so a non-knockout
+  // stage is never flagged.
+  static hasUnresolvedKnockoutParticipants(cachedSet, stage) {
+    if (!GameService.KNOCKOUT_STAGES.has(stage)) return false;
+    return cachedSet.some(
+      (g) => GameService.isPlaceholderTeam(g.homeTeam) || GameService.isPlaceholderTeam(g.awayTeam),
+    );
+  }
+
+  // How often a placeholder-bearing knockout stage may re-check ESPN. Bracket
+  // slots resolve as OTHER stages' games finish, which this stage's own rows can't
+  // signal (their date/status/score don't move when only the matchup resolves), so
+  // we poll — but throttled per stage so a tournament-long wall of placeholders
+  // can't hammer ESPN on every leaderboard/picks load.
+  static PLACEHOLDER_REFRESH_THROTTLE_MS = 5 * 60 * 1000;
+
+  // Per-stage timestamp of the last ESPN fetch, used only to throttle the
+  // placeholder-resolution refresh above. In-process (per serverless instance);
+  // a cold start just costs one extra fetch, which is fine.
+  static _lastStageFetchAt = new Map();
+
   // Decide whether a persisted World Cup stage slate can be served without an
   // ESPN refresh. Mirrors getGamesForWeek's freshness rules: in-progress games
   // tolerate a cache up to 60s old, SCHEDULED games at/past their start time
   // (with a 2-minute look-ahead) force a refresh unless we refreshed within the
   // last minute, and otherwise the 24h isStale() rule applies.
-  static isStageCacheFresh(cachedSet, now = Date.now()) {
+  static isStageCacheFresh(cachedSet, stage = null, now = Date.now()) {
     if (cachedSet.length === 0) return false;
+
+    // Proactive matchup-resolution refresh: a knockout stage still holding
+    // placeholder participants re-checks ESPN so newly-decided bracket matchups
+    // (e.g. "Third Place Group B" → "Bosnia") surface promptly instead of only
+    // after the 24h staleness TTL. Throttled per stage so an all-placeholder
+    // bracket early in the tournament can't refetch every stage on every request.
+    if (GameService.hasUnresolvedKnockoutParticipants(cachedSet, stage)) {
+      const lastFetch = GameService._lastStageFetchAt.get(stage) ?? 0;
+      if (now - lastFetch >= GameService.PLACEHOLDER_REFRESH_THROTTLE_MS) return false;
+    }
 
     // One-time events backfill: a started match (IN_PROGRESS or FINAL) whose
     // events column is still NULL was cached before goal/card parsing existed.
@@ -213,7 +259,7 @@ export class GameService {
     try {
       if (!forceRefresh) {
         const cachedSet = await Game.findByLeagueStage('world_cup', stage);
-        if (GameService.isStageCacheFresh(cachedSet)) {
+        if (GameService.isStageCacheFresh(cachedSet, stage)) {
           for (const g of cachedSet) {
             // Persisted winner wins; recompute from scores for rows written
             // before winner_team_id existed (regulation results only — a PK
@@ -225,6 +271,10 @@ export class GameService {
       }
 
       const service = getESPNService();
+      // Record the fetch up front so the placeholder-resolution throttle counts
+      // from when we asked ESPN, not when it answered — and a failed fetch still
+      // backs off rather than retrying on every request.
+      GameService._lastStageFetchAt.set(stage, Date.now());
       const espnEvents = await service.fetchSoccerWeek('fifa.world', stage);
       const cachedById = await Game.findByESPNIds(espnEvents.map(e => e.id));
 

--- a/backend/tests/game-soccer.test.js
+++ b/backend/tests/game-soccer.test.js
@@ -114,6 +114,51 @@ describe('Game.fromESPNData team.isActive (undecided knockout slots)', () => {
   });
 });
 
+describe('Game.isDifferentFrom team-identity (knockout matchup resolution)', () => {
+  // Shared non-team fields so the ONLY thing varying across rows below is the
+  // matchup itself — exactly the placeholder→resolved transition the cache must
+  // catch (date/status/score don't move when a bracket slot resolves).
+  const base = {
+    espnId: '900',
+    gameDate: new Date('2026-07-01T19:00:00Z'),
+    status: 'SCHEDULED',
+    homeScore: 0,
+    awayScore: 0,
+    period: 0,
+    displayClock: '',
+    statusDetail: '',
+    events: [],
+    league: 'world_cup',
+    stage: 'r32',
+  };
+  const placeholder = () => new Game({
+    ...base,
+    homeTeam: { id: '3', name: 'United States', abbreviation: 'USA', isActive: true },
+    awayTeam: { id: 'tbd-1', name: 'Third Place Group B/E/F/I/J', abbreviation: '3RD', isActive: false },
+  });
+  const resolved = () => new Game({
+    ...base,
+    homeTeam: { id: '3', name: 'United States', abbreviation: 'USA', isActive: true },
+    awayTeam: { id: '4', name: 'Bosnia', abbreviation: 'BIH', isActive: true },
+  });
+
+  test('detects a placeholder resolving into a real team (date/status/score unchanged)', () => {
+    assert.strictEqual(resolved().isDifferentFrom(placeholder()), true);
+  });
+
+  test('is stable for two identical placeholder rows — no cache churn', () => {
+    assert.strictEqual(placeholder().isDifferentFrom(placeholder()), false);
+  });
+
+  test('ignores volatile team fields (record/form/logo) so stable matchups never churn', () => {
+    const a = resolved();
+    const b = resolved();
+    // The kind of drift ESPN emits between refreshes for an already-decided team.
+    b.homeTeam = { ...b.homeTeam, record: '1-0-0', form: 'W', logo: 'https://x/logo.png' };
+    assert.strictEqual(a.isDifferentFrom(b), false);
+  });
+});
+
 describe('Game.toJSON surfaces league and stage', () => {
   test('includes league and stage for a soccer game', () => {
     const [drawMatch] = generateMockWorldCupStage({ stage: 'group' });

--- a/backend/tests/gameservice-worldcup.test.js
+++ b/backend/tests/gameservice-worldcup.test.js
@@ -361,6 +361,87 @@ describe('GameService.getWorldCupStage events-column resilience', () => {
   });
 });
 
+// Proactive matchup-resolution refresh: a knockout stage still holding bracket
+// placeholders must re-check ESPN (throttled) so newly-decided matchups surface
+// promptly, instead of being served stale until the 24h TTL. The placeholder
+// detection mirrors the frontend's teamDecided rule.
+describe('GameService proactive knockout-resolution refresh', () => {
+  beforeEach(() => {
+    process.env.USE_MOCK_ESPN = 'true';
+    MockESPNService.configure();
+    GameService._lastStageFetchAt.clear();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    MockESPNService.reset();
+    delete process.env.USE_MOCK_ESPN;
+    GameService._lastStageFetchAt.clear();
+  });
+
+  // A SCHEDULED knockout game two days out, with an unresolved away slot. Every
+  // other freshness rule reads it as fresh (recently updated, not live, not near
+  // kickoff), so the placeholder rule is the ONLY thing that can force a refresh.
+  const koGame = (overrides = {}) => new Game({
+    id: 1,
+    espnId: '900',
+    homeTeam: { id: '3', name: 'United States', abbreviation: 'USA', isActive: true },
+    awayTeam: { id: 'tbd', name: 'Third Place Group B/E/F/I/J', abbreviation: '3RD', isActive: false },
+    gameDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+    status: 'SCHEDULED',
+    homeScore: 0,
+    awayScore: 0,
+    league: 'world_cup',
+    stage: 'r32',
+    events: [],
+    lastUpdated: new Date(),
+    ...overrides,
+  });
+  const resolvedAway = { id: '4', name: 'Bosnia', abbreviation: 'BIH', isActive: true };
+
+  test('isPlaceholderTeam flags isActive:false, digit abbreviations, and qualification-path names', () => {
+    assert.strictEqual(GameService.isPlaceholderTeam({ abbreviation: 'USA', name: 'United States', isActive: true }), false);
+    assert.strictEqual(GameService.isPlaceholderTeam({ abbreviation: 'BIH', name: 'Bosnia', isActive: false }), true);
+    assert.strictEqual(GameService.isPlaceholderTeam({ abbreviation: '3RD', name: 'x', isActive: true }), true);
+    assert.strictEqual(GameService.isPlaceholderTeam({ abbreviation: 'XX', name: 'Group G Winner', isActive: true }), true);
+  });
+
+  test('hasUnresolvedKnockoutParticipants flags a placeholder knockout slate, never the group stage', () => {
+    assert.strictEqual(GameService.hasUnresolvedKnockoutParticipants([koGame()], 'r32'), true);
+    // The group stage always has two real teams, so it is never flagged.
+    assert.strictEqual(GameService.hasUnresolvedKnockoutParticipants([koGame()], 'group'), false);
+    // A fully-resolved knockout slate is clean.
+    assert.strictEqual(GameService.hasUnresolvedKnockoutParticipants([koGame({ awayTeam: resolvedAway })], 'r32'), false);
+  });
+
+  test('a placeholder knockout stage forces a refresh, throttled to once per window', () => {
+    const now = Date.now();
+    // No prior fetch → throttle elapsed → not fresh (refresh to resolve teams).
+    assert.strictEqual(GameService.isStageCacheFresh([koGame()], 'r32', now), false);
+    // Fetched 1 minute ago → within the 5-min throttle → stays cached.
+    GameService._lastStageFetchAt.set('r32', now - 60 * 1000);
+    assert.strictEqual(GameService.isStageCacheFresh([koGame()], 'r32', now), true);
+    // Fetched 6 minutes ago → throttle elapsed → refresh again.
+    GameService._lastStageFetchAt.set('r32', now - 6 * 60 * 1000);
+    assert.strictEqual(GameService.isStageCacheFresh([koGame()], 'r32', now), false);
+  });
+
+  test('a fully-resolved knockout stage is left cached by this rule', () => {
+    assert.strictEqual(GameService.isStageCacheFresh([koGame({ awayTeam: resolvedAway })], 'r32', Date.now()), true);
+  });
+
+  test('getWorldCupStage re-checks ESPN for a placeholder knockout slate and records the fetch', async () => {
+    mock.method(Game, 'findByLeagueStage', async () => [koGame()]);
+    mock.method(Game, 'findByESPNIds', async () => new Map());
+    const espn = mock.method(MockESPNService, 'fetchSoccerWeek', async () => []);
+
+    await GameService.getWorldCupStage('r32');
+
+    assert.strictEqual(espn.mock.callCount(), 1, 'placeholder knockout slate must re-check ESPN');
+    assert.ok(GameService._lastStageFetchAt.get('r32') != null, 'records the fetch so the next request is throttled');
+  });
+});
+
 describe('GameService.resolveWinnerTeamId (pure)', () => {
   test('knockout falls back to the higher regulation score when no winner flag is set', () => {
     const game = {

--- a/frontend/src/lib/wcNeedsPick.test.ts
+++ b/frontend/src/lib/wcNeedsPick.test.ts
@@ -71,4 +71,35 @@ describe('countNeedsPick', () => {
   it('returns 0 for an empty slate', () => {
     expect(countNeedsPick([], [], NOW)).toBe(0);
   });
+
+  describe('knockoutOnly', () => {
+    // A real, decided knockout match (both teams known) so it counts toward the
+    // knockout-only total — paired with pickable group-stage matches that must be
+    // excluded when the group only allows knockout picks.
+    const knockout = match({
+      id: 10,
+      stage: 'r32',
+      isKnockout: true,
+      homeTeam: { id: '3', name: 'United States', abbreviation: 'USA', logo: '' },
+      awayTeam: { id: '4', name: 'Bosnia', abbreviation: 'BIH', logo: '' },
+    });
+
+    it('counts group + knockout games by default (ongoing group)', () => {
+      const matches = [match({ id: 1 }), match({ id: 2 }), knockout];
+      expect(countNeedsPick(matches, [], NOW)).toBe(3);
+    });
+
+    it('excludes group-stage games when knockoutOnly is true', () => {
+      const matches = [match({ id: 1 }), match({ id: 2 }), knockout];
+      // Only the knockout game remains pickable for a knockout-only group.
+      expect(countNeedsPick(matches, [], NOW, true)).toBe(1);
+    });
+
+    it('is unaffected by knockoutOnly when there are no group-stage games', () => {
+      const matches = [knockout, match({ id: 11, stage: 'r16', isKnockout: true,
+        homeTeam: { id: '5', name: 'Brazil', abbreviation: 'BRA', logo: '' },
+        awayTeam: { id: '6', name: 'France', abbreviation: 'FRA', logo: '' } })];
+      expect(countNeedsPick(matches, [], NOW, true)).toBe(2);
+    });
+  });
 });

--- a/frontend/src/lib/wcNeedsPick.ts
+++ b/frontend/src/lib/wcNeedsPick.ts
@@ -24,12 +24,21 @@ function toDraft(picks: MatchPick[] | undefined): Record<number, MatchPick['pick
  * Count the matches this viewer still needs to pick, given the tournament's
  * matches and the viewer's saved picks. `now` is injected so the open/locked
  * window is testable.
+ *
+ * `knockoutOnly` mirrors the group setting: when true, group-stage matches are
+ * dropped before counting so a knockout-only group's banner/dot only counts the
+ * games that group can actually pick. This keeps the leaderboard banner and the
+ * groups-list dot in lockstep with the Picks tab, which already hides the group
+ * stage for these pools. Defaults false, so ongoing (full-tournament) pools are
+ * counted exactly as before.
  */
 export function countNeedsPick(
   matches: WorldCupMatch[],
   picks: MatchPick[] | undefined,
   now: Date,
+  knockoutOnly: boolean = false,
 ): number {
   const draft = toDraft(picks);
-  return toBrowseGames(matches, draft).filter((g) => needsPick(g, now)).length;
+  const visible = knockoutOnly ? matches.filter((m) => m.stage !== 'group') : matches;
+  return toBrowseGames(visible, draft).filter((g) => needsPick(g, now)).length;
 }

--- a/frontend/src/pages/GroupDetailsPage.test.tsx
+++ b/frontend/src/pages/GroupDetailsPage.test.tsx
@@ -488,6 +488,34 @@ describe('GroupDetailsPage', () => {
       expect(screen.queryByText(/available to make/i)).not.toBeInTheDocument();
     });
 
+    it('counts only knockout games in the banner for a knockout-only group', async () => {
+      // A knockout-only group can't pick group-stage games, so the leaderboard
+      // banner must exclude them too — matching the Picks tab. Without the fix the
+      // banner would count both games ("2 picks…"); with it, only the knockout one.
+      mockGetGroup.mockResolvedValue({ ...worldCupGroup, knockoutOnly: true });
+      mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
+      const knockoutMatch: WorldCupMatch = {
+        id: 20,
+        stage: 'r32',
+        homeTeam: { id: '3', name: 'United States', abbreviation: 'USA', logo: '' },
+        awayTeam: { id: '4', name: 'Bosnia', abbreviation: 'BIH', logo: '' },
+        homeScore: 0,
+        awayScore: 0,
+        status: 'SCHEDULED',
+        isKnockout: true,
+        gameDate: (() => { const d = new Date(); d.setHours(23, 59, 59, 999); return d.toISOString(); })(),
+      };
+      // One pickable group-stage game (excluded) + one decided knockout game.
+      mockGetAllWorldCupStages.mockResolvedValue({ games: [wcMatch, knockoutMatch], count: 2, cached: false });
+      mockGetMyWorldCupPicks.mockResolvedValue({ picks: [] });
+
+      renderPage();
+      await screen.findByRole('heading', { name: worldCupGroup.name });
+
+      expect(await screen.findByText(/1 pick available to make/i)).toBeInTheDocument();
+      expect(screen.queryByText(/2 picks available to make/i)).not.toBeInTheDocument();
+    });
+
     it('banner CTA deeplinks to the Picks tab with the "Needs pick" chip pre-selected', async () => {
       mockGetWorldCupLeaderboard.mockResolvedValue({ leaderboard: [] });
       mockGetAllWorldCupStages.mockResolvedValue(stagesResponse);

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -204,7 +204,7 @@ export default function GroupDetailsPage() {
     return () => {
       cancelled = true;
     };
-  }, [identifier, group?.poolType, activeTab]);
+  }, [identifier, group?.poolType, group?.knockoutOnly, activeTab]);
 
   // No identifier in the query string: nothing to load, show the error UI early.
   if (!identifier) {

--- a/frontend/src/pages/GroupDetailsPage.tsx
+++ b/frontend/src/pages/GroupDetailsPage.tsx
@@ -194,7 +194,9 @@ export default function GroupDetailsPage() {
         if (cancelled) return;
         const matches: WorldCupMatch[] = Array.isArray(stagesResp?.games) ? stagesResp.games : [];
         writeCache(wcCacheKeys.stages, matches);
-        setNeedsPickCount(countNeedsPick(matches, picksResp?.picks, new Date()));
+        setNeedsPickCount(
+          countNeedsPick(matches, picksResp?.picks, new Date(), group?.knockoutOnly ?? false),
+        );
       } catch {
         /* non-fatal: leave the banner hidden */
       }

--- a/frontend/src/pages/GroupsPage.tsx
+++ b/frontend/src/pages/GroupsPage.tsx
@@ -93,7 +93,10 @@ export default function GroupsPage() {
           wcGroups.map(async (g) => {
             try {
               const picksResp = await getMyWorldCupPicks(g.identifier);
-              return [g.identifier, countNeedsPick(matches as WorldCupMatch[], picksResp?.picks, now) > 0] as const;
+              return [
+                g.identifier,
+                countNeedsPick(matches as WorldCupMatch[], picksResp?.picks, now, g.knockoutOnly ?? false) > 0,
+              ] as const;
             } catch {
               return [g.identifier, false] as const;
             }


### PR DESCRIPTION
## Summary

Fixes the two World Cup bugs spotted on the **LTK World Cup Knockout Picks** group: the over-counting "picks available" banner, and stale knockout matchups showing bracket placeholders instead of resolved teams. Both fixes apply to **ongoing and knockout-only** World Cup pools.

## Bug 1 — banner/dot over-counts in a knockout-only group

The Leaderboard banner ("You have 13 picks available to make") and the groups-list "needs pick" dot both call `countNeedsPick(matches, picks, now)`, which counted the **unfiltered** slate. A knockout-only group can't pick group-stage games, but the banner counted the ~12 remaining open group-stage games anyway (banner said 13, Picks tab correctly said 1). Both surfaces already share the same `needsPick`/`teamsDecided` predicate — the only divergence was the missing stage filter.

**Fix:** `countNeedsPick` takes an optional `knockoutOnly` arg that drops `stage === 'group'` before counting; the banner (`GroupDetailsPage`) and the dot (`GroupsPage`) each pass the group's flag. Ongoing pools pass `false` → counts unchanged.

## Bug 2 — resolved knockout matchups served stale (placeholders)

Two compounding, pre-existing cache causes:

1. **`Game.isDifferentFrom()` never compared team identity.** It diffed date/status/score/period/clock/statusDetail/event-count, so when ESPN swaps a placeholder ("Third Place Group B/E/F/I/J", abbr `3RD`, `isActive:false`) for the resolved team (Bosnia/`BIH`/`isActive:true`) with nothing else changing, the cache-update gate never fired. → Now also diffs a **stable** team fingerprint (`id | abbreviation | isActive`) for home/away. Volatile fields (record/form/logo/odds) are deliberately excluded so NFL and group-stage rows never churn the cache.

2. **`isStageCacheFresh()` served future SCHEDULED games from the DB for up to 24h** without consulting ESPN — so even with the diff fix, nothing re-fetched. → Added a **throttled proactive trigger**: a knockout stage still holding placeholder participants (`hasUnresolvedKnockoutParticipants`/`isPlaceholderTeam`, mirroring the frontend `teamDecided` rule) re-checks ESPN at most once per 5 min, tracked per stage in an in-process `_lastStageFetchAt` map. This is what makes "log in after a game ends and see the latest bracket" work. ESPN load stays traffic-independent (~1 call/stage/5 min while placeholders remain; back to the 24h cadence once resolved).

`isStageCacheFresh` now takes `(cachedSet, stage, now)`; legacy 2-arg calls pass `stage=null` and skip the placeholder branch (the group stage never has placeholders). `?refresh=true`/`?force=1` on the stage routes still hard-bypass the cache.

## Tests

- **Frontend:** `wcNeedsPick` knockout-only filter cases; `GroupDetailsPage` banner counts only knockout games for a knockout-only group.
- **Backend:** `isDifferentFrom` detects placeholder→resolved and ignores volatile fields; placeholder detection + throttle window + `getWorldCupStage` re-check wiring.

Verification on this branch:
- Backend `node --test tests/*.test.js` → 283 pass (the 4 failures are pre-existing DB-dependent integration tests, identical on `main`).
- Frontend full `vitest run` → 750 pass; `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)