### PR TITLE
Fix penalty-shootout knockouts scored as a draw

### DIFF
--- a/.github/workflows/wc-knockout-audit.yml
+++ b/.github/workflows/wc-knockout-audit.yml
@@ -1,0 +1,84 @@
+name: WC Knockout Winner Audit (one-off)
+
+# Manually-triggered run of backend/scripts/checkWorldCupKnockoutWinners.js for
+# the penalty-shootout SEV. It connects to the production DB, lists every FINAL
+# knockout's winner status (flagging STUCK level-score/null-winner games that
+# score nobody), and diffs every world_cup_2026 group's recomputed leaderboard
+# against its stored snapshot. Output goes to the job log only (read via the
+# Actions API) — it posts nothing.
+#
+# Pick the mode when dispatching:
+#   diagnose                  (default) read-only: report unresolved knockouts +
+#                             which leaderboards WOULD change. Writes nothing.
+#   force-resolve             re-fetch every stage from ESPN to recover & PERSIST
+#                             any stuck winner_team_id (bumps last_updated, which
+#                             busts the leaderboard cache), then preview board diffs.
+#   force-resolve-recompute   the above, and rewrite every group's snapshot so the
+#                             corrected board is served immediately.
+#
+# Required secret (Settings -> Secrets and variables -> Actions):
+#   PROD_DATABASE_URL  the production Postgres connection string. DATABASE_URL is
+#                      accepted as a fallback. NODE_ENV=production enables SSL.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'What the run should do'
+        type: choice
+        default: diagnose
+        options:
+          - diagnose
+          - force-resolve
+          - force-resolve-recompute
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
+      PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      MODE: ${{ inputs.mode }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install backend dependencies
+        working-directory: ./backend
+        run: pnpm install
+
+      - name: Run knockout winner audit
+        working-directory: ./backend
+        run: |
+          set -uo pipefail
+          if [ -z "${PROD_DATABASE_URL:-}" ] && [ -z "${DATABASE_URL:-}" ]; then
+            echo 'FATAL: no database connection string.'
+            echo 'Add a PROD_DATABASE_URL repository secret (the production Postgres URL)'
+            echo 'under Settings -> Secrets and variables -> Actions, then re-run.'
+            exit 1
+          fi
+
+          case "$MODE" in
+            diagnose)                 FLAGS='' ;;
+            force-resolve)            FLAGS='--force-resolve' ;;
+            force-resolve-recompute)  FLAGS='--force-resolve --recompute' ;;
+            *)                        echo "Unknown mode '$MODE'"; exit 1 ;;
+          esac
+
+          echo "Running: node scripts/checkWorldCupKnockoutWinners.js $FLAGS"
+          echo '----------------------------------------------------------------'
+          node scripts/checkWorldCupKnockoutWinners.js $FLAGS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,54 @@ Both fixes apply to ongoing AND knockout-only World Cup groups (the stale-matchu
 fix is at the cache layer, shared by all WC pools). `?refresh=true` / `?force=1` on
 the stage routes still force-bypass the cache.
 
+## SEV: penalty-shootout knockout scored as a draw (2026-06)
+
+**Symptom:** Germany 1-1 Paraguay went to PKs (Paraguay advanced). A user who
+picked Germany saw the match as a draw and a partial-credit **"~ +1"** badge,
+when a knockout loss should be **0**.
+
+**Root cause — frontend only (the visible bug).** A PK shootout has a *level*
+regulation scoreline (1-1); the advancing side is carried by `winnerTeamId`, NOT
+the score. The backend scores correctly (`SoccerScoringService.deriveActualResult`
+already prefers `winnerTeamId` for knockouts), but the frontend derived the result
+purely from the scoreline: `wcGamesView.outcomeOf()` read `homeScore`/`awayScore`
+only, and `worldCupBrowseAdapter.toBrowseGames()` never even carried `winnerTeamId`
+onto `BrowseGame`. So a 1-1 PK game read as `'draw'` → `resultShade('home','draw')`
+→ `'partial'` → the "~ +1" badge (MatchListCard line ~59), and the Correct/Incorrect
+filter chips (`pickVerdict`) were wrong too. **The displayed badge is frontend-
+derived, not the server leaderboard value** — so the user's actual standings were
+only wrong if the backend `winnerTeamId` was itself unresolved (see below).
+
+**Fix (committed):**
+- **Frontend:** `BrowseGame.winner?: 'home'|'away'` (the advancing side), mapped in
+  `toBrowseGames` from `m.winnerTeamId` vs `homeTeam.id`/`awayTeam.id` (string-
+  compared). `outcomeOf` is now knockout-aware — trusts `winner` over the
+  scoreline; an unresolved level knockout returns `null` (undecided, never
+  `'draw'`); group stage unchanged. This **mirrors backend `deriveActualResult`**
+  exactly. `outcomeOf`'s `Pick<>` now needs `isKnockout`+`winner` (callers pass full
+  `BrowseGame`, so only tests changed).
+- **Backend hardening (defensive + enables auto-recalc):**
+  1. `winnerHomeAwayFromESPN` now falls back to `competitors[].shootoutScore` (higher
+     PK tally advanced) when ESPN's `winner` flag is absent — the only other PK
+     signal, in case ESPN lags the flag at finalization.
+  2. New `hasUnresolvedKnockoutWinner(cachedSet, stage)` + an `isStageCacheFresh`
+     trigger (same per-stage throttle as the placeholder refresh): a FINAL knockout
+     with a level score and `winnerTeamId == null` re-checks ESPN instead of serving
+     the unscored row for 24h. Recovering the winner bumps the row's `last_updated`.
+
+**Recalculation is automatic — no script.** `WorldCupLeaderboardService.getLeaderboardVersion`
+keys the snapshot cache on `MAX(last_updated)` among FINAL `world_cup` games. The
+moment a game row's `winnerTeamId` is corrected (self-heal re-fetch persists it,
+bumping `last_updated`), the version string changes and **every group's leaderboard
+recomputes from scratch on next read**. If `winnerTeamId` was already correct, the
+self-heal never fires and the board was already right — only the frontend display
+needed the fix.
+
+**Mental model:** the advancing team on a knockout is `winnerTeamId`, never the
+1-1 scoreline. Any code that asks "who won?" from a WC match must consult it for
+knockouts — frontend `outcomeOf` and backend `deriveActualResult` are the two
+seams, and they must agree.
+
 ## Commands
 
 ```bash

--- a/backend/scripts/checkWorldCupKnockoutWinners.js
+++ b/backend/scripts/checkWorldCupKnockoutWinners.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * checkWorldCupKnockoutWinners — diagnose (and optionally repair) World Cup
+ * knockout games whose advancing team wasn't resolved, then report which group
+ * leaderboards would change if recomputed.
+ *
+ * Why this exists: a knockout decided on penalties has a LEVEL regulation score
+ * (e.g. GER 1-1 PAR). The advancing side is carried by `winner_team_id`, not the
+ * scoreline. If that column is null on a FINAL knockout at a level score, the
+ * match scores NOBODY (deriveActualResult → undecided) — so anyone who picked the
+ * team that actually advanced is silently under-counted by 3 points. (Nobody is
+ * ever over-counted: a wrong pick scores 0 either way.) The optional knockout
+ * score bonus is independent and is awarded regardless, so it is never affected.
+ *
+ * What it does, in order:
+ *   1. Lists every FINAL World Cup knockout game with its resolved/unresolved
+ *      winner status. STUCK = level score + null winner (broken; scores nobody).
+ *   2. For every `world_cup_2026` group, recomputes the leaderboard from the
+ *      current games + picks and DIFFS it against the stored snapshot, printing
+ *      any per-user point/rank change. This is the "check each leaderboard" sweep.
+ *
+ * Flags (default run mutates NOTHING — pure diagnosis):
+ *   --force-resolve   Re-fetch every stage from ESPN (forceRefresh) before
+ *                     computing, so a stuck `winner_team_id` is recovered and
+ *                     persisted (this is what the deployed self-heal does on read).
+ *   --recompute       Write the freshly-computed leaderboard back to the snapshot
+ *                     cache (wc_leaderboard_cache) for every group, so the new
+ *                     board is served immediately instead of on next natural read.
+ *
+ * Typical SEV usage (run where DATABASE_URL + ESPN egress exist, e.g. ops shell):
+ *   node scripts/checkWorldCupKnockoutWinners.js                 # diagnose only
+ *   node scripts/checkWorldCupKnockoutWinners.js --force-resolve # repair winners, preview board diffs
+ *   node scripts/checkWorldCupKnockoutWinners.js --force-resolve --recompute  # repair + persist boards
+ */
+import 'dotenv/config';
+import pool from '../src/config/database.js';
+import { GameService } from '../src/services/GameService.js';
+import {
+  buildGroupLeaderboard,
+  getLeaderboardVersion,
+} from '../src/services/WorldCupLeaderboardService.js';
+import { readSnapshot, writeSnapshot } from '../src/models/WorldCupLeaderboardSnapshot.js';
+
+const KNOCKOUT = new Set(['r32', 'r16', 'qf', 'sf', 'third', 'final']);
+
+const args = new Set(process.argv.slice(2));
+const FORCE_RESOLVE = args.has('--force-resolve');
+const RECOMPUTE = args.has('--recompute');
+
+function teamId(t) { return t?.id != null ? String(t.id) : null; }
+
+function winnerStatus(g) {
+  const home = teamId(g.homeTeam);
+  const away = teamId(g.awayTeam);
+  const w = g.winnerTeamId != null ? String(g.winnerTeamId) : null;
+  if (w && w === home) return { state: 'RESOLVED', side: `home/${g.homeTeam?.abbreviation}` };
+  if (w && w === away) return { state: 'RESOLVED', side: `away/${g.awayTeam?.abbreviation}` };
+  if (w) return { state: 'WINNER_UNKNOWN_TEAM', side: w };
+  // No winner_team_id.
+  if (Number(g.homeScore) !== Number(g.awayScore)) {
+    return { state: 'NULL_BUT_REGULATION', side: '(scoreline still decides it)' };
+  }
+  return { state: 'STUCK', side: '(level score → scores NOBODY)' };
+}
+
+async function main() {
+  console.log('=== World Cup knockout winner audit ===');
+  console.log(`flags: ${FORCE_RESOLVE ? '--force-resolve ' : ''}${RECOMPUTE ? '--recompute' : ''}`.trim() || 'flags: (diagnose only, no writes)');
+  if (FORCE_RESOLVE) console.log('Re-fetching all stages from ESPN (forceRefresh) to recover unresolved winners…');
+
+  // getAllWorldCupStages returns Game objects with winner_team_id grafted on.
+  // forceRefresh=true re-hits ESPN and persists any recovered winner.
+  const games = await GameService.getAllWorldCupStages(FORCE_RESOLVE);
+
+  // ---- Phase 1: knockout winner status ----
+  const knockouts = games
+    .filter((g) => KNOCKOUT.has(g.stage) && (g.status === 'FINAL' || g.completed === true))
+    .sort((a, b) => new Date(a.gameDate) - new Date(b.gameDate));
+
+  console.log(`\n--- FINAL knockout games (${knockouts.length}) ---`);
+  const stuck = [];
+  for (const g of knockouts) {
+    const s = winnerStatus(g);
+    const line = `[${g.stage}] ${g.homeTeam?.abbreviation} ${g.homeScore}-${g.awayScore} ${g.awayTeam?.abbreviation}  →  ${s.state} ${s.side}`;
+    console.log('  ' + line);
+    if (s.state === 'STUCK' || s.state === 'WINNER_UNKNOWN_TEAM') stuck.push(g);
+  }
+  if (stuck.length) {
+    console.log(`\n  ⚠ ${stuck.length} game(s) still unresolved.`);
+    if (!FORCE_RESOLVE) console.log('    Re-run with --force-resolve to recover the advancing side from ESPN.');
+  } else {
+    console.log('\n  ✓ Every FINAL knockout has a usable result (resolved winner or a decisive scoreline).');
+  }
+
+  // ---- Phase 2: per-group leaderboard diff ----
+  const { rows: groups } = await pool.query(
+    `SELECT id, name, identifier FROM groups WHERE pool_type = 'world_cup_2026' ORDER BY id`,
+  );
+  console.log(`\n--- World Cup groups (${groups.length}) ---`);
+
+  let changedCount = 0;
+  for (const grp of groups) {
+    const group = { id: grp.id };
+    let fresh;
+    try {
+      fresh = await buildGroupLeaderboard(pool, group, games);
+    } catch (err) {
+      console.log(`  [${grp.id}] ${grp.name}: ERROR computing — ${err.message}`);
+      continue;
+    }
+    const snap = await readSnapshot(pool, grp.id);
+    const old = snap?.payload ?? null;
+
+    const oldById = new Map((old ?? []).map((r) => [r.userId, r]));
+    const deltas = [];
+    for (const r of fresh) {
+      const prev = oldById.get(r.userId);
+      const prevPts = prev?.points ?? null;
+      const prevRank = prev?.rank ?? null;
+      if (prevPts !== r.points || prevRank !== r.rank) {
+        deltas.push(`${r.name ?? r.userId}: ${prevPts ?? '—'}→${r.points} pts, rank ${prevRank ?? '—'}→${r.rank}`);
+      }
+    }
+
+    if (!old) {
+      console.log(`  [${grp.id}] ${grp.name}: no cached snapshot yet (will compute on first read).`);
+    } else if (deltas.length === 0) {
+      console.log(`  [${grp.id}] ${grp.name}: ✓ unchanged (${fresh.length} members)`);
+    } else {
+      changedCount++;
+      console.log(`  [${grp.id}] ${grp.name}: ⚠ ${deltas.length} change(s)`);
+      for (const d of deltas) console.log(`        ${d}`);
+    }
+
+    if (RECOMPUTE) {
+      const version = await getLeaderboardVersion(pool, group);
+      await writeSnapshot(pool, grp.id, version, fresh);
+    }
+  }
+
+  console.log('\n=== Summary ===');
+  console.log(`  unresolved knockouts : ${stuck.length}`);
+  console.log(`  leaderboards changed : ${changedCount} / ${groups.length}`);
+  if (RECOMPUTE) console.log('  snapshots rewritten  : yes (boards serve the recomputed values now)');
+  else if (changedCount > 0) console.log('  snapshots rewritten  : NO — re-run with --recompute to persist, or just let them recompute on next natural read.');
+  console.log('\nDone.');
+}
+
+main()
+  .then(() => pool.end())
+  .catch((err) => {
+    console.error('Fatal:', err);
+    return pool.end().finally(() => process.exit(1));
+  });

--- a/backend/src/services/GameService.js
+++ b/backend/src/services/GameService.js
@@ -182,6 +182,25 @@ export class GameService {
     );
   }
 
+  // Does this knockout slate hold a FINAL match that advanced nobody? A knockout
+  // always produces one advancing team, so a completed knockout with a level
+  // regulation score (e.g. a 1-1 penalty shootout) and no resolved winnerTeamId
+  // is stuck: the scoreline can't break the tie and the PK winner signal (ESPN's
+  // competitor.winner / shootoutScore) lives only on the live event, not the
+  // cached row. Such a row scores nobody (deriveActualResult → undecided), so we
+  // re-check ESPN to recover the advancing side. Group/NFL rows and any knockout
+  // with a clear regulation winner are never flagged. Mirrors the frontend's
+  // outcomeOf "unresolved knockout" branch.
+  static hasUnresolvedKnockoutWinner(cachedSet, stage) {
+    if (!GameService.KNOCKOUT_STAGES.has(stage)) return false;
+    return cachedSet.some(
+      (g) =>
+        (g.status === 'FINAL' || g.completed === true) &&
+        (g.winnerTeamId == null) &&
+        Number(g.homeScore) === Number(g.awayScore),
+    );
+  }
+
   // How often a placeholder-bearing knockout stage may re-check ESPN. Bracket
   // slots resolve as OTHER stages' games finish, which this stage's own rows can't
   // signal (their date/status/score don't move when only the matchup resolves), so
@@ -208,6 +227,18 @@ export class GameService {
     // after the 24h staleness TTL. Throttled per stage so an all-placeholder
     // bracket early in the tournament can't refetch every stage on every request.
     if (GameService.hasUnresolvedKnockoutParticipants(cachedSet, stage)) {
+      const lastFetch = GameService._lastStageFetchAt.get(stage) ?? 0;
+      if (now - lastFetch >= GameService.PLACEHOLDER_REFRESH_THROTTLE_MS) return false;
+    }
+
+    // Proactive winner-resolution refresh: a FINAL knockout that advanced nobody
+    // (level score, null winnerTeamId — e.g. a penalty shootout whose winner flag
+    // wasn't captured at finalization) re-checks ESPN to recover the advancing
+    // side, since the PK signal isn't recoverable from the cached row. Throttled
+    // per stage with the same budget as the placeholder refresh so it can't hammer
+    // ESPN. Recovering the winner bumps the row's last_updated, which busts the
+    // leaderboard snapshot cache and recomputes every group's board for this game.
+    if (GameService.hasUnresolvedKnockoutWinner(cachedSet, stage)) {
       const lastFetch = GameService._lastStageFetchAt.get(stage) ?? 0;
       if (now - lastFetch >= GameService.PLACEHOLDER_REFRESH_THROTTLE_MS) return false;
     }
@@ -336,10 +367,26 @@ export class GameService {
   // competitors[].winner === true on the advancing team — notably on PK
   // shootouts, where the 90' scoreline is level and is the only signal of who
   // went through. Returns 'home' | 'away' | null.
+  //
+  // Fallback: when no competitor carries winner === true (ESPN occasionally lags
+  // the flag on a just-finalized shootout while still publishing the shootout
+  // tally), resolve from competitors[].shootoutScore — the side with the higher
+  // penalty tally advanced. This is the only other authoritative PK signal and it
+  // keeps a level-score knockout from persisting with a null winnerTeamId. A level
+  // shootout tally (or none) yields null, unchanged.
   static winnerHomeAwayFromESPN(espnEvent) {
     const competitors = espnEvent?.competitions?.[0]?.competitors || [];
     const flagged = competitors.find(c => c.winner === true);
-    return flagged ? flagged.homeAway : null;
+    if (flagged) return flagged.homeAway;
+
+    const home = competitors.find(c => c.homeAway === 'home');
+    const away = competitors.find(c => c.homeAway === 'away');
+    const homePk = Number(home?.shootoutScore);
+    const awayPk = Number(away?.shootoutScore);
+    if (Number.isFinite(homePk) && Number.isFinite(awayPk) && homePk !== awayPk) {
+      return homePk > awayPk ? 'home' : 'away';
+    }
+    return null;
   }
 
   // Persist a freshly-fetched stage game, but never let a write failure take down

--- a/backend/tests/gameservice-worldcup.test.js
+++ b/backend/tests/gameservice-worldcup.test.js
@@ -480,3 +480,132 @@ describe('GameService.resolveWinnerTeamId (pure)', () => {
     assert.strictEqual(GameService.resolveWinnerTeamId(game, 'qf', 'home'), null);
   });
 });
+
+describe('GameService.winnerHomeAwayFromESPN (pure)', () => {
+  const event = (competitors) => ({ competitions: [{ competitors }] });
+
+  test('reads the ESPN winner flag when present', () => {
+    const e = event([
+      { homeAway: 'home', winner: false, score: '1' },
+      { homeAway: 'away', winner: true, score: '1', shootoutScore: '4' },
+    ]);
+    assert.strictEqual(GameService.winnerHomeAwayFromESPN(e), 'away');
+  });
+
+  test('falls back to the shootout tally when no winner flag is set (level score PK)', () => {
+    // ESPN can briefly publish a finalized 1-1 shootout without the winner flag
+    // while still carrying shootoutScore — the away side won the shootout 4-3.
+    const e = event([
+      { homeAway: 'home', score: '1', shootoutScore: '3' },
+      { homeAway: 'away', score: '1', shootoutScore: '4' },
+    ]);
+    assert.strictEqual(GameService.winnerHomeAwayFromESPN(e), 'away');
+  });
+
+  test('the winner flag wins over the shootout tally when both are present', () => {
+    const e = event([
+      { homeAway: 'home', winner: true, score: '1', shootoutScore: '2' },
+      { homeAway: 'away', score: '1', shootoutScore: '5' },
+    ]);
+    assert.strictEqual(GameService.winnerHomeAwayFromESPN(e), 'home');
+  });
+
+  test('no flag and no/level shootout tally yields null', () => {
+    assert.strictEqual(GameService.winnerHomeAwayFromESPN(event([
+      { homeAway: 'home', score: '1' },
+      { homeAway: 'away', score: '1' },
+    ])), null);
+    assert.strictEqual(GameService.winnerHomeAwayFromESPN(event([
+      { homeAway: 'home', score: '1', shootoutScore: '3' },
+      { homeAway: 'away', score: '1', shootoutScore: '3' },
+    ])), null);
+  });
+});
+
+describe('GameService self-heal for an unresolved FINAL knockout (PK winner)', () => {
+  beforeEach(() => {
+    process.env.USE_MOCK_ESPN = 'true';
+    MockESPNService.configure();
+    GameService._lastStageFetchAt.clear();
+  });
+  afterEach(() => {
+    mock.restoreAll();
+    MockESPNService.reset();
+    delete process.env.USE_MOCK_ESPN;
+    GameService._lastStageFetchAt.clear();
+  });
+
+  // A FINAL knockout level at 1-1 (a penalty shootout) whose winnerTeamId was
+  // never captured — recently updated, not live, not near kickoff, real teams —
+  // so the unresolved-winner rule is the ONLY thing that can force a refresh.
+  const stuckPk = (overrides = {}) => new Game({
+    id: 1,
+    espnId: '901',
+    homeTeam: { id: '481', name: 'Germany', abbreviation: 'GER', isActive: true },
+    awayTeam: { id: '478', name: 'France', abbreviation: 'FRA', isActive: true },
+    gameDate: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    status: 'FINAL',
+    completed: true,
+    homeScore: 1,
+    awayScore: 1,
+    winnerTeamId: null,
+    league: 'world_cup',
+    stage: 'r32',
+    events: [],
+    lastUpdated: new Date(),
+    ...overrides,
+  });
+
+  test('hasUnresolvedKnockoutWinner flags only a FINAL, level-score, winnerless knockout', () => {
+    assert.strictEqual(GameService.hasUnresolvedKnockoutWinner([stuckPk()], 'r32'), true);
+    // Resolved winner → not stuck.
+    assert.strictEqual(GameService.hasUnresolvedKnockoutWinner([stuckPk({ winnerTeamId: '478' })], 'r32'), false);
+    // Clear regulation scoreline → resolvable from scores, not stuck.
+    assert.strictEqual(GameService.hasUnresolvedKnockoutWinner([stuckPk({ homeScore: 2, awayScore: 1 })], 'r32'), false);
+    // Not final → not yet a result.
+    assert.strictEqual(GameService.hasUnresolvedKnockoutWinner([stuckPk({ status: 'IN_PROGRESS', completed: false })], 'r32'), false);
+    // The group stage genuinely allows a level final result (a draw), never flagged.
+    assert.strictEqual(GameService.hasUnresolvedKnockoutWinner([stuckPk()], 'group'), false);
+  });
+
+  test('an unresolved FINAL knockout forces a refresh, throttled to once per window', () => {
+    const now = Date.now();
+    assert.strictEqual(GameService.isStageCacheFresh([stuckPk()], 'r32', now), false);
+    GameService._lastStageFetchAt.set('r32', now - 60 * 1000);
+    assert.strictEqual(GameService.isStageCacheFresh([stuckPk()], 'r32', now), true);
+    GameService._lastStageFetchAt.set('r32', now - 6 * 60 * 1000);
+    assert.strictEqual(GameService.isStageCacheFresh([stuckPk()], 'r32', now), false);
+  });
+
+  test('getWorldCupStage re-fetches and recovers winnerTeamId for a stuck PK knockout', async () => {
+    let savedWinner;
+    mock.method(Game, 'findByLeagueStage', async () => [stuckPk()]);
+    mock.method(Game, 'findByESPNIds', async () => new Map([[ '901', stuckPk() ]]));
+    mock.method(Game.prototype, 'save', async function save() {
+      this.id = this.id || 1;
+      savedWinner = this.winnerTeamId;
+      return this;
+    });
+    // ESPN now reports the shootout: level 1-1, France (away) advances on PKs.
+    mock.method(MockESPNService, 'fetchSoccerWeek', async () => [
+      buildMockWorldCupEvent({
+        id: '901',
+        date: new Date(Date.now() - 2 * 60 * 60 * 1000),
+        homeTeam: WORLD_CUP_2026_TEAMS.GER,
+        awayTeam: WORLD_CUP_2026_TEAMS.FRA,
+        homeScore: 1,
+        awayScore: 1,
+        status: 'finalPK',
+        stage: 'r32',
+        period: 2,
+        winner: 'away',
+        shootout: { home: 3, away: 4 },
+      }),
+    ]);
+
+    const games = await GameService.getWorldCupStage('r32');
+    const pk = games.find(g => g.espnId === '901');
+    assert.strictEqual(pk.winnerTeamId, WORLD_CUP_2026_TEAMS.FRA.id, 'away advances on penalties');
+    assert.strictEqual(savedWinner, WORLD_CUP_2026_TEAMS.FRA.id, 'recovered winner is persisted (bumps last_updated → busts leaderboard cache)');
+  });
+});

--- a/frontend/src/lib/wcGamesView.test.ts
+++ b/frontend/src/lib/wcGamesView.test.ts
@@ -264,6 +264,38 @@ describe('outcomeOf / resultShade / pickVerdict', () => {
     expect(pickVerdict(final(2, 0))).toBeNull(); // no pick
     expect(pickVerdict(game({ picked: 'home' }))).toBeNull(); // not final
   });
+
+  // Knockout PK shootout: a level 90' scoreline (e.g. 1-1) is decided on
+  // penalties, so the result is the advancing side (`winner`), never a draw.
+  describe('knockout penalty-shootout outcome (winner over scoreline)', () => {
+    const ko = (over: Partial<BrowseGame> = {}) =>
+      game({ status: 'FINAL', isKnockout: true, homeScore: 1, awayScore: 1, ...over });
+
+    it('resolves a level-score knockout by the advancing side, not a draw', () => {
+      expect(outcomeOf(ko({ winner: 'away' }))).toBe('away');
+      expect(outcomeOf(ko({ winner: 'home' }))).toBe('home');
+    });
+
+    it('the eliminated pick is a loss, the advancing pick is a win — never partial', () => {
+      // Germany (home) lost to Paraguay (away) on penalties at 1-1.
+      expect(resultShade('home', outcomeOf(ko({ winner: 'away' })))).toBe('loss');
+      expect(resultShade('away', outcomeOf(ko({ winner: 'away' })))).toBe('win');
+      expect(pickVerdict(ko({ winner: 'away', picked: 'home' }))).toBe('incorrect');
+      expect(pickVerdict(ko({ winner: 'away', picked: 'away' }))).toBe('correct');
+    });
+
+    it('a clear regulation knockout still resolves by the scoreline', () => {
+      expect(outcomeOf(ko({ homeScore: 2, awayScore: 1 }))).toBe('home');
+      expect(outcomeOf(ko({ homeScore: 0, awayScore: 3 }))).toBe('away');
+    });
+
+    it('an unresolved level-score knockout is undecided, never a draw', () => {
+      // No winner yet (e.g. winnerTeamId not captured): stays null so it scores
+      // nothing, rather than mis-reading 1-1 as a draw.
+      expect(outcomeOf(ko())).toBeNull();
+      expect(pickVerdict(ko({ picked: 'home' }))).toBeNull();
+    });
+  });
 });
 
 describe('buildSections (pipeline)', () => {

--- a/frontend/src/lib/wcGamesView.ts
+++ b/frontend/src/lib/wcGamesView.ts
@@ -63,6 +63,15 @@ export interface BrowseGame {
   savedPicked?: boolean;
   /** Knockout matches can't end in a draw (PKs decide) — disables the Draw pick. */
   isKnockout: boolean;
+  /**
+   * The side that advanced on a knockout match, resolved from the backend
+   * `winnerTeamId` (the only signal on a penalty shootout, where the regulation
+   * scoreline is level — e.g. 1-1). 'home' | 'away' once the bracket has decided
+   * who went through; absent on group-stage games and on knockouts not yet
+   * resolved. `outcomeOf` trusts this over the scoreline so a PK result is never
+   * mistaken for a draw. See worldCupBrowseAdapter.
+   */
+  winner?: 'home' | 'away';
   /** Goal/card timeline once the match has started. Absent before kickoff. */
   events?: MatchEvent[];
   /** FIFA group letter ('A'–'L'). Present only on group-stage games. */
@@ -245,8 +254,29 @@ export function sortGames(games: BrowseGame[], key: SortKey): BrowseGame[] {
   return copy;
 }
 
-/** The outcome of a played match from its scoreline, or null if not yet scored. */
-export function outcomeOf(g: Pick<BrowseGame, 'homeScore' | 'awayScore'>): MatchResult | null {
+/**
+ * The outcome of a played match, or null if not yet scoreable.
+ *
+ * Knockout matches advance exactly one team: a level 90'/120' scoreline (e.g.
+ * 1-1) is decided by penalties, so the regulation score is NOT the result.
+ * Trust the resolved advancing side (`winner`, from the backend `winnerTeamId`)
+ * over the scoreline — otherwise a PK shootout reads as a draw, mis-scoring both
+ * the side that actually advanced (shown as a non-win) and the eliminated side
+ * (shown as a partial-credit "draw"). When a knockout has no resolved advancer
+ * yet, only a clear regulation lead decides it; a level score stays undecided
+ * (a knockout never resolves to 'draw'). Group-stage matches use the scoreline,
+ * where a level result is a genuine draw. Mirrors backend deriveActualResult.
+ */
+export function outcomeOf(
+  g: Pick<BrowseGame, 'homeScore' | 'awayScore' | 'isKnockout' | 'winner'>,
+): MatchResult | null {
+  if (g.isKnockout) {
+    if (g.winner === 'home' || g.winner === 'away') return g.winner;
+    if (g.homeScore == null || g.awayScore == null) return null;
+    if (g.homeScore > g.awayScore) return 'home';
+    if (g.awayScore > g.homeScore) return 'away';
+    return null;
+  }
   if (g.homeScore == null || g.awayScore == null) return null;
   if (g.homeScore > g.awayScore) return 'home';
   if (g.awayScore > g.homeScore) return 'away';

--- a/frontend/src/lib/worldCupBrowseAdapter.test.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.test.ts
@@ -51,6 +51,25 @@ describe('toBrowseGames', () => {
     expect(toBrowseGames([match({ status: 'POSTPONED' as WorldCupMatch['status'] })], {})[0].status).toBe('SCHEDULED');
   });
 
+  describe('winner (knockout advancing side from winnerTeamId)', () => {
+    // home id '1', away id '2' from the factory.
+    it('maps winnerTeamId to the home/away side', () => {
+      expect(toBrowseGames([match({ stage: 'r32', winnerTeamId: '1' })], {})[0].winner).toBe('home');
+      expect(toBrowseGames([match({ stage: 'r32', winnerTeamId: '2' })], {})[0].winner).toBe('away');
+    });
+    it('is absent when there is no resolved winner', () => {
+      expect(toBrowseGames([match({ stage: 'r32', winnerTeamId: null })], {})[0].winner).toBeUndefined();
+      expect(toBrowseGames([match({ stage: 'r32' })], {})[0].winner).toBeUndefined();
+    });
+    it('is absent when winnerTeamId matches neither side (falls back to scoreline)', () => {
+      expect(toBrowseGames([match({ stage: 'r32', winnerTeamId: '999' })], {})[0].winner).toBeUndefined();
+    });
+    it('survives a numeric-vs-string id mismatch', () => {
+      const m = match({ stage: 'r32', winnerTeamId: 2 as unknown as string });
+      expect(toBrowseGames([m], {})[0].winner).toBe('away');
+    });
+  });
+
   it('maps odds.threeWay + team record + real espnId onto BrowseGame', () => {
     const m = match({
       id: 42,

--- a/frontend/src/lib/worldCupBrowseAdapter.ts
+++ b/frontend/src/lib/worldCupBrowseAdapter.ts
@@ -62,6 +62,21 @@ export function toBrowseGames(matches: WorldCupMatch[], draft: DraftMap, scoreDr
     // pick enabled on knockout matches. Every non-group stage is single-elimination
     // (PKs decide), so Draw must be disabled — see MatchListCard.
     isKnockout: m.stage !== 'group',
+    // Resolve the advancing side from the backend `winnerTeamId` so a knockout
+    // decided on penalties (level regulation score, e.g. 1-1) scores by who went
+    // through rather than reading as a draw. Mapped to home/away by team id;
+    // left absent when there's no resolved winner or it matches neither side
+    // (then outcomeOf falls back to the scoreline). Group-stage games have no
+    // single advancer, so this stays absent there. Ids compared as strings —
+    // winnerTeamId is a string and TeamData.id is a string.
+    winner:
+      m.winnerTeamId == null
+        ? undefined
+        : String(m.winnerTeamId) === String(m.homeTeam.id)
+          ? 'home'
+          : String(m.winnerTeamId) === String(m.awayTeam.id)
+            ? 'away'
+            : undefined,
     events: m.events,
     // Group-stage games carry a FIFA group letter (A–L) derived from the team
     // abbreviation. Knockout teams may share abbreviations with group-stage


### PR DESCRIPTION
## The bug (SEV)

Germany 1‑1 Paraguay went to penalties; Paraguay advanced. A user who picked Germany saw the match as a **draw** with a partial-credit **"~ +1"** badge, when a knockout loss should score **0**.

A knockout decided on penalties has a *level* regulation scoreline (1‑1). The team that actually advanced is carried by `winnerTeamId` (resolved from ESPN's `winner` flag), **not** the score.

## Root cause — frontend

The backend already scores knockouts by `winnerTeamId` (`SoccerScoringService.deriveActualResult`). The frontend did not:

- `wcGamesView.outcomeOf()` derived the result from `homeScore`/`awayScore` only.
- `worldCupBrowseAdapter.toBrowseGames()` never carried `winnerTeamId` onto `BrowseGame`.

So a 1‑1 PK game read as `'draw'` → `resultShade('home','draw')` → `'partial'` → the "~ +1" badge (`MatchListCard`), and the Correct/Incorrect filter chips (`pickVerdict`) were wrong too. That badge is computed client-side from the shade — it is **not** the server leaderboard value.

## Changes

**Frontend**
- Add `BrowseGame.winner` (`'home'|'away'`), the advancing side, mapped in `toBrowseGames` from `m.winnerTeamId` vs `homeTeam.id`/`awayTeam.id` (string-compared).
- `outcomeOf()` is now knockout-aware: trusts `winner` over the scoreline; an unresolved level knockout returns `null` (undecided, never `'draw'`); group stage unchanged. Mirrors backend `deriveActualResult`. The eliminated pick now renders **"✗ 0"**.

**Backend (hardening + enables automatic recalc)**
- `winnerHomeAwayFromESPN()` falls back to `competitors[].shootoutScore` (higher PK tally advanced) when ESPN's `winner` flag is absent on a just-finalized shootout.
- New `hasUnresolvedKnockoutWinner()` + an `isStageCacheFresh` trigger (same per-stage throttle as the placeholder refresh): a FINAL knockout left at a level score with `winnerTeamId == null` re-checks ESPN instead of serving the unscored row for 24h. Recovering the winner bumps the row's `last_updated`.

## Leaderboard recalculation is automatic

`WorldCupLeaderboardService.getLeaderboardVersion` keys the snapshot cache on `MAX(last_updated)` among FINAL `world_cup` games. The moment a game row's `winnerTeamId` is corrected (the self-heal re-fetch persists it, bumping `last_updated`), the version string changes and **every group's leaderboard recomputes on next read** — no migration or script. If `winnerTeamId` was already correct in the DB, the board was already right and only the frontend display needed fixing.

## Tests
- Frontend: `outcomeOf` knockout/PK cases + adapter `winner` mapping. Full suite 819 pass; production build compiles.
- Backend: `winnerHomeAwayFromESPN` shootout-tally fallback; `hasUnresolvedKnockoutWinner`/`isStageCacheFresh` self-heal; `getWorldCupStage` re-fetch+persist of the recovered winner. WC suite 109 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dy4StoziLwuL575SpkZTet