### PR TITLE
fix(wc): self-heal score-prediction columns on the read paths (deploy-ordering fix)

### DIFF
--- a/backend/scripts/addWorldCupColumns.js
+++ b/backend/scripts/addWorldCupColumns.js
@@ -107,13 +107,24 @@ async function addWorldCupColumns() {
     `);
     console.log('   ✅ games.winner_team_id ensured');
 
+    // 4d. user_picks.predicted_home_score / predicted_away_score — optional knockout
+    //     score predictions for the bonus. Nullable INTEGER; NFL, group-stage, and
+    //     no-prediction picks leave them NULL. Mirrors the write- and read-path
+    //     self-heal (UserPick.ensureScorePredictionColumns) so a deterministic
+    //     migration covers them too — the leaderboard + picks reads SELECT these,
+    //     so a deploy that serves a read before any pick write would 500 without them.
+    console.log('\n4d. Adding user_picks.predicted_home_score / predicted_away_score (integer nullable)...');
+    await pool.query(`ALTER TABLE user_picks ADD COLUMN IF NOT EXISTS predicted_home_score INTEGER NULL`);
+    await pool.query(`ALTER TABLE user_picks ADD COLUMN IF NOT EXISTS predicted_away_score INTEGER NULL`);
+    console.log('   ✅ user_picks.predicted_home_score / predicted_away_score ensured');
+
     // 5. Verify the columns landed with the expected shape.
     console.log('\n5. Verifying added columns...');
     const verify = await pool.query(`
       SELECT table_name, column_name, data_type, is_nullable, column_default
       FROM information_schema.columns
       WHERE (table_name = 'games' AND column_name IN ('league', 'stage', 'winner_team_id'))
-         OR (table_name = 'user_picks' AND column_name = 'picked_result')
+         OR (table_name = 'user_picks' AND column_name IN ('picked_result', 'predicted_home_score', 'predicted_away_score'))
          OR (table_name = 'groups' AND column_name IN ('pool_type', 'knockout_only'))
       ORDER BY table_name, column_name
     `);

--- a/backend/src/routes/worldCupPicks.js
+++ b/backend/src/routes/worldCupPicks.js
@@ -193,6 +193,11 @@ router.get('/group/:groupId/world-cup/me', authenticateToken, async (req, res) =
     const { groupId } = req.params;
     const group = await ensureMembership(groupId, req.user.id);
 
+    // Self-heal the score-prediction columns on the READ path too: a fresh deploy
+    // serves reads before any pick write has run the write-path ensure, and this
+    // SELECT names the columns — without this it 500s in that window.
+    await UserPick.ensureScorePredictionColumns();
+
     const { rows } = await pool.query(
       `SELECT up.game_id, up.picked_result, up.predicted_home_score, up.predicted_away_score
        FROM user_picks up
@@ -307,6 +312,9 @@ router.get('/group/:groupId/world-cup/user/:userId', authenticateToken, async (r
     if (!(await isGroupMember(group.id, targetUserId))) {
       return res.status(404).json({ error: 'User is not a member of this group' });
     }
+
+    // Self-heal the score-prediction columns on the read path (see /me above).
+    await UserPick.ensureScorePredictionColumns();
 
     const { rows } = await pool.query(
       `SELECT up.game_id, up.picked_result, up.predicted_home_score, up.predicted_away_score

--- a/backend/src/services/WorldCupLeaderboardService.js
+++ b/backend/src/services/WorldCupLeaderboardService.js
@@ -1,6 +1,7 @@
 import { buildLeaderboard, SCORING_VERSION } from './SoccerScoringService.js';
 import { GameService } from './GameService.js';
 import { readSnapshot as readSnap, writeSnapshot as writeSnap } from '../models/WorldCupLeaderboardSnapshot.js';
+import { UserPick } from '../models/UserPick.js';
 
 export function buildVersionString({ gameWatermark, memberCount, memberMaxId, picksWatermark, scoringVersion }) {
   return [gameWatermark ?? 'none', memberCount ?? 0, memberMaxId ?? 0, picksWatermark ?? 'none', scoringVersion ?? SCORING_VERSION].join('|');
@@ -62,6 +63,12 @@ export async function buildGroupLeaderboard(pool, group, games) {
       WHERE gm.group_id = $1`,
     [group.id]
   );
+
+  // Self-heal the score-prediction columns before SELECTing them: the leaderboard
+  // is a READ path that can run before any pick write on a fresh deploy (and the
+  // SCORING_VERSION bump forces a cache miss, so the first read recomputes here).
+  // Without this the SELECT 500s in that window. Latched after the first call.
+  await UserPick.ensureScorePredictionColumns();
 
   let pickRows = [];
   if (wcGameIds.length > 0) {

--- a/backend/tests/worldcup-leaderboard-service.test.js
+++ b/backend/tests/worldcup-leaderboard-service.test.js
@@ -2,6 +2,14 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert';
 import { buildGroupLeaderboard, buildVersionString, getLeaderboardVersion, getGroupLeaderboardCached, leaderboardsMatch } from '../src/services/WorldCupLeaderboardService.js';
 import { SCORING_VERSION } from '../src/services/SoccerScoringService.js';
+import { UserPick } from '../src/models/UserPick.js';
+
+// buildGroupLeaderboard self-heals the score-prediction columns via UserPick (which
+// uses the model's real pool, not the fake passed in) before its SELECT. Replace it
+// with a counting no-op so these unit tests never touch a real DB; its real behavior
+// is covered in userpick-score-prediction.test.js.
+let ensureCalls = 0;
+UserPick.ensureScorePredictionColumns = async () => { ensureCalls += 1; };
 
 // Minimal fake pool: returns canned rows per call, in order.
 function fakePool(resultsInOrder) {
@@ -10,6 +18,12 @@ function fakePool(resultsInOrder) {
 }
 
 describe('buildGroupLeaderboard', () => {
+  test('self-heals the score-prediction columns before reading them', async () => {
+    ensureCalls = 0;
+    await buildGroupLeaderboard(fakePool([[], []]), { id: 1 }, []);
+    assert.equal(ensureCalls, 1, 'must run the read-path column self-heal before the picks SELECT');
+  });
+
   test('scores members against finalized games and ranks them', async () => {
     const group = { id: 7 };
     const games = [

--- a/backend/tests/worldcup-picks-route.test.js
+++ b/backend/tests/worldcup-picks-route.test.js
@@ -40,6 +40,10 @@ describe('World Cup picks router', () => {
   beforeEach(() => {
     mock.method(AuthService, 'verifyAccessToken', () => ({ userId: 1 }));
     mock.method(User, 'findById', async () => ({ id: 1, name: 'Tester', email: 't@x.io' }));
+    // The read paths self-heal the score-prediction columns; stub it to a no-op so
+    // these route tests don't issue the info_schema/ALTER queries against the mocked
+    // pool. Its real behavior is covered in userpick-score-prediction.test.js.
+    mock.method(UserPick, 'ensureScorePredictionColumns', async () => {});
   });
 
   afterEach(() => {
@@ -750,6 +754,21 @@ describe('World Cup picks router', () => {
       const group = data.picks.find((p) => p.gameId === 101);
       assert.strictEqual(group.predictedHomeScore, null);
       assert.strictEqual(group.predictedAwayScore, null);
+    });
+
+    test('self-heals the score-prediction columns before SELECTing them (deploy-ordering guard)', async () => {
+      mock.method(Group, 'findByIdentifier', async () => ({ id: 9, userRole: 'member' }));
+      const ensure = mock.method(UserPick, 'ensureScorePredictionColumns', async () => {});
+      mock.method(pool, 'query', async (sql) => {
+        if (/FROM user_picks/.test(sql)) return { rows: [] };
+        throw new Error(`unexpected query: ${sql}`);
+      });
+
+      const res = await fetch(`${baseURL}/api/picks/group/wc-pool/world-cup/me`, {
+        headers: { ...AUTH_HEADER },
+      });
+      assert.strictEqual(res.status, 200);
+      assert.ok(ensure.mock.callCount() >= 1, 'GET /me must self-heal the score columns before reading them');
     });
   });
 


### PR DESCRIPTION
## Why

PR #146 caused a **~25-second production outage** on its fresh deploy. The new `predicted_home_score` / `predicted_away_score` columns on `user_picks` were created only on the first pick **write** (`UserPick.ensureScorePredictionColumns`), but the **reads** select them:
- `GET …/world-cup/leaderboard` (via `buildGroupLeaderboard`)
- `GET …/world-cup/me` and `…/world-cup/user/:userId`

So any read served before the first write `500`'d with `column "predicted_home_score" does not exist` — made worse by the `SCORING_VERSION` 2→3 bump forcing a cache **miss** on the first leaderboard read. Vercel logs confirmed the burst of 500s across multiple groups, ending the instant the first pick write created the columns.

## Fix

Make the **read paths self-heal too**, so the columns are guaranteed before any select:
- `buildGroupLeaderboard` ensures the columns before its picks `SELECT` — one choke point covering the cached-miss, live, fallback, and shadow paths.
- `GET /me` and `GET /user/:userId` ensure before their selects.
- `addWorldCupColumns.js` gains the two columns (step 4d + verification) so the deterministic migration covers them as well.

The static `_scoreColumnsEnsured` latch keeps this a one-time `information_schema` check per process, then a no-op.

## Tests

- Leaderboard-service + route **regression tests** assert the ensure runs before the read.
- Both suites stub the ensure to a no-op elsewhere so the mock pools never issue the `information_schema`/`ALTER` queries.
- Full backend suite: 342 pass (the only 2 failures are the pre-existing env-only `db-init` tests that need a live default Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)