### PR TITLE
Fix: edit form shows wrong pool type for World Cup groups

### DIFF
--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.test.tsx
@@ -111,6 +111,28 @@ describe('CreateGroupForm', () => {
     });
   });
 
+  describe('edit mode locks immutable pool fields', () => {
+    it('reflects the World Cup pool type and disables the select', () => {
+      renderForm({ initialValues: { identifier: 'g', poolType: 'world_cup_2026' } });
+      const select = screen.getByLabelText('Pool Type');
+      expect(select).toHaveValue('world_cup_2026');
+      expect(select).toBeDisabled();
+      expect(screen.getByText(/Pool type can.t be changed after creation/)).toBeInTheDocument();
+    });
+
+    it('reflects and locks the knockout-only setting', () => {
+      renderForm({ initialValues: { identifier: 'g', poolType: 'world_cup_2026', knockoutOnly: true } });
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeChecked();
+      expect(checkbox).toBeDisabled();
+    });
+
+    it('keeps the pool type editable when creating a new group', () => {
+      renderForm();
+      expect(screen.getByLabelText('Pool Type')).not.toBeDisabled();
+    });
+  });
+
   describe('auto-slug from name', () => {
     it('auto-fills Group ID from name', () => {
       renderForm();

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
@@ -89,6 +89,9 @@ export default function CreateGroupForm({
   // The knockout-only setting is meaningful only for World Cup pools, so it lives
   // behind the pool-type choice and rides along on it.
   const isWorldCup = poolType === 'world_cup_2026';
+  // In edit mode (identifier supplied) pool type + knockout-only are immutable —
+  // the update route ignores them — so the form locks those controls.
+  const isEditMode = !!initialValues?.identifier;
   const [identifierManuallyEdited, setIdentifierManuallyEdited] = useState(
     !!initialValues?.identifier
   );
@@ -273,12 +276,17 @@ export default function CreateGroupForm({
               // an NFL pool (the server rejects that combination anyway).
               if (next !== 'world_cup_2026') setKnockoutOnly(false);
             }}
-            disabled={loading}
+            disabled={loading || isEditMode}
             className="block w-full rounded-md border border-secondary-300 px-3 py-2 text-secondary-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:bg-secondary-100 disabled:text-secondary-500 dark:bg-secondary-900 dark:border-secondary-600 dark:text-secondary-100"
           >
             <option value="nfl_weekly">NFL Weekly</option>
             <option value="world_cup_2026">World Cup 2026</option>
           </select>
+          {isEditMode && (
+            <p className="mt-1 text-sm text-secondary-500 dark:text-secondary-400">
+              Pool type can&apos;t be changed after creation.
+            </p>
+          )}
         </div>
 
         {/* World Cup 2026 sub-setting. Only shown for a World Cup pool — it has no
@@ -292,7 +300,7 @@ export default function CreateGroupForm({
                 type="checkbox"
                 checked={knockoutOnly}
                 onChange={(e) => setKnockoutOnly(e.target.checked)}
-                disabled={loading}
+                disabled={loading || isEditMode}
                 className="mt-0.5 h-4 w-4 rounded border-secondary-300 text-primary-600 focus:ring-primary-500 disabled:opacity-50"
               />
               <span className="text-sm">

--- a/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
+++ b/frontend/src/designsystem/components/CreateGroupForm/CreateGroupForm.tsx
@@ -67,7 +67,11 @@ function slugifyName(name: string): string {
  * CreateGroupForm is a fully controlled form for creating (or editing) a group.
  *
  * - Auto-generates the Group ID slug from the name unless the user manually edits it.
- * - If `initialValues.identifier` is provided the Group ID field is locked.
+ * - Edit mode is signalled by `initialValues.identifier` being present — the same
+ *   single signal already used to lock the Group ID. In edit mode the Group ID
+ *   AND the immutable pool fields (pool type, knockout-only) are locked, because
+ *   the update route does not accept changes to any of them. (The only two callers
+ *   are CreateGroupPage — no initialValues — and EditGroupPage — identifier set.)
  * - Manages async submission with an internal loading state.
  * - Displays success/error feedback via InlineToast anchored above the submit button.
  */
@@ -89,8 +93,9 @@ export default function CreateGroupForm({
   // The knockout-only setting is meaningful only for World Cup pools, so it lives
   // behind the pool-type choice and rides along on it.
   const isWorldCup = poolType === 'world_cup_2026';
-  // In edit mode (identifier supplied) pool type + knockout-only are immutable —
-  // the update route ignores them — so the form locks those controls.
+  // Edit mode uses the same single signal as the Group ID lock below: a supplied
+  // identifier. In edit mode pool type + knockout-only are immutable (the update
+  // route ignores them), so the form locks those controls too.
   const isEditMode = !!initialValues?.identifier;
   const [identifierManuallyEdited, setIdentifierManuallyEdited] = useState(
     !!initialValues?.identifier

--- a/frontend/src/pages/EditGroupPage.test.tsx
+++ b/frontend/src/pages/EditGroupPage.test.tsx
@@ -95,6 +95,28 @@ describe('EditGroupPage', () => {
     });
   });
 
+  it('reflects a World Cup knockout group: WC pool type + knockout, both locked', async () => {
+    // Regression: the edit form used to omit poolType/knockoutOnly from
+    // initialValues, so a World Cup group showed "NFL Weekly" by default.
+    mockGetGroup.mockResolvedValue({
+      name: 'LTK World Cup Knockout Picks',
+      identifier: 'test-group',
+      description: '',
+      maxMembers: 200,
+      poolType: 'world_cup_2026',
+      knockoutOnly: true,
+    });
+    renderPage();
+
+    const select = await screen.findByLabelText('Pool Type');
+    expect(select).toHaveValue('world_cup_2026');
+    expect(select).toBeDisabled();
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeDisabled();
+  });
+
   it('renders a not-found message and no form when getGroup rejects', async () => {
     mockGetGroup.mockRejectedValue(new Error('Group not found'));
     renderPage();

--- a/frontend/src/pages/EditGroupPage.tsx
+++ b/frontend/src/pages/EditGroupPage.tsx
@@ -95,6 +95,12 @@ export default function EditGroupPage() {
               identifier: group.identifier,
               description: group.description ?? '',
               maxMembers: group.maxMembers,
+              // Pool type + knockout-only are immutable after creation (the update
+              // route ignores them); pass them through so the form reflects the
+              // group's real type and locks those controls instead of defaulting
+              // to NFL Weekly.
+              poolType: group.poolType,
+              knockoutOnly: group.knockoutOnly,
             }}
             onSubmit={handleSubmit}
             onCancel={() => navigate(-1)}

--- a/frontend/tests/e2e/edit-group-reflects-pool-type.spec.ts
+++ b/frontend/tests/e2e/edit-group-reflects-pool-type.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+
+// Regression for the "edit World Cup group shows NFL Weekly" bug. EditGroupPage
+// used to omit poolType/knockoutOnly from the form's initialValues, so opening an
+// existing World Cup (knockout-only) group defaulted the Pool Type select to NFL.
+// getGroup returns pool_type/knockout_only (snake_case from the backend row); the
+// edit form must reflect them — and since both are immutable after creation, lock
+// the controls. (/edit-group is the filename-derived route the coverage check matches.)
+test('editing a World Cup knockout group reflects pool type + knockout (locked)', async ({ page }) => {
+  await page.goto('/login')
+
+  await page.evaluate(() => {
+    const payload = {
+      userId: 1,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      pictureUrl: null,
+      exp: 9999999999, // far-future so the token never reads as expired
+    }
+    const token = `header.${btoa(JSON.stringify(payload))}.sig`
+    localStorage.setItem('accessToken', token)
+  })
+
+  // Catch-all safety net first (lowest precedence); the specific getGroup route
+  // is registered after so it wins.
+  await page.route('**/api/**', (route) => route.fulfill({ json: {} }))
+
+  // getGroup for the edited group: a knockout-only World Cup pool, snake_case shape.
+  await page.route('**/api/groups/ltk-world-cup-knockout-picks', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        name: 'LTK World Cup Knockout Picks',
+        identifier: 'ltk-world-cup-knockout-picks',
+        description: '',
+        maxMembers: 200,
+        memberCount: 1,
+        userRole: 'admin',
+        pool_type: 'world_cup_2026',
+        knockout_only: true,
+      }),
+    }),
+  )
+
+  await page.goto('/edit-group/ltk-world-cup-knockout-picks')
+
+  // Pool Type reflects World Cup and is locked (immutable after creation).
+  const select = page.getByLabel('Pool Type')
+  await expect(select).toBeVisible()
+  await expect(select).toHaveValue('world_cup_2026')
+  await expect(select).toBeDisabled()
+  await expect(page.getByText(/Pool type can.t be changed after creation/)).toBeVisible()
+
+  // Knockout-only is checked and locked.
+  const checkbox = page.getByRole('checkbox')
+  await expect(checkbox).toBeChecked()
+  await expect(checkbox).toBeDisabled()
+})


### PR DESCRIPTION
## Bug

Editing an existing **World Cup** group showed **"NFL Weekly"** in the Pool Type field (see screenshot context: `ltk-world-cup-knockout-picks`, a knockout-only WC group, rendered as NFL Weekly).

## Root cause

`EditGroupPage` built the form's `initialValues` with `name`, `identifier`, `description`, `maxMembers` — but **omitted `poolType` and `knockoutOnly`**. The shared `CreateGroupForm` therefore fell back to its create defaults (`'nfl_weekly'` / `false`). The data was already available — `getGroup` returns both (mapping `pool_type`/`knockout_only`) — the edit page just wasn't passing it through.

## Fix

- `EditGroupPage`: pass `poolType` and `knockoutOnly` into `initialValues` so the form reflects the group's real type.
- `CreateGroupForm`: since pool type + knockout-only are **immutable after creation** (the `PUT` route's `allowedFields` excludes them), lock both controls in edit mode (`disabled`) and add a "Pool type can't be changed after creation." hint — so the UI isn't misleading. Create mode is unchanged (both editable).

## Tests (unit + e2e, per the request)

- **CreateGroupForm unit:** edit mode reflects the WC pool type + disables the select (with hint), reflects + locks the knockout checkbox, and leaves the select editable when creating.
- **EditGroupPage unit:** loading a WC knockout group shows World Cup 2026 + checked knockout, both disabled.
- **E2e (`edit-group-reflects-pool-type.spec.ts`):** navigates to `/edit-group/…` for a mocked WC knockout group and asserts the Pool Type select shows `world_cup_2026`, is disabled (with the hint), and the knockout checkbox is checked + disabled.

Verified: frontend unit **760 passed**, build clean, e2e **42 passed** (the one failure is the pre-existing flaky `invite-survives-login` spec, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
