### PR TITLE
Configurable group member limit (up to 500)

### DIFF
--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS groups (
   identifier VARCHAR(100) UNIQUE NOT NULL, -- URL-friendly unique identifier
   description TEXT,
   is_public BOOLEAN DEFAULT true,
-  max_members INTEGER DEFAULT 20 CHECK (max_members <= 40 AND max_members >= 2),
+  max_members INTEGER DEFAULT 20 CONSTRAINT groups_max_members_range CHECK (max_members <= 500 AND max_members >= 2),
   pool_type VARCHAR(20) NOT NULL DEFAULT 'nfl_weekly' CHECK (pool_type IN ('nfl_weekly','world_cup_2026')), -- pick-pool variant
   knockout_only BOOLEAN NOT NULL DEFAULT false, -- world_cup_2026 sub-setting: members may only pick knockout-stage games (no group stage)
   avatar_url VARCHAR(500),
@@ -406,5 +406,26 @@ BEGIN
     ON user_picks(user_id, group_id, week, season, season_type, confidence_level) 
     WHERE confidence_level IS NOT NULL;
     RAISE NOTICE 'Created correct confidence unique index with group_id';
+  END IF;
+END $$;
+-- Raise the group member ceiling from 40 to 500. The original cap was an inline
+-- unnamed CHECK auto-named groups_max_members_check; existing databases still have
+-- it, so drop it and install the named groups_max_members_range (<=500) constraint.
+-- Fresh databases get groups_max_members_range directly from the CREATE TABLE above,
+-- making this a no-op for them. Idempotent: safe to re-run.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'groups_max_members_check'
+  ) THEN
+    ALTER TABLE groups DROP CONSTRAINT groups_max_members_check;
+    RAISE NOTICE 'Dropped legacy groups_max_members_check (<=40) constraint';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'groups_max_members_range'
+  ) THEN
+    ALTER TABLE groups ADD CONSTRAINT groups_max_members_range
+      CHECK (max_members <= 500 AND max_members >= 2);
+    RAISE NOTICE 'Added groups_max_members_range (<=500) constraint';
   END IF;
 END $$;

--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS groups (
   identifier VARCHAR(100) UNIQUE NOT NULL, -- URL-friendly unique identifier
   description TEXT,
   is_public BOOLEAN DEFAULT true,
-  max_members INTEGER DEFAULT 20 CONSTRAINT groups_max_members_range CHECK (max_members <= 500 AND max_members >= 2),
+  max_members INTEGER DEFAULT 50 CONSTRAINT groups_max_members_range CHECK (max_members <= 500 AND max_members >= 2),
   pool_type VARCHAR(20) NOT NULL DEFAULT 'nfl_weekly' CHECK (pool_type IN ('nfl_weekly','world_cup_2026')), -- pick-pool variant
   knockout_only BOOLEAN NOT NULL DEFAULT false, -- world_cup_2026 sub-setting: members may only pick knockout-stage games (no group stage)
   avatar_url VARCHAR(500),
@@ -428,4 +428,8 @@ BEGIN
       CHECK (max_members <= 500 AND max_members >= 2);
     RAISE NOTICE 'Added groups_max_members_range (<=500) constraint';
   END IF;
+  -- Align the column default with the app default (50) on existing DBs. The inline
+  -- DEFAULT above only applies to fresh CREATE TABLE; this catches legacy rows'
+  -- table default. Idempotent.
+  ALTER TABLE groups ALTER COLUMN max_members SET DEFAULT 50;
 END $$;

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -8,6 +8,10 @@ export class Group {
   // warm lambda and then "goes back to normal" (zero extra queries).
   static _knockoutOnlyColumnEnsured = false;
 
+  // Self-heal latch for the max_members CHECK constraint (see
+  // ensureMaxMembersConstraint). Same warm-instance fast path as above.
+  static _maxMembersConstraintEnsured = false;
+
   constructor(data) {
     this.id = data.id;
     this.name = data.name;
@@ -66,13 +70,50 @@ export class Group {
     }
   }
 
+  // Ensure the groups.max_members CHECK allows up to 500. Production resilience:
+  // prod runs with INIT_DB unset, so schema.sql is NOT synced on deploy, and the
+  // legacy inline constraint (groups_max_members_check) still caps at 40. Because
+  // create() now defaults max_members to 50, a missing migration would 500 EVERY
+  // new group. Mirror the ensureKnockoutOnlyColumn self-heal: swap the legacy
+  // <=40 constraint for the named groups_max_members_range (<=500) on the first
+  // create/update after a deploy, then latch. Concurrency-safe: DROP ... IF EXISTS
+  // is idempotent, and a duplicate ADD from a racing cold start throws into the
+  // catch (which does NOT latch, so the next call settles to a no-op).
+  static async ensureMaxMembersConstraint() {
+    if (this._maxMembersConstraintEnsured) return; // warm-instance fast path
+    try {
+      const { rows } = await pool.query(
+        `SELECT conname FROM pg_constraint WHERE conname IN ('groups_max_members_check', 'groups_max_members_range')`
+      );
+      const names = rows.map((r) => r.conname);
+      const hasNew = names.includes('groups_max_members_range');
+      const hasLegacy = names.includes('groups_max_members_check');
+      if (hasLegacy || !hasNew) {
+        console.log('[groups] Migrating max_members constraint to allow up to 500');
+        await pool.query(`ALTER TABLE groups DROP CONSTRAINT IF EXISTS groups_max_members_check`);
+        if (!hasNew) {
+          await pool.query(
+            `ALTER TABLE groups ADD CONSTRAINT groups_max_members_range CHECK (max_members <= 500 AND max_members >= 2)`
+          );
+        }
+        console.log('[groups] max_members constraint now allows up to 500');
+      }
+      this._maxMembersConstraintEnsured = true;
+    } catch (e) {
+      // Do NOT latch on failure — let the next create/update retry.
+      console.warn('[groups] Failed to ensure max_members constraint (may already be applied):', e.message);
+    }
+  }
+
   // Create new group
   static async create(groupData, creatorId) {
     const { name, identifier, description, isPublic, maxMembers, avatarUrl, poolType, knockoutOnly } = groupData;
 
-    // Self-heal the knockout_only column before the INSERT references it. No-op
-    // once the column exists (latched), so this is free on the steady-state path.
+    // Self-heal schema before the INSERT: the knockout_only column must exist, and
+    // the max_members constraint must allow the new default (50 > the legacy 40
+    // cap). Both no-op once latched, so this is free on the steady-state path.
     await Group.ensureKnockoutOnlyColumn();
+    await Group.ensureMaxMembersConstraint();
     
     // Ensure identifier is unique and URL-friendly
     // Clean identifier: lowercase, replace invalid chars with dash, collapse dashes, trim dashes
@@ -434,6 +475,10 @@ export class Group {
     if (roleCheck.rows.length === 0 || roleCheck.rows[0].role !== 'admin') {
       throw new Error('Only group admins can update group settings');
     }
+
+    // Self-heal the max_members constraint so an admin raising the limit past the
+    // legacy 40 cap isn't rejected by a stale CHECK. No-op once latched.
+    await Group.ensureMaxMembersConstraint();
 
     // Member-limit changes are bounded to [2, 500] and may not be lowered below the
     // group's CURRENT member count — an admin must have members leave first. A group

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -98,6 +98,9 @@ export class Group {
         }
         console.log('[groups] max_members constraint now allows up to 500');
       }
+      // Align the column default with the app default (50). Idempotent metadata-only
+      // change; only matters for inserts that omit max_members (the API always sends it).
+      await pool.query(`ALTER TABLE groups ALTER COLUMN max_members SET DEFAULT 50`);
       this._maxMembersConstraintEnsured = true;
     } catch (e) {
       // Do NOT latch on failure — let the next create/update retry.

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -434,7 +434,28 @@ export class Group {
     if (roleCheck.rows.length === 0 || roleCheck.rows[0].role !== 'admin') {
       throw new Error('Only group admins can update group settings');
     }
-    
+
+    // Member-limit changes are bounded to [2, 500] and may not be lowered below the
+    // group's CURRENT member count — an admin must have members leave first. A group
+    // can be expanded freely up to the cap.
+    if (Object.prototype.hasOwnProperty.call(updates, 'maxMembers')) {
+      const newMax = updates.maxMembers;
+      if (!Number.isInteger(newMax) || newMax < 2 || newMax > 500) {
+        throw new Error('Member limit must be a whole number between 2 and 500');
+      }
+      const { rows } = await pool.query(
+        'SELECT COUNT(*)::int AS count FROM group_memberships WHERE group_id = $1',
+        [groupId]
+      );
+      const currentCount = rows[0].count;
+      if (newMax < currentCount) {
+        throw new Error(
+          `Member limit (${newMax}) is below the current member count (${currentCount}). ` +
+          `Members must leave the group before you can lower the limit this far.`
+        );
+      }
+    }
+
     const allowedFields = ['name', 'description', 'is_public', 'max_members', 'avatar_url'];
     const updateFields = [];
     const values = [];

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -8,14 +8,16 @@ const router = express.Router();
 // Create a new group
 router.post('/', authenticateToken, async (req, res) => {
   try {
-    const { name, identifier, description, isPublic = true, maxMembers = 40, avatarUrl, poolType, knockoutOnly } = req.body;
+    const { name, identifier, description, isPublic = true, maxMembers = 50, avatarUrl, poolType, knockoutOnly } = req.body;
 
     if (!name || !identifier) {
       return res.status(400).json({ error: 'Name and identifier are required' });
     }
 
-    if (maxMembers > 40) {
-      return res.status(400).json({ error: 'Maximum members cannot exceed 40' });
+    // Member limit is configurable per group, bounded to [2, 500] (the absolute
+    // cap). The DB CHECK enforces the same range; we surface a 400 first.
+    if (!Number.isInteger(maxMembers) || maxMembers < 2 || maxMembers > 500) {
+      return res.status(400).json({ error: 'Member limit must be a whole number between 2 and 500' });
     }
 
     // poolType is optional. The CHECK constraint on groups.pool_type would
@@ -387,6 +389,14 @@ router.put('/:identifier', authenticateToken, async (req, res) => {
   } catch (error) {
     if (error.message.includes('Only group admins')) {
       return res.status(403).json({ error: error.message });
+    }
+    // Lowering the limit below the current member count is a conflict the admin
+    // must resolve (have members leave) before it can be applied.
+    if (error.message.includes('below the current member count')) {
+      return res.status(409).json({ error: error.message });
+    }
+    if (error.message.includes('Member limit must be')) {
+      return res.status(400).json({ error: error.message });
     }
     res.status(500).json({ error: error.message });
   }

--- a/backend/tests/group-update-member-limit.test.js
+++ b/backend/tests/group-update-member-limit.test.js
@@ -1,4 +1,4 @@
-import { test, describe, afterEach, mock } from 'node:test';
+import { test, describe, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { Group } from '../src/models/Group.js';
 import pool from '../src/config/database.js';
@@ -9,7 +9,10 @@ import pool from '../src/config/database.js';
 // equal-to-count boundary, the [2,500] bounds, and the admin gate.
 
 describe('Group.update — member limit guard', () => {
-  afterEach(() => mock.restoreAll());
+  // The max_members constraint self-heal is covered by groups-ensure-constraint.test.js;
+  // latch it here so update() skips it and the stubbed pool only sees the guard's queries.
+  beforeEach(() => { Group._maxMembersConstraintEnsured = true; });
+  afterEach(() => { mock.restoreAll(); Group._maxMembersConstraintEnsured = false; });
 
   // role: the caller's membership role (null = not a member).
   // memberCount: rows returned by the COUNT(*) query.

--- a/backend/tests/group-update-member-limit.test.js
+++ b/backend/tests/group-update-member-limit.test.js
@@ -1,0 +1,69 @@
+import { test, describe, afterEach, mock } from 'node:test';
+import assert from 'node:assert';
+import { Group } from '../src/models/Group.js';
+import pool from '../src/config/database.js';
+
+// Unit-tests the real member-limit guard inside Group.update by stubbing the pool
+// singleton: the admin role lookup, the current member-count query, and the UPDATE.
+// No live Postgres. Covers the shrink guard (can't drop below current count), the
+// equal-to-count boundary, the [2,500] bounds, and the admin gate.
+
+describe('Group.update — member limit guard', () => {
+  afterEach(() => mock.restoreAll());
+
+  // role: the caller's membership role (null = not a member).
+  // memberCount: rows returned by the COUNT(*) query.
+  function stubPool({ role = 'admin', memberCount = 3 } = {}) {
+    mock.method(pool, 'query', async (sql, params) => {
+      if (/SELECT role FROM group_memberships/.test(sql)) {
+        return { rows: role ? [{ role }] : [] };
+      }
+      if (/COUNT\(\*\)/.test(sql)) {
+        return { rows: [{ count: memberCount }] };
+      }
+      // The UPDATE ... RETURNING *
+      return { rows: [{ id: 10, max_members: params[0] }] };
+    });
+  }
+
+  test('expanding the limit up to the 500 cap succeeds', async () => {
+    stubPool({ memberCount: 3 });
+    const res = await Group.update(10, { maxMembers: 500 }, 1);
+    assert.equal(res.max_members, 500);
+  });
+
+  test('lowering below the current member count is rejected (shrink guard)', async () => {
+    stubPool({ memberCount: 38 });
+    await assert.rejects(
+      () => Group.update(10, { maxMembers: 30 }, 1),
+      /below the current member count \(38\)/,
+    );
+  });
+
+  test('lowering to exactly the current member count is allowed', async () => {
+    stubPool({ memberCount: 30 });
+    const res = await Group.update(10, { maxMembers: 30 }, 1);
+    assert.equal(res.max_members, 30);
+  });
+
+  test('a limit over 500 throws the bounds error before touching member count', async () => {
+    stubPool({ memberCount: 3 });
+    await assert.rejects(() => Group.update(10, { maxMembers: 501 }, 1), /between 2 and 500/);
+  });
+
+  test('a limit below 2 throws the bounds error', async () => {
+    stubPool({ memberCount: 3 });
+    await assert.rejects(() => Group.update(10, { maxMembers: 1 }, 1), /between 2 and 500/);
+  });
+
+  test('a non-admin cannot change the limit', async () => {
+    stubPool({ role: 'member', memberCount: 3 });
+    await assert.rejects(() => Group.update(10, { maxMembers: 50 }, 1), /Only group admins/);
+  });
+
+  test('updates that do not touch maxMembers skip the limit guard', async () => {
+    stubPool({ memberCount: 3 });
+    const res = await Group.update(10, { name: 'Renamed' }, 1);
+    assert.ok(res);
+  });
+});

--- a/backend/tests/groups-ensure-constraint.test.js
+++ b/backend/tests/groups-ensure-constraint.test.js
@@ -1,0 +1,93 @@
+import { test, describe, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert';
+import { Group } from '../src/models/Group.js';
+import pool from '../src/config/database.js';
+
+// The groups.max_members CHECK constraint self-heals from the legacy <=40 cap to
+// <=500 on the first group create/update after a deploy (prod runs with INIT_DB
+// unset). These tests drive Group.ensureMaxMembersConstraint directly with a
+// stubbed pool. The static `_maxMembersConstraintEnsured` latch is reset around
+// each case because it persists for the process lifetime.
+
+describe('Group.ensureMaxMembersConstraint (self-heal)', () => {
+  beforeEach(() => { Group._maxMembersConstraintEnsured = false; });
+  afterEach(() => { mock.restoreAll(); Group._maxMembersConstraintEnsured = false; });
+
+  test('swaps the legacy <=40 constraint for the <=500 range', async () => {
+    const sqls = [];
+    mock.method(pool, 'query', async (sql) => {
+      sqls.push(sql);
+      if (/FROM pg_constraint/.test(sql)) return { rows: [{ conname: 'groups_max_members_check' }] };
+      return { rows: [] }; // the ALTERs
+    });
+
+    await Group.ensureMaxMembersConstraint();
+
+    assert.ok(
+      sqls.some((s) => /DROP CONSTRAINT IF EXISTS groups_max_members_check/.test(s)),
+      'drops the legacy constraint',
+    );
+    assert.ok(
+      sqls.some((s) => /ADD CONSTRAINT groups_max_members_range CHECK \(max_members <= 500/.test(s)),
+      'adds the <=500 range constraint',
+    );
+    assert.strictEqual(Group._maxMembersConstraintEnsured, true, 'latches after migrating');
+  });
+
+  test('adds the range constraint when neither constraint is present', async () => {
+    const sqls = [];
+    mock.method(pool, 'query', async (sql) => {
+      sqls.push(sql);
+      if (/FROM pg_constraint/.test(sql)) return { rows: [] }; // neither present
+      return { rows: [] };
+    });
+
+    await Group.ensureMaxMembersConstraint();
+
+    assert.ok(sqls.some((s) => /ADD CONSTRAINT groups_max_members_range/.test(s)), 'adds the range constraint');
+    assert.strictEqual(Group._maxMembersConstraintEnsured, true);
+  });
+
+  test('does NOT alter when the <=500 range constraint already exists', async () => {
+    const sqls = [];
+    mock.method(pool, 'query', async (sql) => {
+      sqls.push(sql);
+      if (/FROM pg_constraint/.test(sql)) return { rows: [{ conname: 'groups_max_members_range' }] };
+      return { rows: [] };
+    });
+
+    await Group.ensureMaxMembersConstraint();
+
+    assert.ok(!sqls.some((s) => /ALTER TABLE/.test(s)), 'no ALTER issued when already migrated');
+    assert.strictEqual(Group._maxMembersConstraintEnsured, true);
+  });
+
+  test('latches so a warm instance skips the catalog check on later calls', async () => {
+    let queryCount = 0;
+    mock.method(pool, 'query', async (sql) => {
+      queryCount++;
+      if (/FROM pg_constraint/.test(sql)) return { rows: [{ conname: 'groups_max_members_range' }] };
+      return { rows: [] };
+    });
+
+    await Group.ensureMaxMembersConstraint();
+    await Group.ensureMaxMembersConstraint();
+    await Group.ensureMaxMembersConstraint();
+
+    assert.strictEqual(queryCount, 1, 'only the first call hits the DB');
+  });
+
+  test('does NOT latch on failure, so the next call retries', async () => {
+    let queryCount = 0;
+    mock.method(pool, 'query', async () => {
+      queryCount++;
+      throw new Error('transient DB error');
+    });
+
+    await Group.ensureMaxMembersConstraint();
+    await Group.ensureMaxMembersConstraint();
+
+    assert.strictEqual(queryCount, 2, 'a transient failure does not permanently latch');
+    assert.strictEqual(Group._maxMembersConstraintEnsured, false);
+  });
+});

--- a/backend/tests/groups-ensure-constraint.test.js
+++ b/backend/tests/groups-ensure-constraint.test.js
@@ -48,7 +48,7 @@ describe('Group.ensureMaxMembersConstraint (self-heal)', () => {
     assert.strictEqual(Group._maxMembersConstraintEnsured, true);
   });
 
-  test('does NOT alter when the <=500 range constraint already exists', async () => {
+  test('does NOT change the constraint when the range already exists, but aligns the default', async () => {
     const sqls = [];
     mock.method(pool, 'query', async (sql) => {
       sqls.push(sql);
@@ -58,7 +58,11 @@ describe('Group.ensureMaxMembersConstraint (self-heal)', () => {
 
     await Group.ensureMaxMembersConstraint();
 
-    assert.ok(!sqls.some((s) => /ALTER TABLE/.test(s)), 'no ALTER issued when already migrated');
+    assert.ok(!sqls.some((s) => /(DROP|ADD) CONSTRAINT/.test(s)), 'no constraint change when already migrated');
+    assert.ok(
+      sqls.some((s) => /ALTER COLUMN max_members SET DEFAULT 50/.test(s)),
+      'still aligns the column default to 50',
+    );
     assert.strictEqual(Group._maxMembersConstraintEnsured, true);
   });
 
@@ -71,10 +75,11 @@ describe('Group.ensureMaxMembersConstraint (self-heal)', () => {
     });
 
     await Group.ensureMaxMembersConstraint();
+    const afterFirst = queryCount;
     await Group.ensureMaxMembersConstraint();
     await Group.ensureMaxMembersConstraint();
 
-    assert.strictEqual(queryCount, 1, 'only the first call hits the DB');
+    assert.strictEqual(queryCount, afterFirst, 'later calls add no queries (latched)');
   });
 
   test('does NOT latch on failure, so the next call retries', async () => {

--- a/backend/tests/groups-member-limit-route.test.js
+++ b/backend/tests/groups-member-limit-route.test.js
@@ -1,0 +1,119 @@
+import { test, describe, before, after, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert';
+import express from 'express';
+import groupsRouter from '../src/routes/groups.js';
+import { AuthService } from '../src/services/AuthService.js';
+import { User } from '../src/models/User.js';
+import { Group } from '../src/models/Group.js';
+
+// Exercises the configurable member-limit validation on the groups create + update
+// routes without a live Postgres. Auth + the Group model are stubbed; the focus is
+// the route-level bounds checks ([2,500]) and the HTTP status mapping for the
+// shrink-below-count conflict.
+
+const AUTH_HEADER = { Authorization: 'Bearer test-token' };
+
+describe('Groups member-limit routes', () => {
+  let server;
+  let baseURL;
+
+  before(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/groups', groupsRouter);
+    await new Promise((resolve) => {
+      server = app.listen(0, () => {
+        baseURL = `http://localhost:${server.address().port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    mock.method(AuthService, 'verifyAccessToken', () => ({ userId: 1 }));
+    mock.method(User, 'findById', async () => ({ id: 1, name: 'Tester', email: 't@x.io' }));
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  function post(body) {
+    return fetch(`${baseURL}/api/groups`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+      body: JSON.stringify(body),
+    });
+  }
+  function put(identifier, body) {
+    return fetch(`${baseURL}/api/groups/${identifier}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
+      body: JSON.stringify(body),
+    });
+  }
+
+  describe('create', () => {
+    test('defaults the member limit to 50 when omitted', async () => {
+      let seen = null;
+      mock.method(Group, 'create', async (data) => { seen = data; return { id: 1, ...data }; });
+      const res = await post({ name: 'G', identifier: 'g' });
+      assert.equal(res.status, 201);
+      assert.equal(seen.maxMembers, 50);
+    });
+
+    test('accepts a member limit up to the 500 cap', async () => {
+      mock.method(Group, 'create', async (data) => ({ id: 1, ...data }));
+      const res = await post({ name: 'G', identifier: 'g', maxMembers: 500 });
+      assert.equal(res.status, 201);
+    });
+
+    test('rejects a member limit over 500', async () => {
+      const res = await post({ name: 'G', identifier: 'g', maxMembers: 501 });
+      assert.equal(res.status, 400);
+    });
+
+    test('rejects a member limit below 2', async () => {
+      const res = await post({ name: 'G', identifier: 'g', maxMembers: 1 });
+      assert.equal(res.status, 400);
+    });
+
+    test('rejects a non-integer member limit', async () => {
+      const res = await post({ name: 'G', identifier: 'g', maxMembers: 12.5 });
+      assert.equal(res.status, 400);
+    });
+  });
+
+  describe('update status mapping', () => {
+    test('maps the shrink-below-count error to 409', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 10 }));
+      mock.method(Group, 'update', async () => {
+        throw new Error('Member limit (30) is below the current member count (38). Members must leave the group before you can lower the limit this far.');
+      });
+      const res = await put('g', { maxMembers: 30 });
+      assert.equal(res.status, 409);
+      const body = await res.json();
+      assert.match(body.error, /below the current member count/);
+    });
+
+    test('maps an out-of-range limit error to 400', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 10 }));
+      mock.method(Group, 'update', async () => {
+        throw new Error('Member limit must be a whole number between 2 and 500');
+      });
+      const res = await put('g', { maxMembers: 999 });
+      assert.equal(res.status, 400);
+    });
+
+    test('a successful expansion returns 200', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 10 }));
+      mock.method(Group, 'update', async (id, updates) => ({ id, max_members: updates.maxMembers }));
+      const res = await put('g', { maxMembers: 200 });
+      assert.equal(res.status, 200);
+    });
+  });
+});

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
@@ -85,6 +85,20 @@ describe('CreateGroupForm', () => {
       expect(screen.getByText(/between 2 and 500/)).toBeInTheDocument();
     });
 
+    it('blocks submission and shows an error for a non-integer limit', async () => {
+      // step="any" lets a value like 12.5 through native validation so the form's
+      // own integer check runs and surfaces the inline error.
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderForm({ onSubmit });
+      fireEvent.change(screen.getByLabelText(/Group Name/), { target: { value: 'My Group' } });
+      fireEvent.change(screen.getByLabelText('Member limit'), { target: { value: '12.5' } });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/between 2 and 500/)).toBeInTheDocument();
+    });
+
     it('blocks submission when the limit is below 2', async () => {
       const onSubmit = vi.fn().mockResolvedValue(undefined);
       renderForm({ onSubmit });

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
@@ -51,6 +51,52 @@ describe('CreateGroupForm', () => {
     });
   });
 
+  describe('member limit', () => {
+    it('renders the Member limit field defaulting to 50', () => {
+      renderForm();
+      expect(screen.getByLabelText('Member limit')).toHaveValue(50);
+    });
+
+    it('prefills the Member limit from initialValues (edit mode)', () => {
+      renderForm({ initialValues: { maxMembers: 120 } });
+      expect(screen.getByLabelText('Member limit')).toHaveValue(120);
+    });
+
+    it('submits the chosen member limit', async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderForm({ onSubmit });
+      fireEvent.change(screen.getByLabelText(/Group Name/), { target: { value: 'My Group' } });
+      fireEvent.change(screen.getByLabelText('Member limit'), { target: { value: '250' } });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+      });
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ maxMembers: 250 }));
+    });
+
+    it('blocks submission and shows an error when the limit exceeds 500', async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderForm({ onSubmit });
+      fireEvent.change(screen.getByLabelText(/Group Name/), { target: { value: 'My Group' } });
+      fireEvent.change(screen.getByLabelText('Member limit'), { target: { value: '600' } });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText(/between 2 and 500/)).toBeInTheDocument();
+    });
+
+    it('blocks submission when the limit is below 2', async () => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderForm({ onSubmit });
+      fireEvent.change(screen.getByLabelText(/Group Name/), { target: { value: 'My Group' } });
+      fireEvent.change(screen.getByLabelText('Member limit'), { target: { value: '1' } });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('auto-slug from name', () => {
     it('auto-fills Group ID from name', () => {
       renderForm();
@@ -224,6 +270,7 @@ describe('CreateGroupForm', () => {
         description: 'A cool group',
         poolType: 'nfl_weekly',
         knockoutOnly: false,
+        maxMembers: 50,
       });
     });
 

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
@@ -15,7 +15,14 @@ export interface CreateGroupFormValues {
    * knockout-stage games. Always false unless poolType is 'world_cup_2026'.
    */
   knockoutOnly: boolean;
+  /** Maximum members allowed in the group. Bounded to [2, 500]. */
+  maxMembers: number;
 }
+
+/** Absolute member-limit bounds, mirrored on the server. */
+const MEMBER_LIMIT_MIN = 2;
+const MEMBER_LIMIT_MAX = 500;
+const MEMBER_LIMIT_DEFAULT = 50;
 
 export interface CreateGroupFormProps {
   /**
@@ -36,6 +43,7 @@ interface FormErrors {
   name?: string;
   identifier?: string;
   description?: string;
+  maxMembers?: string;
 }
 
 interface ToastState {
@@ -73,6 +81,11 @@ export default function CreateGroupForm({
   const [description, setDescription] = useState(initialValues?.description ?? '');
   const [poolType, setPoolType] = useState<PoolType>(initialValues?.poolType ?? 'nfl_weekly');
   const [knockoutOnly, setKnockoutOnly] = useState<boolean>(initialValues?.knockoutOnly ?? false);
+  // Stored as a string so the number input can be edited freely (incl. transient
+  // empty/partial values); parsed + bounds-checked on submit.
+  const [maxMembers, setMaxMembers] = useState<string>(
+    String(initialValues?.maxMembers ?? MEMBER_LIMIT_DEFAULT)
+  );
   // The knockout-only setting is meaningful only for World Cup pools, so it lives
   // behind the pool-type choice and rides along on it.
   const isWorldCup = poolType === 'world_cup_2026';
@@ -120,6 +133,16 @@ export default function CreateGroupForm({
       newErrors.description = 'Description must be 200 characters or less';
     }
 
+    const parsedMax = Number(maxMembers);
+    if (
+      maxMembers.trim() === '' ||
+      !Number.isInteger(parsedMax) ||
+      parsedMax < MEMBER_LIMIT_MIN ||
+      parsedMax > MEMBER_LIMIT_MAX
+    ) {
+      newErrors.maxMembers = `Member limit must be a whole number between ${MEMBER_LIMIT_MIN} and ${MEMBER_LIMIT_MAX}`;
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   }
@@ -132,7 +155,7 @@ export default function CreateGroupForm({
     try {
       // knockoutOnly only travels with a World Cup pool; force it off otherwise
       // so a stale toggle from a since-changed pool type can never leak through.
-      await onSubmit({ name, identifier, description, poolType, knockoutOnly: isWorldCup && knockoutOnly });
+      await onSubmit({ name, identifier, description, poolType, knockoutOnly: isWorldCup && knockoutOnly, maxMembers: Number(maxMembers) });
       setToast({ open: true, message: 'Group created!', variant: 'success' });
     } catch (err) {
       setToast({
@@ -198,6 +221,36 @@ export default function CreateGroupForm({
           multiline
           disabled={loading}
         />
+
+        <div>
+          <label
+            htmlFor="max-members"
+            className="block text-sm font-medium text-secondary-700 dark:text-secondary-200 mb-1"
+          >
+            Member limit
+          </label>
+          {/* Bounds are enforced by validateForm (consistent with the other
+              fields), not native min/max — native constraint validation would
+              silently block submit before our inline error could show. */}
+          <input
+            id="max-members"
+            type="number"
+            inputMode="numeric"
+            value={maxMembers}
+            onChange={(e) => setMaxMembers(e.target.value)}
+            disabled={loading}
+            aria-invalid={!!errors.maxMembers}
+            className="block w-full rounded-md border border-secondary-300 px-3 py-2 text-secondary-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:bg-secondary-100 disabled:text-secondary-500 dark:bg-secondary-900 dark:border-secondary-600 dark:text-secondary-100"
+          />
+          {errors.maxMembers ? (
+            <p className="mt-1 text-sm text-error-600 dark:text-error-400">{errors.maxMembers}</p>
+          ) : (
+            <p className="mt-1 text-sm text-secondary-500 dark:text-secondary-400">
+              Up to {MEMBER_LIMIT_MAX} members. You can raise this anytime; lowering it below the
+              current member count requires members to leave first.
+            </p>
+          )}
+        </div>
 
         <div>
           <label

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
@@ -236,6 +236,10 @@ export default function CreateGroupForm({
             id="max-members"
             type="number"
             inputMode="numeric"
+            // step="any" disables native stepMismatch validation (default step=1
+            // would block submit on a non-integer like 12.5 before validateForm's
+            // integer check could surface the inline message).
+            step="any"
             value={maxMembers}
             onChange={(e) => setMaxMembers(e.target.value)}
             disabled={loading}

--- a/frontend/src/lib/groupsService.js
+++ b/frontend/src/lib/groupsService.js
@@ -65,7 +65,7 @@ export async function createGroup(payload) {
     identifier: payload.identifier,
     description: payload.description,
     isPublic: true,
-    maxMembers: 40
+    maxMembers: payload.maxMembers ?? 50
   };
   // Only forward poolType when provided so existing NFL group creation is unchanged.
   if (payload.poolType) body.poolType = payload.poolType;
@@ -197,6 +197,12 @@ export async function updateGroup(identifier, updates) {
   if (res.status === 400) {
     const data = await res.json().catch(() => ({}));
     throw new Error(data.error || 'Invalid group update');
+  }
+  // 409: the new member limit is below the current member count. Surface the
+  // server's message verbatim so the admin sees that members must leave first.
+  if (res.status === 409) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || 'Member limit is below the current member count; members must leave first');
   }
   if (!res.ok) throw new Error('Failed to update group');
   return await res.json();

--- a/frontend/src/pages/CreateGroupPage.test.tsx
+++ b/frontend/src/pages/CreateGroupPage.test.tsx
@@ -58,6 +58,7 @@ describe('CreateGroupPage', () => {
       description: '',
       poolType: 'nfl_weekly',
       knockoutOnly: false,
+      maxMembers: 50,
     });
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/groups');
@@ -85,6 +86,7 @@ describe('CreateGroupPage', () => {
       description: '',
       poolType: 'world_cup_2026',
       knockoutOnly: false,
+      maxMembers: 50,
     });
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/groups');

--- a/frontend/src/pages/EditGroupPage.test.tsx
+++ b/frontend/src/pages/EditGroupPage.test.tsx
@@ -82,11 +82,13 @@ describe('EditGroupPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Create Group' }));
     });
 
-    // The immutable identifier is the first arg; the payload carries only the
-    // mutable name/description (no identifier).
+    // The immutable identifier is the first arg; the payload carries the mutable
+    // name/description plus the member limit (defaulting to 50 here since the
+    // fixture group has no maxMembers), and never the identifier.
     expect(mockUpdateGroup).toHaveBeenCalledWith('test-group', {
       name: 'Renamed Group',
       description: 'Updated description',
+      maxMembers: 50,
     });
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/groups');

--- a/frontend/src/pages/EditGroupPage.tsx
+++ b/frontend/src/pages/EditGroupPage.tsx
@@ -60,6 +60,7 @@ export default function EditGroupPage() {
     await updateGroup(identifier, {
       name: values.name,
       description: values.description,
+      maxMembers: values.maxMembers,
     });
     navigate('/groups');
   }
@@ -93,6 +94,7 @@ export default function EditGroupPage() {
               name: group.name,
               identifier: group.identifier,
               description: group.description ?? '',
+              maxMembers: group.maxMembers,
             }}
             onSubmit={handleSubmit}
             onCancel={() => navigate(-1)}


### PR DESCRIPTION
## What & why

Makes a group's member limit **configurable** instead of a hard-coded cap, and raises the absolute maximum from **40 to 500**. This is the Tier-1 follow-up unlocked by the leaderboard caching work (#141): the per-request `O(members × games)` aggregation is gone, so larger groups are now practical.

## Behavior

- **Set at creation or after.** The limit is editable on the create form and the edit form (admin only). New groups default to **50**; the floor is **2**, the ceiling **500**.
- **Expand anytime** up to 500.
- **Shrink guard.** An admin cannot lower the limit below the group's *current* member count. The save is rejected (the limit is left unchanged) with a clear message — e.g. *"Member limit (30) is below the current member count (38). Members must leave the group before you can lower the limit this far."* — surfaced as an inline error on the edit form. Other settings remain editable.

## Changes

**Backend**
- `schema.sql`: replace the inline `CHECK (max_members <= 40)` with a named `groups_max_members_range CHECK (… <= 500 …)`, plus an idempotent migration block for fresh/explicit syncs.
- **Self-heal (no INIT_DB needed):** `Group.ensureMaxMembersConstraint()` mirrors the existing `ensureKnockoutOnlyColumn` pattern — on the first group create/update after a deploy it swaps the legacy `groups_max_members_check (<=40)` for `groups_max_members_range (<=500)`, then latches (zero-query no-op afterward). This is required for correctness: the new default of 50 exceeds the legacy 40 cap, so without it every group creation would 500. Verified swapping a real legacy constraint at runtime.
- `groups.js` (create): validate `[2, 500]`, default 50.
- `Group.update`: validate `[2, 500]` **and** reject lowering below the live member count (→ **409**); bounds errors → **400**; expansion allowed up to the cap. Admin-gating unchanged.

**Frontend**
- `CreateGroupForm`: a "Member limit" field (default 50), bounds-checked by the form's own validation so the inline error shows (native `min`/`max` were intentionally omitted — they silently block submit before the custom message can render). Threaded through `CreateGroupFormValues` → create + edit submit paths.
- `groupsService.updateGroup`: maps the new **409** to the server's message so the shrink alert reaches the user; `createGroup` forwards the chosen limit.

## Deployment

**No `INIT_DB` toggle and no manual SQL required.** The constraint self-heals on the first group create/update after this deploys (same approach as the knockout-only column in #142). Deploy via the normal pipeline; the legacy `<=40` constraint swaps itself to `<=500` automatically and idempotently.

## Testing

- **Backend: 307 green** (`NODE_ENV=test npm test`, docker Postgres). +20 new tests: route validation + 400/409 status mapping, the model-level shrink/bounds guard, and the constraint self-heal (legacy-swap / fresh-add / already-migrated / latch / failure-retry). Self-heal also verified against a real legacy constraint. No existing test removed or weakened.
- **Frontend unit: 755 passed** (Node 20). New `CreateGroupForm` coverage; create+edit payload assertions updated to include `maxMembers`.
- **Build/typecheck:** clean.
- **E2e: 41/42 pass.** The one failure is the pre-existing flaky `invite-survives-login.spec.ts` (backend-mocked OAuth flow, unrelated to this change). The new group-form e2e specs pass.

## Follow-ups (unchanged, not in this PR)

The leaderboard `rank`/`memberId` frontend bugs and Tier-2 (pagination + sticky "my rank") remain separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
