### PR TITLE
Make pick cards use equal-width, equal-height columns (CSS grid)

### DIFF
--- a/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
+++ b/frontend/src/designsystem/components/WorldCupBrowse/MatchListCard.tsx
@@ -164,20 +164,23 @@ export default function MatchListCard({ game, now, onPick, onOpenDetail, disable
 
             return (
               <>
-                {/* One horizontal row of three equal-width slots: home pick ·
-                    middle · away pick. In group games the middle slot is the
-                    Draw choice; in knockout games (no Draw) it holds the two
-                    optional score fields, centered. Keeping the middle slot
-                    flex-1 (not shrink-to-fit) means the team buttons stay the
-                    same width as a three-way pick instead of stretching to
-                    swallow the leftover space. */}
-                <div className="flex items-center gap-xs">
+                {/* Three equal-width columns: home pick · middle · away pick. A
+                    CSS grid (not flex) so every column is exactly one third on
+                    both card types — in a group game the middle third is the Draw
+                    choice; in a knockout game (no Draw) it holds the two optional
+                    score fields, centered. With flex, each column's content width
+                    skews the split, so knockout team buttons came out wider than a
+                    group card's thirds; grid-cols-3 (three minmax(0,1fr) tracks)
+                    pins them to exactly a third regardless of content. The empty
+                    spacer keeps the away button in the third column when there's
+                    no Draw and no score inputs (read-only knockout). */}
+                <div className="grid grid-cols-3 items-stretch gap-xs">
                   <ChoiceButton team={game.home} odds={game.home.moneyline} record={game.home.record} selected={game.picked === 'home'} onClick={() => onPick(game.id, 'home')} disabled={disabled || !teamsAssigned} />
                   {!game.isKnockout ? (
                     <ChoiceButton odds={game.drawOdds} selected={game.picked === 'draw'} onClick={() => onPick(game.id, 'draw')} disabled={disabled || !teamsAssigned} />
                   ) : onScoreChange ? (
                     <div
-                      className="flex flex-1 items-center justify-center gap-xxs"
+                      className="flex min-w-0 items-center justify-center gap-xxs"
                       aria-label="Predict the score (optional)"
                       title={picked ? 'Optional: predict the score for bonus points' : 'Pick a team first to predict the score'}
                     >
@@ -185,7 +188,9 @@ export default function MatchListCard({ game, now, onPick, onOpenDetail, disable
                       <span className={picked ? 'text-content-subtle' : 'text-content-subtle/40'}>–</span>
                       {scoreInput('away', awayVal, game.away.name)}
                     </div>
-                  ) : null}
+                  ) : (
+                    <div aria-hidden="true" />
+                  )}
                   <ChoiceButton team={game.away} odds={game.away.moneyline} record={game.away.record} selected={game.picked === 'away'} onClick={() => onPick(game.id, 'away')} disabled={disabled || !teamsAssigned} />
                 </div>
                 {/* Both-or-neither hint: shown when exactly one score is filled. */}


### PR DESCRIPTION
## Problem

Follow-up to #148, which merged the first attempt (setting the knockout score slot to `flex-1`). Two issues remained:

1. **Columns still weren't equal thirds.** With flexbox, each column's content width skews the split — the knockout team buttons measured ~158px against a group card's ~149px thirds, so a knockout card's columns didn't line up with a group card's.
2. **The Draw button was shorter than the team buttons.** Team buttons carry an extra line (the W-D-L record, e.g. `2-0-0`) that Draw doesn't, and the row centered each cell rather than stretching it.

Goal: all three columns of a pick card should be the same width **and** the same height, whether it's a knockout pick or a group-stage pick.

## Fix

Lay the pick row out as a **3-column CSS grid** (`grid-cols-3` = three `minmax(0,1fr)` tracks) with `items-stretch`:

- Grid tracks are sized independently of cell content, so every column is exactly one third on both card types — a knockout card's columns line up pixel-for-pixel with a group card's, and the score fields sit centered in the roomier middle third.
- `items-stretch` makes every cell fill the row height, so the Draw button is the same height as the team buttons instead of shrinking to its content.
- An empty spacer keeps the away button in the third column for the read-only knockout case (no Draw, no score inputs).

## Verification

Rendered both card types and measured the laid-out columns:

- **Group:** JOR · Draw · ARG — all **149px** wide, all **95px** tall.
- **Knockout:** RSA · score · CAN — all **149px** wide, all **76px** tall; same column edges as the group card.

(The two card types differ in overall height only because knockout games don't show a W-D-L record line — within each card all three columns match.)

- `vitest run` — `MatchListCard.test.tsx` (17 tests) pass.
- `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016e1vUaouvSSqR2KBzSSs82)_